### PR TITLE
Fixes relecov schema v1.0.0

### DIFF
--- a/relecov_tools/config_json.py
+++ b/relecov_tools/config_json.py
@@ -2,7 +2,8 @@
 import json
 import os
 
-#
+
+# pass test
 class ConfigJson:
     def __init__(
         self,

--- a/relecov_tools/config_json.py
+++ b/relecov_tools/config_json.py
@@ -2,7 +2,7 @@
 import json
 import os
 
-
+#
 class ConfigJson:
     def __init__(
         self,

--- a/relecov_tools/schema/relecov_schema.json
+++ b/relecov_tools/schema/relecov_schema.json
@@ -1,6 +1,6 @@
 {
     "schema": "RELECOV",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "required": [
         "collecting_lab_sample_id",
         "collecting_institution",
@@ -80,6 +80,17 @@
             "description": "",
             "classification": "Sample collection and processing",
             "label": "Sample ID given in the microbiology lab",
+            "fill_mode": "sample"
+        },
+        "isolate_sample_id": {
+            "examples": [
+                ""
+            ],
+            "ontology": "NCIT:C53471",
+            "type": "string",
+            "description": "",
+            "classification": "Database Identifiers",
+            "label": "Sample ID given if multiple rna-extraction or passages",
             "fill_mode": "sample"
         },
         "sequencing_sample_id": {
@@ -617,7 +628,7 @@
             "label": "Environmental Material",
             "fill_mode": "batch"
         },
-        "environmental_site": {
+        "environmental_system": {
             "Enums": [
                 "Acute care facility [ENVO:03501135]",
                 "Animal house [ENVO:00003040]",
@@ -678,7 +689,7 @@
         },
         "tax_id": {
             "examples": [
-                "probably 2697049 in all cases"
+                "2697049"
             ],
             "ontology": "GENEPIO_0001724",
             "type": "string",
@@ -695,7 +706,7 @@
             "type": "string",
             "description": "An unique identifier by which each subject can be referred to, de-identified.",
             "classification": "Host information",
-            "label": "Host Subject Id",
+            "label": "Host Subject Id"
         },
         "host_health_state": {
             "examples": [
@@ -705,7 +716,7 @@
             "type": "string",
             "description": " Status of the host",
             "classification": "Host health state information",
-            "label": "Host health state",
+            "label": "Host health state"
         },
         "host_common_name": {
             "Enums": [
@@ -1001,8 +1012,8 @@
                 "Nanopore COVID Midi: 2304 samples",
                 "Nanopore COVID Mini: 576 samples",
                 "Vela Diagnostics:ViroKey SQ FLEX Library Prep Reagents",
-                "Other",
-            ]
+                "Other"
+            ],
             "examples": [
                 "Illumina DNA Prep Tagmentation"
             ],
@@ -1014,12 +1025,20 @@
             "fill_mode": "batch"
         },
         "enrichment_protocol": {
+            "Enums":[
+                "Amplicon",
+                "Probes",
+                "Custom probes",
+                "Custom amplicon",
+                "No enrichment",
+                "Other"
+            ],
             "examples": [
                 "AMPLICON"
             ],
             "ontology": "EFO_0009089",
             "type": "string",
-            "description": "",
+            "description": "Type of enrichment protocol",
             "classification": "Sequencing",
             "label": "Enrichment Protocol",
             "fill_mode": "batch"
@@ -1036,17 +1055,43 @@
             "fill_mode": "batch"
         },
         "enrichment_panel": {
+            "Enums":[
+                "ARTIC",
+                "Illumina respiratory Virus Oligo Panel",
+                "Illumina AmpliSeq Community panel",
+                "Illumina AmpliSeq SARS-CoV-2 Research Panel for Illumina",
+                "Ion AmpliSeq SARS‑CoV‑2 Research Panel",
+                "xGen  SC2 Midnight1200 Amplicon Panel",
+                "ViroKey SQ FLEX SARS-CoV-2 Primer Set",
+                "NEBNext VarSkip Short SARS-CoV-2 primers",
+                "Other"
+            ],
             "examples": [
                 "ARTIC"
             ],
             "ontology": "0",
             "type": "string",
-            "description": "",
+            "description": "Commercial or custom panel/assay used for enrichment.",
             "classification": "Sequencing",
             "label": "Enrichment panel/assay",
             "fill_mode": "batch"
         },
         "enrichment_panel_version": {
+            "Enums":[
+                "ARTIC v1",
+                "ARTIC v2",
+                "ARTIC v3",
+                "ARTIC v4",
+                "Illumina AmpliSeq Community panel",
+                "Illumina AmpliSeq SARS-CoV-2 Research Panel for Illumina",
+                "Illumina Respiratory Virus Oligos Panel V1",
+                "Illumina Respiratory Virus Oligos Panel V2",
+                "Ion AmpliSeq SARS-CoV-2 Insight",
+                "xGen  SC2 Midnight1200 Amplicon Panel",
+                "ViroKey SQ FLEX SARS-CoV-2 Primer Set", 
+                "NEBNext VarSkip Short SARS-CoV-2 primers",
+                "Other"
+            ],
             "examples": [
                 "ARTIC v4"
             ],
@@ -1080,30 +1125,164 @@
             "fill_mode": "batch"
         },
         "flowcell_kit": {
+            "Enums":[
+                "HiSeq 3000/4000 PE Cluster Kit",
+                "HiSeq 3000/4000 SBS Kit (50 cycles)",
+                "HiSeq 3000/4000 SBS Kit (150 cycles)",
+                "HiSeq 3000/4000 SBS Kit (300 cycles)",
+                "HiSeq 3000/4000 SBS Kit",
+                "HiSeq 3000/4000 SR Cluster Kit",
+                "TG HiSeq 3000/4000 SBS Kit (50 cycles)",
+                "TG HiSeq 3000/4000 SBS Kit (150 cycles)",
+                "TG HiSeq 3000/4000 SBS Kit (300 cycles)",
+                "TG HiSeq 3000/4000 PE ClusterKit",
+                "TG HiSeq 3000/4000 SR ClusterKit",
+                "HiSeq PE Cluster Kit v4 cBot",
+                "HiSeq SR Rapid Cluster Kit v2",
+                "HiSeq PE Rapid Cluster Kit v2",
+                "TG HiSeq Rapid PE Cluster Kit v2",
+                "HiSeq Rapid Duo cBot Sample Loading Kit",
+                "TG TruSeq Rapid Duo cBot Sample Loading Kit",
+                "HiSeq Rapid SBS Kit v2 (50 cycles)",
+                "HiSeq Rapid SBS Kit v2 (200 cycles)",
+                "HiSeq Rapid SBS Kit v2 (500 cycles)",
+                "TG HiSeq Rapid SBS Kit v2 (200 Cycle)",
+                "TG HiSeq Rapid SBS Kit v2 (50 Cycle)",
+                "HiSeq SR Cluster Kit v4 cBot",
+                "TG HiSeq SR Cluster Kit v4 - cBot",
+                "TG HiSeq PE Cluster Kit v4 – cBot",
+                "HiSeq X Ten Reagent Kit v2.5",
+                "HiSeq X Ten Reagent Kit v2.5 - 10 pack",
+                "HiSeq X Five Reagent Kit v2.5",
+                "MiSeq Reagent Kit v3 (150-cycle)",
+                "MiSeq Reagent Kit v3 (600-cycle)",
+                "TG MiSeq Reagent Kit v3 (600 cycle)",
+                "TG MiSeq Reagent Kit v3 (150 cycle)",
+                "MiSeq Reagent Kit v3 (150-cycle)",
+                "MiSeq Reagent Kit v3 (600-cycle)",
+                "TG MiSeq Reagent Kit v3 (600 cycle)",
+                "TG MiSeq Reagent Kit v3 (150 cycle)",
+                "MiSeq Reagent Kit v3 (150-cycle)",
+                "MiSeq Reagent Kit v3 (600-cycle)",
+                "TG MiSeq Reagent Kit v3 (600 cycle)",
+                "TG MiSeq Reagent Kit v3 (150 cycle)",
+                "MiSeq Reagent Kit v2 (50-cycles)",
+                "MiSeq Reagent Kit v2 (300-cycles)",
+                "MiSeq Reagent Kit v2 (500-cycles)",
+                "MiniSeq Rapid Reagent Kit (100 cycles)",
+                "MiniSeq High Output Reagent Kit (75-cycles)",
+                "MiniSeq High Output Reagent Kit (150-cycles)",
+                "NextSeq 1000/2000 P1 Reagents (300 Cycles)",
+                "NextSeq 1000/2000 P2 Reagents (100 Cycles) v3",
+                "NextSeq 1000/2000 P2 Reagents (200 Cycles) v3",
+                "NextSeq 1000/2000 P2 Reagents (300 Cycles) v3",
+                "NextSeq 2000 P3 Reagents (50 Cycles)", 
+                "NextSeq 2000 P3 Reagents (100 Cycles)",
+                "NextSeq 2000 P3 Reagents (200 Cycles)", 
+                "NextSeq 2000 P3 Reagents (300 Cycles)",
+                "NextSeq 1000/2000 Read and Index Primers", 
+                "NextSeq 1000/2000 Index Primer Kit",
+                "NextSeq 1000/2000 Read Primer Kit", 
+                "NextSeq 500/550 High Output Kit v2.5 (75 Cycles)",
+                "NextSeq 500/550 High Output Kit v2.5 (150 Cycles)",
+                "NextSeq 500/550 High Output Kit v2.5 (300 Cycles)",
+                "NextSeq 500/550 Mid Output Kit v2.5 (150 Cycles)",
+                "NextSeq 500/550 Mid Output Kit v2.5 (300 Cycles)",
+                "TG NextSeq  500/550 High Output Kit v2.5 (75 Cycles)", 
+                "TG NextSeq  500/550 High Output Kit v2.5 (150 Cycles)",
+                "TG NextSeq  500/550 High Output Kit v2.5 (300 Cycles)",
+                "TG NextSeq 500/550 Mid Output Kit v2.5 (150 Cycles)",
+                "TG NextSeq 500/550 Mid Output Kit v2.5 (300 Cycles)",
+                "NovaSeq 6000 S4 Reagent Kit v1.5 (300 cycles)",
+                "NovaSeq 6000 S4 Reagent Kit v1.5 (200 cycles)",
+                "NovaSeq 6000 S4 Reagent Kit v1.5 (35 cycles)",
+                "NovaSeq 6000 S2 Reagent Kit v1.5 (300 cycles)",
+                "NovaSeq 6000 S2 Reagent Kit v1.5 (200 cycles)",
+                "NovaSeq 6000 S2 Reagent Kit v1.5 (100 cycles)",
+                "NovaSeq 6000 S1 Reagent Kit v1.5 (300 cycles)",
+                "NovaSeq 6000 S1 Reagent Kit v1.5 (200 cycles)", 
+                "NovaSeq 6000 S1 Reagent Kit v1.5 (100 cycles)", 
+                "NovaSeq 6000 SP Reagent Kit v1.5 (500 cycles)",
+                "NovaSeq 6000 SP Reagent Kit v1.5 (300 cycles)",
+                "NovaSeq 6000 SP Reagent Kit v1.5 (200 cycles)", 
+                "NovaSeq 6000 SP Reagent Kit v1.5 (100 cycles)",
+                "NovaSeq 6000 SP Reagent Kit (100 cycles)", 
+                "NovaSeq 6000 SP Reagent Kit (200 cycles)", 
+                "NovaSeq 6000 SP Reagent Kit (300 cycles)",
+                "NovaSeq 6000 SP Reagent Kit (500 cycles)",
+                "NovaSeq 6000 S1 Reagent Kit (100 cycles)",
+                "NovaSeq 6000 S1 Reagent Kit (200 cycles)",
+                "NovaSeq 6000 S1 Reagent Kit (300 cycles)",
+                "NovaSeq 6000 S2 Reagent Kit (100 cycles)",
+                "NovaSeq 6000 S2 Reagent Kit (200 cycles)", 
+                "NovaSeq 6000 S2 Reagent Kit (300 cycles)", 
+                "NovaSeq 6000 S4 Reagent Kit (200 cycles)",
+                "NovaSeq 6000 S4 Reagent Kit (300 cycles)", 
+                "NovaSeq 6000 S4 Reagent Kit (300 Cycles) – 10 pack",
+                "NovaSeq 6000 S4 Reagent Kit (300 Cycles) – 20 pack",
+                "NovaSeq 6000 S4 Reagent Kit (300 Cycles) – 40 pack",
+                "NovaSeq Library Tubes Accessory Pack (24 tubes)",
+                "NovaSeq XP 4-Lane Kit v1.5", 
+                "NovaSeq XP 2-Lane Kit v1.5",
+                "NovaSeq XP 2-Lane Kit",
+                "NovaSeq Xp 4-Lane Kit",
+                "NovaSeq Xp Flow Cell Dock",
+                "NovaSeq Xp 2-Lane Manifold Pack",
+                "NovaSeq Xp 4-Lane Manifold Pack",
+                "PhiX Control v3",
+                "TG PhiX Control Kit v3",
+                "NextSeq PhiX Control Kit",
+                "TruSeq Dual Index Sequencing Primer Box, Single-Read",
+                "TruSeq Dual Index Sequencing Primer Box, Paired-End",
+                "TruSeq PE Cluster Kit v3-cBot-HS",
+                "TruSeq PE Cluster Kit v5-CS-GA",
+                "HiSeq SR Rapid Cluster Kit v2",
+                "HiSeq PE Rapid Cluster Kit v2",
+                "TG HiSeq Rapid PE Cluster Kit v2",
+                "HiSeq SR Rapid Cluster Kit v2",
+                "HiSeq PE Rapid Cluster Kit v2",
+                "TG HiSeq Rapid PE Cluster Kit v2",
+                "TruSeq SBS Kit v3-HS (200 cycles)",
+                "TruSeq SBS Kit v3-HS (50 cycles)",
+                "TG TruSeq SBS Kit v3 - HS (200-cycles)",
+                "TruSeq SBS Kit v5-GA",
+                "TruSeq SR Cluster Kit v3-cBot-HS",
+                "TG TruSeq SR Cluster Kit v1–cBot - HS",
+                "iSeq 100 i1 Reagent v2 (300-cycle)",
+                "iSeq 100 i1 Reagent v2 (300-cycle) 4 pack",
+                "iSeq 100 i1 Reagent v2 (300-cycle) 8 pack",
+                "Other"
+            ],
             "examples": [
-                ""
+                "iSeq 100 i1 Reagent v2 (300-cycle) 8 pack"
             ],
             "ontology": "0",
             "type": "string",
-            "description": "",
+            "description": "Flowcell sequencer used for sequencing the sample",
             "classification": "Sequencing",
             "label": "Flowcell Kit",
             "fill_mode": "batch"
         },
         "runID": {
             "examples": [
-                ""
+                "NextSeq_GEN_320"
             ],
             "ontology": "NCIT_C117058",
             "type": "string",
-            "description": "",
+            "description": "Unique sequencing run identifier.",
             "classification": "Sequencing",
             "label": "Runid",
             "fill_mode": "batch"
         },
         "sequencing_instrument_platform": {
+            "Enums":[
+                "Oxford Nanopore",
+                "Illumina",
+                "Ion Torrent",
+                "Other"
+            ],
             "examples": [
-                ""
+                "Illumina"
             ],
             "ontology": "0",
             "type": "string",
@@ -1112,7 +1291,55 @@
             "label": "Sequencing Instrument Platform",
             "fill_mode": "batch"
         },
+        "library_source": {
+            "Enums": [
+                "GENOMIC",
+                "TRANSCRIPTOMIC",
+                "METAGENOMIC",
+                "METATRANSCRIPTOMIC",
+                "SYNTHETIC",
+                "VIRAL RNA",
+                "OTHER"
+            ],
+            "examples": [
+                "METAGENOMIC"
+            ],
+            "ontology": "GENEPIO_0001965",
+            "type": "string",
+            "description": "Molecule type used to make the library.",
+            "classification": "Sequencing",
+            "label": "Source material",
+            "fill_mode": "batch"
+        },
         "library_selection": {
+            "Enums":[
+                "RANDOM",
+                "PCR",
+                "RANDOM PCR",
+                "RT-PCR",
+                "HMPR",
+                "MF",
+                "repeat fractionation",
+                "size fractionation",
+                "MSLL",
+                "cDNA",
+                "ChIP",
+                "MNase",
+                "DNase",
+                "Hybrid Selection",
+                "Reduced Representation",
+                "Restriction Digest",
+                "5-methylcytidine antibody",
+                "MBD2 protein methyl-CpG binding domain",
+                "CAGE",
+                "RACE",
+                "MDA",
+                "padlock probes capture method",
+                "Oligo-dT",
+                "Inverse rRNA selection",
+                "ChIP-Seq",
+                "Other"
+            ],
             "examples": [
                 "RANDOM PCR"
             ],
@@ -1157,256 +1384,18 @@
             "fill_mode": "batch"
         },
         "library_layout": {
+            "Enums":[
+               "SINGLE",
+               "PAIRED"
+            ],
             "examples": [
-                "PAIRED end"
+                "PAIRED"
             ],
             "ontology": "NCIT:C175894",
             "type": "string",
-            "description": "Single or paired.",
+            "description": "Single or paired sequencing configuration",
             "classification": "Sequencing",
             "label": "Library Layout",
-            "fill_mode": "batch"
-        },
-        "dehosting_method_software_name": {
-            "examples": [
-                "Nanostripper"
-            ],
-            "ontology": "GENEPIO:0001459",
-            "type": "string",
-            "description": "The method used to remove host reads from the pathogen sequence.",
-            "classification": "Bioinformatic Analysis fields",
-            "label": "Dehosting Method",
-            "fill_mode": "batch"
-        },
-        "dehosting_method_software_version": {
-            "examples": [
-                "2.4.1"
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "The method version used to remove host reads from the pathogen sequence.",
-            "classification": "Bioinformatic Analysis fields",
-            "label": "Dehosting Method Version",
-            "fill_mode": "batch"
-        },
-        "assembly": {
-            "examples": [
-                ""
-            ],
-            "ontology": "NCIT_C63548",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatic Analysis fields",
-            "label": "Assembly",
-            "fill_mode": "batch"
-        },
-        "if_assembly_other": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatic Analysis fields",
-            "label": "If assembly Is Other, Specify",
-            "fill_mode": "batch"
-        },
-        "assembly_params": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatic Analysis fields",
-            "label": "Assambly params",
-            "fill_mode": "batch"
-        },
-        "variant_calling_software_name": {
-            "examples": [
-                ""
-            ],
-            "ontology": "operation_3227",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatic Variants",
-            "label": "Variant Calling",
-            "fill_mode": "batch"
-        },
-        "variant_calling_software_version": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatic Variants",
-            "label": "Variant Calling Version",
-            "fill_mode": "batch"
-        },
-        "if_variant_calling_other": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatic Variants",
-            "label": "If variant calling Is Other, Specify",
-            "fill_mode": "batch"
-        },
-        "variant_calling_params": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatic Variants",
-            "label": "Variant Calling params",
-            "fill_mode": "batch"
-        },
-        "consensus_sequence_R1_name": {
-            "ontology": "GENEPIO:0001461",
-            "type": "string",
-            "description": "The name of the consensus sequence.",
-            "examples": [
-                "ncov123assembly3"
-            ],
-            "classification": "Bioinformatic Analysis fields",
-            "label": "Consensus sequence name",
-            "fill_mode": "batch"
-        },
-        "consensus_sequence_R2_name": {
-            "ontology": "GENEPIO:0001460",
-            "type": "string",
-            "description": "The name of the consensus sequence.",
-            "examples": [
-                "ncov123assembly3"
-            ],
-            "classification": "Bioinformatic Analysis fields",
-            "label": "Consensus sequence name",
-            "fill_mode": "batch"
-        },
-        "consensus_sequence_R1_md5": {
-            "ontology": "NMR:1000568",
-            "type": "string",
-            "description": "The name of the consensus sequence.",
-            "examples": [
-                "ncov123assembly3"
-            ],
-            "classification": "Bioinformatic Analysis fields",
-            "label": "Consensus sequence name md5",
-            "fill_mode": "batch"
-        },
-        "consensus_sequence_R2_md5": {
-            "ontology": "NMR:1000569",
-            "type": "string",
-            "description": "The name of the consensus sequence.",
-            "examples": [
-                "ncov123assembly3"
-            ],
-            "classification": "Bioinformatic Analysis fields",
-            "label": "Consensus sequence name md5",
-            "fill_mode": "batch"
-        },
-        "consensus_sequence_filepath": {
-            "examples": [
-                "/User/Documents/RespLab/Data/ncov123assembly.fasta"
-            ],
-            "ontology": "GENEPIO:0001462",
-            "type": "string",
-            "description": "The filepath of the consesnsus sequence file.",
-            "classification": "Bioinformatic Analysis fields",
-            "label": "Consensus sequence filepath",
-            "fill_mode": "batch"
-        },
-        "long_table_path": {
-            "examples": [
-                "1.3"
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "The path where the long table is ",
-            "classification": "Bioinformatic Analysis fields",
-            "label": "Long table path",
-            "fill_mode": "batch"
-        },
-        "consensus_sequence_software_name": {
-            "examples": [
-                "Ivar"
-            ],
-            "ontology": "GENEPIO:0001463",
-            "type": "string",
-            "description": "The name of software used to generate the consensus sequence.",
-            "classification": "Bioinformatic Analysis fields",
-            "label": "Consensus sequence software name",
-            "fill_mode": "batch"
-        },
-        "if_consensus_other": {
-            "examples": [
-                "1.3"
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "The version of the software used to generate the consensus sequence.",
-            "classification": "Bioinformatic Analysis fields",
-            "label": "If consensus Is Other, Specify",
-            "fill_mode": "batch"
-        },
-        "consensus_sequence_software_version": {
-            "examples": [
-                "1.3"
-            ],
-            "ontology": "GENEPIO:0001469",
-            "type": "string",
-            "description": "The version of the software used to generate the consensus sequence.",
-            "classification": "Bioinformatic Analysis fields",
-            "label": "Consensus sequence software version",
-            "fill_mode": "batch"
-        },
-        "consensus_params": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatic Analysis fields",
-            "label": "Consensus Params",
-            "fill_mode": "batch"
-        },
-        "depth_of_coverage_value": {
-            "examples": [
-                "400x"
-            ],
-            "ontology": "GENEPIO:0001474",
-            "type": "string",
-            "description": "The average number of reads representing a given nucleotide in the reconstructed sequence.",
-            "classification": "Bioinformatics and QC metrics fields",
-            "label": "Depth of coverage value ",
-            "fill_mode": "batch"
-        },
-        "sample_name": {
-            "examples": [
-                "234546"
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatics and QC metrics fields",
-            "label": "Sample Name",
-            "fill_mode": "batch"
-        },
-        "depth_of_coverage_threshold": {
-            "examples": [
-                "100x"
-            ],
-            "ontology": "GENEPIO:0001475",
-            "type": "string",
-            "description": "The threshold used as a cut-off for the depth of coverage.",
-            "classification": "Bioinformatics and QC metrics fields",
-            "label": "Depth of coverage threshold",
             "fill_mode": "batch"
         },
         "sequence_file_R1_fastq": {
@@ -1475,37 +1464,38 @@
             "label": "Filepath fast5",
             "fill_mode": "batch"
         },
-        "number_of_base_pairs_sequenced": {
+        "analysis_date": {
             "examples": [
-                "387566"
+                "e.g 2020-08-07"
             ],
-            "ontology": "GENEPIO:0001482",
+            "ontology": "0",
             "type": "string",
-            "description": "The number of total base pairs generated by the sequencing process.",
+            "format": "date",
+            "description": "",
             "classification": "Bioinformatics and QC metrics fields",
-            "label": "Number of base pairs sequenced ",
+            "label": "Analysis date",
             "fill_mode": "batch"
         },
-        "consensus_genome_length": {
+        "dehosting_method_software_name": {
             "examples": [
-                "38677"
+                "Nanostripper"
             ],
-            "ontology": "GENEPIO:0001483",
+            "ontology": "GENEPIO:0001459",
             "type": "string",
-            "description": "Size of the assembled genome described as the number of base pairs.",
-            "classification": "Bioinformatics and QC metrics fields",
-            "label": "Consensus genome length",
+            "description": "The method used to remove host reads from the pathogen sequence.",
+            "classification": "Bioinformatic Analysis fields",
+            "label": "Dehosting Method",
             "fill_mode": "batch"
         },
-        "ns_per_100_kbp": {
+        "dehosting_method_software_version": {
             "examples": [
-                "300"
+                "2.4.1"
             ],
-            "ontology": "GENEPIO:0001484",
+            "ontology": "0",
             "type": "string",
-            "description": "The number of N symbols present in the consensus fasta sequence, per 100kbp of sequence.",
-            "classification": "Bioinformatics and QC metrics fields",
-            "label": "Ns per 100 kbp",
+            "description": "The method version used to remove host reads from the pathogen sequence.",
+            "classification": "Bioinformatic Analysis fields",
+            "label": "Dehosting Method Version",
             "fill_mode": "batch"
         },
         "reference_genome_accession": {
@@ -1553,6 +1543,11 @@
             "fill_mode": "batch"
         },
         "commercial_open_source_both": {
+            "Enums":[
+                "Commercial",
+                "Open Source",
+                "Both"
+            ],
             "examples": [
                 ""
             ],
@@ -1565,22 +1560,22 @@
         },
         "preprocessing_software_name": {
             "examples": [
-                ""
+                "fastp"
             ],
             "ontology": "MS_1002386",
             "type": "string",
-            "description": "",
+            "description": "Software used for preprocessing step.",
             "classification": "Bioinformatic Analysis fields",
             "label": "Preprocessing",
             "fill_mode": "batch"
         },
         "preprocessing_software_version": {
             "examples": [
-                ""
+                "v5.3.1"
             ],
             "ontology": "0",
             "type": "string",
-            "description": "",
+            "description": "Version of the preprocessing software used.",
             "classification": "Bioinformatic Analysis fields",
             "label": "Preprocessing Version",
             "fill_mode": "batch"
@@ -1602,29 +1597,29 @@
             ],
             "ontology": "0",
             "type": "string",
-            "description": "",
+            "description": "Preprocessing parameters used.",
             "classification": "Bioinformatic Analysis fields",
             "label": "Preprocessing params",
             "fill_mode": "batch"
         },
         "mapping_software_name": {
             "examples": [
-                ""
+                "bowtie2"
             ],
             "ontology": "topic:0102",
             "type": "string",
-            "description": "",
+            "description": "Software used for mapping step.",
             "classification": "Bioinformatic Analysis fields",
             "label": "Mapping",
             "fill_mode": "batch"
         },
         "mapping_software_version": {
             "examples": [
-                ""
+                "v7.0.1"
             ],
             "ontology": "0",
             "type": "string",
-            "description": "",
+            "description": "Version of the mapper used.",
             "classification": "Bioinformatic Analysis fields",
             "label": "Mapping Version",
             "fill_mode": "batch"
@@ -1646,9 +1641,328 @@
             ],
             "ontology": "0",
             "type": "string",
-            "description": "",
+            "description": "Parameters used for mapping step.",
             "classification": "Bioinformatic Analysis fields",
             "label": "Mapping params",
+            "fill_mode": "batch"
+        },
+        "assembly": {
+            "examples": [
+                "Spades"
+            ],
+            "ontology": "NCIT_C63548",
+            "type": "string",
+            "description": "Software used for assembly of the pathogen genome.",
+            "classification": "Bioinformatic Analysis fields",
+            "label": "Assembly",
+            "fill_mode": "batch"
+        },
+        "if_assembly_other": {
+            "examples": [
+                "v3.1"
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "Assembly software version",
+            "classification": "Bioinformatic Analysis fields",
+            "label": "If assembly Is Other, Specify",
+            "fill_mode": "batch"
+        },
+        "assembly_params": {
+            "examples": [
+                "-k 127,56,27"
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "Params used for genome assembly.",
+            "classification": "Bioinformatic Analysis fields",
+            "label": "Assambly params",
+            "fill_mode": "batch"
+        },
+        "variant_calling_software_name": {
+            "examples": [
+                "Ivar"
+            ],
+            "ontology": "operation_3227",
+            "type": "string",
+            "description": "Software used for variant calling.",
+            "classification": "Bioinformatic Variants",
+            "label": "Variant Calling",
+            "fill_mode": "batch"
+        },
+        "variant_calling_software_version": {
+            "examples": [
+                "v4.1"
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "Variant calling software version",
+            "classification": "Bioinformatic Variants",
+            "label": "Variant Calling Version",
+            "fill_mode": "batch"
+        },
+        "if_variant_calling_other": {
+            "examples": [
+                ""
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "",
+            "classification": "Bioinformatic Variants",
+            "label": "If variant calling Is Other, Specify",
+            "fill_mode": "batch"
+        },
+        "variant_calling_params": {
+            "examples": [
+                "-t 0.5 -Q 20"
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "Params used for variant calling",
+            "classification": "Bioinformatic Variants",
+            "label": "Variant Calling params",
+            "fill_mode": "batch"
+        },
+        "consensus_sequence_name": {
+            "ontology": "GENEPIO:0001460",
+            "type": "string",
+            "description": "The name of the consensus sequence.",
+            "examples": [
+                "ncov123assembly3"
+            ],
+            "classification": "Bioinformatic Analysis fields",
+            "label": "Consensus sequence name",
+            "fill_mode": "batch"
+        },
+        "consensus_sequence_filename": {
+            "ontology": "GENEPIO:0001461",
+            "type": "string",
+            "description": "The name of the consensus sequence filename",
+            "examples": [
+                "ncov123assembly3"
+            ],
+            "classification": "Bioinformatic Analysis fields",
+            "label": "Consensus sequence name",
+            "fill_mode": "batch"
+        },
+        "consensus_sequence_md5": {
+            "ontology": "0",
+            "type": "string",
+            "description": "The name of the consensus sequence.",
+            "examples": [
+                "5gaskañlkdak3143242ñlkas"
+            ],
+            "classification": "Bioinformatic Analysis fields",
+            "label": "Consensus sequence name md5",
+            "fill_mode": "batch"
+        },
+        "consensus_sequence_filepath": {
+            "examples": [
+                "/User/Documents/RespLab/Data/ncov123assembly.fasta"
+            ],
+            "ontology": "GENEPIO:0001462",
+            "type": "string",
+            "description": "The filepath of the consesnsus sequence file.",
+            "classification": "Bioinformatic Analysis fields",
+            "label": "Consensus sequence filepath",
+            "fill_mode": "batch"
+        },
+        "long_table_path": {
+            "examples": [
+                "/User/Documents/RespLab/ncov123_longtable.tsv"
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "The path where the long table including all variants and annotations is.",
+            "classification": "Bioinformatic Analysis fields",
+            "label": "Long table path",
+            "fill_mode": "batch"
+        },
+        "consensus_sequence_software_name": {
+            "examples": [
+                "Ivar"
+            ],
+            "ontology": "GENEPIO:0001463",
+            "type": "string",
+            "description": "The name of software used to generate the consensus sequence.",
+            "classification": "Bioinformatic Analysis fields",
+            "label": "Consensus sequence software name",
+            "fill_mode": "batch"
+        },
+        "if_consensus_other": {
+            "examples": [
+                "v1.3"
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "The version of the software used to generate the consensus sequence.",
+            "classification": "Bioinformatic Analysis fields",
+            "label": "If consensus Is Other, Specify",
+            "fill_mode": "batch"
+        },
+        "consensus_sequence_software_version": {
+            "examples": [
+                "1.3"
+            ],
+            "ontology": "GENEPIO:0001469",
+            "type": "string",
+            "description": "The version of the software used to generate the consensus sequence.",
+            "classification": "Bioinformatic Analysis fields",
+            "label": "Consensus sequence software version",
+            "fill_mode": "batch"
+        },
+        "consensus_params": {
+            "examples": [
+                "AF > 0.75"
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "Parameters used for consensus generation",
+            "classification": "Bioinformatic Analysis fields",
+            "label": "Consensus Params",
+            "fill_mode": "batch"
+        },
+        "consensus_genome_length": {
+            "examples": [
+                "38677"
+            ],
+            "ontology": "GENEPIO:0001483",
+            "type": "string",
+            "description": "Size of the assembled genome described as the number of base pairs.",
+            "classification": "Bioinformatics and QC metrics fields",
+            "label": "Consensus genome length",
+            "fill_mode": "batch"
+        },
+        "depth_of_coverage_threshold": {
+            "examples": [
+                "10x"
+            ],
+            "ontology": "GENEPIO:0001475",
+            "type": "string",
+            "description": "The threshold used as a cut-off for the depth of coverage.",
+            "classification": "Bioinformatics and QC metrics fields",
+            "label": "Depth of coverage threshold",
+            "fill_mode": "batch"
+        },
+        "number_of_base_pairs_sequenced": {
+            "examples": [
+                "387566"
+            ],
+            "ontology": "GENEPIO:0001482",
+            "type": "string",
+            "description": "The number of total base pairs generated by the sequencing process.",
+            "classification": "Bioinformatics and QC metrics fields",
+            "label": "Number of base pairs sequenced ",
+            "fill_mode": "batch"
+        },
+        "qc_filtered": {
+            "examples": [
+                ""
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "",
+            "classification": "Bioinformatics and QC metrics fields",
+            "label": "%qc filtered",
+            "fill_mode": "batch"
+        },
+        "per_reads_host": {
+            "examples": [
+                ""
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "",
+            "classification": "Bioinformatics and QC metrics fields",
+            "label": "%reads host",
+            "fill_mode": "batch"
+        },
+        "per_reads_virus": {
+            "examples": [
+                ""
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "",
+            "classification": "Bioinformatics and QC metrics fields",
+            "label": "%reads virus",
+            "fill_mode": "batch"
+        },
+        "per_unmapped": {
+            "examples": [
+                ""
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "",
+            "classification": "Bioinformatics and QC metrics fields",
+            "label": "%unmapped",
+            "fill_mode": "batch"
+        },
+        "depth_of_coverage_value": {
+            "examples": [
+                "400x"
+            ],
+            "ontology": "GENEPIO:0001474",
+            "type": "string",
+            "description": "The average number of reads representing a given nucleotide in the reconstructed sequence.",
+            "classification": "Bioinformatics and QC metrics fields",
+            "label": "Depth of coverage value ",
+            "fill_mode": "batch"
+        },
+        "per_genome_greater_10x": {
+            "examples": [
+                ""
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "",
+            "classification": "Bioinformatics and QC metrics fields",
+            "label": "% genome greater 10x",
+            "fill_mode": "batch"
+        },
+        "per_Ns": {
+            "examples": [
+                ""
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "",
+            "classification": "Bioinformatics and QC metrics fields",
+            "label": "%Ns",
+            "fill_mode": "batch"
+        },
+        "ns_per_100_kbp": {
+            "examples": [
+                "300"
+            ],
+            "ontology": "GENEPIO:0001484",
+            "type": "string",
+            "description": "The number of N symbols present in the consensus fasta sequence, per 100kbp of sequence.",
+            "classification": "Bioinformatics and QC metrics fields",
+            "label": "Ns per 100 kbp",
+            "fill_mode": "batch"
+        },
+        "number_of_variants_in_consensus": {
+            "examples": [
+                ""
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "",
+            "classification": "Bioinformatic Variants",
+            "label": "Number of variants (AF greater 75%)",
+            "fill_mode": "batch"
+        },
+        "number_of_variants_with_effect": {
+            "examples": [
+                ""
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "",
+            "classification": "Bioinformatic Variants",
+            "label": "Number of variants with effect",
             "fill_mode": "batch"
         },
         "lineage_name": {
@@ -1675,7 +1989,7 @@
         },
         "if_lineage_identification_other": {
             "examples": [
-                "Other than Pangolin"
+                "Nextclade"
             ],
             "ontology": "0",
             "type": "string",
@@ -1695,17 +2009,6 @@
             "label": "Lineage/clade analysis software version",
             "fill_mode": "batch"
         },
-        "isolate_sample_id": {
-            "examples": [
-                ""
-            ],
-            "ontology": "NCIT:C53471",
-            "type": "string",
-            "description": "",
-            "classification": "Database Identifiers",
-            "label": "Sample ID given if multiple rna-extraction or passages",
-            "fill_mode": "sample"
-        },
         "variant_designation": {
             "Enums": [
                 "Variant of Interest (VOI) [GENEPIO:0100082]",
@@ -1718,7 +2021,7 @@
             "examples": [
                 "Variant of Concern (VOC) [GENEPIO:0100083]"
             ],
-            "classification": "Bioinformatic Variants",
+            "classification": "Lineage fields",
             "label": "Variant designation",
             "fill_mode": "batch"
         },
@@ -1771,94 +2074,6 @@
             ],
             "classification": "Pathogen diagnostic testing",
             "label": "Gene Name 1",
-            "fill_mode": "batch"
-        },
-        "qc_filtered": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatics and QC metrics fields",
-            "label": "%qc filtered",
-            "fill_mode": "batch"
-        },
-        "per_reads_host": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatics and QC metrics fields",
-            "label": "%reads host",
-            "fill_mode": "batch"
-        },
-        "per_reads_virus": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatics and QC metrics fields",
-            "label": "%reads virus",
-            "fill_mode": "batch"
-        },
-        "per_unmapped": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatics and QC metrics fields",
-            "label": "%unmapped",
-            "fill_mode": "batch"
-        },
-        "per_genome_greater_10x": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatics and QC metrics fields",
-            "label": "% genome greater 10x",
-            "fill_mode": "batch"
-        },
-        "per_Ns": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatics and QC metrics fields",
-            "label": "%Ns",
-            "fill_mode": "batch"
-        },
-        "number_of_variants_in_consensus": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatic Variants",
-            "label": "Number of variants (AF greater 75%)",
-            "fill_mode": "batch"
-        },
-        "number_of_variants_with_effect": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Bioinformatic Variants",
-            "label": "Number of variants with effect",
             "fill_mode": "batch"
         },
         "diagnostic_pcr_Ct_value_1": {
@@ -1923,30 +2138,6 @@
             "label": "Gene Name 2",
             "fill_mode": "batch"
         },
-        "analysis_date": {
-            "examples": [
-                "e.g 2020-08-07"
-            ],
-            "ontology": "0",
-            "type": "string",
-            "format": "date",
-            "description": "",
-            "classification": "Bioinformatics and QC metrics fields",
-            "label": "Analysis date",
-            "fill_mode": "batch"
-        },
-        "lineage_identification_date": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "format": "date",
-            "description": "",
-            "classification": "Lineage fields",
-            "label": "Lineage identification date",
-            "fill_mode": "batch"
-        },
         "diagnostic_pcr_Ct_value_2": {
             "examples": [
                 "36"
@@ -1958,39 +2149,6 @@
             "label": "Diagnostic Pcr Ct Value-2",
             "fill_mode": "batch"
         },
-        "analysis_authors": {
-            "examples": [
-                ""
-            ],
-            "ontology": "NCIT:C42781",
-            "type": "string",
-            "description": "",
-            "classification": "Contributor Acknowledgement",
-            "label": "Analysis Authors",
-            "fill_mode": "batch"
-        },
-        "author_submitter": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Contributor Acknowledgement",
-            "label": "Author Submitter",
-            "fill_mode": "batch"
-        },
-        "gisaid_id": {
-            "examples": [
-                ""
-            ],
-            "ontology": "NCIT:C54269",
-            "type": "string",
-            "description": "enter your GISAID-Username",
-            "classification": "Database Identifiers",
-            "label": "GISAID id",
-            "fill_mode": "sample"
-        },
         "authors": {
             "examples": [
                 ""
@@ -1998,479 +2156,143 @@
             "ontology": "GENEPIO:0001517",
             "type": "string",
             "description": "",
-            "classification": "Contributor Acknowledgement",
+            "classification": "Public databases",
             "label": "Authors",
             "fill_mode": "batch"
         },
-        "common_name": {
+        "gisaid_submitter_id": {
             "examples": [
                 ""
             ],
-            "ontology": "NCIT:C164471",
+            "ontology": "NCIT:C54269",
             "type": "string",
-            "description": "The common name of the organism.",
-            "classification": "Sample collection and processing",
-            "label": "Common name",
-            "fill_mode": "batch"
+            "description": "GISAID sequence ID.",
+            "classification": "Public Databases",
+            "label": "GISAID id",
+            "fill_mode": "sample"
         },
-        "collector_name": {
+        "gisaid_accession_id": {
             "examples": [
-                "John Smith"
+                "NCIT:C180324"
             ],
-            "ontology": "GENEPIO:0001797",
+            "ontology": "",
             "type": "string",
-            "description": "Name of the person who collected the specimen",
-            "classification": "Sample collection and processing",
-            "label": "Sample collector name",
-            "table": "sample",
-            "fill_mode": "batch"
+            "description": "GISAID sequence ID.",
+            "classification": "Public Databases",
+            "label": "GISAID id",
+            "fill_mode": "sample"
         },
-        "library_source": {
-            "Enums": [
-                "5-methycytidine antibody method [GENPIO:0001941]",
-                "CAGE method [GENPIO:0001942]",
-                "CF-H method [GENPIO:0001943]",
-                "CF-M method ]GENPIO:0001944]",
-                "CF-S method [GENPIO:0001945]",
-                "CF-T method [GENPIO:0001946]",
-                "ChIP method ]GENPIO:0001947]",
-                "DNAse method [GENPIO:0001948]",
-                "HMPR method [GENPIO:0001949]",
-                "Hybrid Selection Method [GENPIO:0001950]",
-                "MBD2 protein methyl-CpG binding domain method [GENPIO:0001951]",
-                "MF method [GENPIO:0001952]",
-                "MNase method [GENPIO:0001953]",
-                "MSLL method [GENPIO:0001954]",
-                "PCR method [GENPIO:0001955]",
-                "RACE method [GENPIO:0001956]",
-                "RANDOM PCR method [GENPIO:0001957]",
-                "RANDOM method [GENPIO:0001958]",
-                "RT-PCR method [GENPIO:0001959]",
-                "Reduced Representation method [GENPIO:0001960]",
-                "Resctriction Digest method [GENPIO:0001961]",
-                "cDNA method [GENPIO:0001962]",
-                "other library method [GENPIO:0001964]",
-                "size fractionation method [GENPIO:0001963]"
-            ],
+        "gisaid_virus_name": {
             "examples": [
-                "METAGENOMIC"
+                "hCoV-19/Canada/prov_rona_99/2020"
             ],
-            "ontology": "GENEPIO_0001965",
+            "ontology": "GENEPIO:0100282",
             "type": "string",
-            "description": "Molecule type used to make the library.",
-            "classification": "Sequencing",
-            "label": "Source material",
-            "fill_mode": "batch"
+            "description": "The user-defined GISAID virus name assigned to the sequence.",
+            "classification": "Public Databases",
+            "label": "GISAID Virus Name",
+            "fill_mode": "sample"
         },
-        "analysis_accession": {
+        "ena_analysis_accession": {
             "examples": [
                 ""
             ],
             "ontology": "GENEPIO_0001145",
             "type": "string",
             "description": "",
-            "classification": "Submission ENA",
+            "classification": "Public databases",
             "label": "Analysis Accession",
             "fill_mode": "batch"
         },
-        "study_accession": {
+        "ena_study_accession": {
             "examples": [
                 "e.g PRJEB39632"
             ],
             "ontology": "GENEPIO_0001136",
             "type": "string",
             "description": "",
-            "classification": "Submission ENA",
+            "classification": "Public databases",
             "label": "Study accession",
             "fill_mode": "batch"
         },
-        "secondary_study_accession": {
-            "examples": [
-                "e.g ERP123173"
-            ],
-            "ontology": "BU_ISCIII:012",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Secondary study accession",
-            "fill_mode": "batch"
-        },
-        "sample_accession": {
+        "ena_sample_accession": {
             "examples": [
                 "e.g SAMEA7098096"
             ],
             "ontology": "GENEPIO_0001139",
             "type": "string",
             "description": "",
-            "classification": "Submission ENA",
+            "classification": "Public databases",
             "label": "Sample accession",
             "fill_mode": "batch"
         },
-        "secondary_sample_accession": {
-            "examples": [
-                "e.g ERS4858671"
-            ],
-            "ontology": "BU_ISCIII:014",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Secondary sample accession",
-            "fill_mode": "batch"
-        },
-        "experiment_accession": {
+        "ena_experiment_accession": {
             "examples": [
                 "e.g ERX4331406"
             ],
             "ontology": "BU_ISCIII:015",
             "type": "string",
             "description": "",
-            "classification": "Submission ENA",
+            "classification": "Public databases",
             "label": "Experiment Accession",
             "fill_mode": "batch"
         },
-        "run_accession": {
+        "ena_run_accession": {
             "examples": [
                 "e.g ERX4331406"
             ],
             "ontology": "BU_ISCIII:016",
             "type": "string",
             "description": "",
-            "classification": "Submission ENA",
+            "classification": "Public databases",
             "label": "Run Accession",
             "fill_mode": "batch"
         },
-        "submission_accession": {
+        "ena_submission_accession": {
             "examples": [
                 "e.g ERA2794974"
             ],
             "ontology": "BU_ISCIII:017",
             "type": "string",
             "description": "",
-            "classification": "Submission ENA",
+            "classification": "Public databases",
             "label": "Submission Accession",
             "fill_mode": "batch"
         },
-        "read_count": {
-            "examples": [
-                "e.g 837055"
-            ],
-            "ontology": "STATO_0000064",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Read count",
-            "fill_mode": "batch"
-        },
-        "read_length": {
-            "examples": [
-                ""
-            ],
-            "ontology": "STATO_0000064",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Read length",
-            "fill_mode": "batch"
-        },
-        "base_count": {
-            "examples": [
-                "e.g 503907110"
-            ],
-            "ontology": "UO_0000244",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Base count",
-            "fill_mode": "batch"
-        },
-        "first_public": {
-            "examples": [
-                "e.g 2020-08-07"
-            ],
-            "ontology": "NCIT_C142711",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "First Public date",
-            "fill_mode": "batch"
-        },
-        "last_updated": {
-            "examples": [
-                "e.g 2020-07-29"
-            ],
-            "ontology": "OMIABIS_0001005",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "format": "date",
-            "label": "Last Updated",
-            "fill_mode": "batch"
-        },
-        "experiment_title": {
+        "ena_experiment_title": {
             "examples": [
                 "e.g Illumina MiSeq paired end sequencing"
             ],
             "ontology": "ORNASEQ_0000004",
             "type": "string",
             "description": "",
-            "classification": "Submission ENA",
+            "classification": "Public Databases",
             "label": "Experiment title",
             "fill_mode": "batch"
         },
-        "study_title": {
+        "ena_study_title": {
             "examples": [
                 "e.g SARS-CoV-2 genomes from late April in Stockholm"
             ],
             "ontology": "OPMI_0000380",
             "type": "string",
             "description": "",
-            "classification": "Submission ENA",
+            "classification": "Public Databases",
             "label": "Study title",
             "fill_mode": "batch"
         },
-        "study_alias": {
-            "examples": [
-                "e.g Sweden"
-            ],
-            "ontology": "SIO_001066",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Study alias",
-            "fill_mode": "batch"
-        },
-        "experiment_alias": {
-            "examples": [
-                "e.g ena-STUDY-KAROLINSKA INSITUTET-29-07-2020-14:18:07:925-2092"
-            ],
-            "ontology": "NCIT_C42790",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Experiment alias",
-            "fill_mode": "batch"
-        },
-        "run_alias": {
-            "examples": [
-                "e.g ena-EXPERIMENT-KAROLINSKA INSITUTET-29-07-2020-14:50:07:151-1"
-            ],
-            "ontology": "NCIT_C47911",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Run Alias",
-            "fill_mode": "batch"
-        },
-        "fastq_bytes": {
-            "examples": [
-                "e.g ena-RUN-KAROLINSKA INSITUTET-29-07-2020-14:50:07:151-1"
-            ],
-            "ontology": "NCIT_C48047",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Fastq bytes",
-            "fill_mode": "batch"
-        },
-        "fastq_md5_r1": {
-            "examples": [
-                ""
-            ],
-            "ontology": "MS_1000568",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Fastq md5 r1",
-            "fill_mode": "batch"
-        },
-        "fastq_md5_r2": {
-            "examples": [
-                ""
-            ],
-            "ontology": "MS_1000568",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Fastq md5 r2",
-            "fill_mode": "batch"
-        },
-        "fastq_ftp": {
-            "examples": [
-                ""
-            ],
-            "ontology": "PRIDE_0000469",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Fastq ftp",
-            "fill_mode": "batch"
-        },
-        "fastq_aspera": {
-            "examples": [
-                "e.g ftp.sra.ebi.ac.uk/vol1/fastq/ERR438/005/ERR4387385/ERR4387385_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/ERR438/005/ERR4387385/ERR4387385_2.fastq.gz"
-            ],
-            "ontology": "BU_ISCIII:032",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Fastq aspera",
-            "fill_mode": "batch"
-        },
-        "fastq_galaxy": {
-            "examples": [
-                "e.g fasp.sra.ebi.ac.uk:/vol1/fastq/ERR438/005/ERR4387385/ERR4387385_1.fastq.gz;fasp.sra.ebi.ac.uk:/vol1/fastq/ERR438/005/ERR4387385/ERR4387385_2.fastq.gz"
-            ],
-            "ontology": "ENVO_01000807",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Fastq galaxy",
-            "fill_mode": "batch"
-        },
-        "submitted_bytes": {
-            "examples": [
-                "e.g ftp.sra.ebi.ac.uk/vol1/fastq/ERR438/005/ERR4387385/ERR4387385_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/ERR438/005/ERR4387385/ERR4387385_2.fastq.gz"
-            ],
-            "ontology": "NCIT_C172872",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Submitted bytes ",
-            "fill_mode": "batch"
-        },
-        "submitted_md5": {
-            "examples": [
-                "e.g 139853010;166270048"
-            ],
-            "ontology": "BU_ISCIII:035",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Submitted md5",
-            "fill_mode": "batch"
-        },
-        "submitted_ftp": {
-            "examples": [
-                "e.g d726a9abc918e2b43bd68b24c7d01b3a;f01eba1b2bad974bdf61b81b1ae8ac2a"
-            ],
-            "ontology": "BU_ISCIII:036",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Submitted ftp",
-            "fill_mode": "batch"
-        },
-        "submitted_aspera": {
-            "examples": [
-                "e.g ftp.sra.ebi.ac.uk/vol1/run/ERR438/ERR4387385/P17157_1007_S7_L001_R1_001.fastq.gz;ftp.sra.ebi.ac.uk/vol1/run/ERR438/ERR4387385/P17157_1007_S7_L001_R2_001.fastq.gz"
-            ],
-            "ontology": "BU_ISCIII:037",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Submitted aspera",
-            "fill_mode": "batch"
-        },
-        "submitted_galaxy": {
-            "examples": [
-                "e.g fasp.sra.ebi.ac.uk:/vol1/run/ERR438/ERR4387385/P17157_1007_S7_L001_R1_001.fastq.gz;fasp.sra.ebi.ac.uk:/vol1/run/ERR438/ERR4387385/P17157_1007_S7_L001_R2_001.fastq.gz"
-            ],
-            "ontology": "BU_ISCIII:038",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Submitted Galaxy",
-            "fill_mode": "batch"
-        },
-        "submitted_format": {
-            "examples": [
-                "e.g  ftp.sra.ebi.ac.uk/vol1/run/ERR438/ERR4387385/P17157_1007_S7_L001_R1_001.fastq.gz;ftp.sra.ebi.ac.uk/vol1/run/ERR438/ERR4387385/P17157_1007_S7_L001_R2_001.fastq.gz"
-            ],
-            "ontology": "BU_ISCIII:039",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Submitted Format",
-            "fill_mode": "batch"
-        },
-        "sra_bytes": {
-            "examples": [
-                "e.g FASTQ;FASTQ"
-            ],
-            "ontology": "BU_ISCIII:040",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "SRA bytes",
-            "fill_mode": "batch"
-        },
-        "sra_md5": {
-            "examples": [
-                "e.g 260236789"
-            ],
-            "ontology": "BU_ISCIII:041",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "SRA md5",
-            "fill_mode": "batch"
-        },
-        "sra_ftp": {
-            "examples": [
-                "e.g 2cf0d467d6dc4ae0a5473774d54c059c"
-            ],
-            "ontology": "BU_ISCIII:042",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "SRA ftp",
-            "fill_mode": "batch"
-        },
-        "sra_aspera": {
-            "examples": [
-                "e.g ftp.sra.ebi.ac.uk/vol1/err/ERR438/005/ERR4387385"
-            ],
-            "ontology": "BU_ISCIII:043",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "SRA aspera",
-            "fill_mode": "batch"
-        },
-        "sra_galaxy": {
-            "examples": [
-                "e.g fasp.sra.ebi.ac.uk:/vol1/err/ERR438/005/ERR4387385"
-            ],
-            "ontology": "BU_ISCIII:044",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "SRA galaxy",
-            "fill_mode": "batch"
-        },
-        "broker_name": {
+        "ena_broker_name": {
             "examples": [
                 "P17157_1007"
             ],
             "ontology": "BU_ISCIII:045",
             "type": "string",
             "description": "",
-            "classification": "Submission ENA",
+            "classification": "Public Databases",
             "label": "Broker Name",
             "fill_mode": "batch"
         },
-        "nominal_sdev": {
-            "examples": [
-                ""
-            ],
-            "ontology": "STATO_0000237",
-            "type": "string",
-            "description": "",
-            "classification": "Submission ENA",
-            "label": "Nominal sdev",
-            "fill_mode": "batch"
-        },
-        "first_created_date": {
+        "ena_first_created_date": {
             "examples": [
                 "e.g 2020-08-07"
             ],
@@ -2478,53 +2300,9 @@
             "type": "string",
             "format": "date",
             "description": "",
-            "classification": "Submission ENA",
+            "classification": "Public Databases",
             "label": "First created date",
             "fill_mode": "batch"
-        },
-        "type": {
-            "examples": [
-                "betacoronavirus"
-            ],
-            "ontology": "NCIT:C25284",
-            "type": "string",
-            "description": "default must remain 'betacoronavirus'",
-            "classification": "Database Identifiers",
-            "label": "Type",
-            "fill_mode": "batch"
-        },
-        "biosample_accession_ENA": {
-            "examples": [
-                "SAMN14180202"
-            ],
-            "ontology": "GENEPIO:0001139",
-            "type": "string",
-            "description": "The identifier assigned to a BioSample in INSDC archives.",
-            "classification": "Database Identifiers",
-            "label": "ENA Sample ID",
-            "fill_mode": "sample"
-        },
-        "virus_name": {
-            "examples": [
-                "hCoV-19/Canada/prov_rona_99/2020"
-            ],
-            "ontology": "GENEPIO:0100282",
-            "type": "string",
-            "description": "The user-defined GISAID virus name assigned to the sequence.",
-            "classification": "Database Identifiers",
-            "label": "GISAID Virus Name",
-            "fill_mode": "sample"
-        },
-               "center_name": {
-            "examples": [
-                " KAROLINSKA INSITUTET"
-            ],
-            "ontology": "NCIT_C19983",
-            "type": "string",
-            "description": "The name of the institution",
-            "classification": "Sample collection and processing",
-            "label": "Center Name",
-            "fill_mode": "batch"
-        },
+        }
     }
 }

--- a/relecov_tools/schema/relecov_schema.json
+++ b/relecov_tools/schema/relecov_schema.json
@@ -16,6 +16,17 @@
     ],
     "type": "object",
     "properties": {
+        "public_health_sample_id_sivies": {
+            "examples": [
+                "2022CEU03926"
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "",
+            "classification": "Sample collection and processing",
+            "label": "Public Health sample id (SIVIES)",
+            "fill_mode": "sample"
+        },
         "collecting_lab_sample_id": {
             "examples": [
                 "prov_rona_99"
@@ -59,6 +70,28 @@
             "classification": "Sample collection and processing",
             "label": "Originating Laboratory Address",
             "fill_mode": "batch"
+        },
+         "microbiology_lab_sample_id": {
+            "examples": [
+                ""
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "",
+            "classification": "Sample collection and processing",
+            "label": "Sample ID given in the microbiology lab",
+            "fill_mode": "sample"
+        },
+        "sequencing_sample_id": {
+            "examples": [
+                ""
+            ],
+            "ontology": "GENEPIO:0000079",
+            "type": "string",
+            "description": "If the information is unknown or can not be shared, leave blank.",
+            "classification": "Database Identifiers",
+            "label": "Sample ID given for sequencing",
+            "fill_mode": "sample"
         },
          "submitting_lab_sample_id": {
             "examples": [
@@ -116,7 +149,7 @@
             "label": "Sample Collection Date",
             "fill_mode": "sample"
         },
-          "sample_received_date": {
+        "sample_received_date": {
             "examples": [
                 "3/21/2020"
             ],
@@ -439,6 +472,190 @@
             "label": "Autonomic Community",
             "fill_mode": "batch"
         },
+         "geo_loc_region": {
+            "examples": [
+                "Derbyshire"
+            ],
+            "ontology": "GENEPIO:0100280",
+            "type": "string",
+            "description": "The county/region of origin of the sample.",
+            "classification": "Sample collection and processing",
+            "label": "Province",
+            "fill_mode": "batch"
+        },
+        "geo_loc_city": {
+            "examples": [
+                "Vancouver"
+            ],
+            "ontology": "GENEPIO:0001189",
+            "type": "string",
+            "description": "The city of origin of the sample.",
+            "classification": "Sample collection and processing",
+            "label": "City",
+            "fill_mode": "batch"
+        },
+        "geo_loc_latitude": {
+            "examples": [
+                "38.98 N"
+            ],
+            "ontology": "OBI:0001620",
+            "type": "string",
+            "description": "The latitude coordinates of the geographical location of sample collection.",
+            "classification": "Sample collection and processing",
+            "label": "Geo Loc Latitude",
+            "fill_mode": "batch"
+        },
+        "geo_loc_longitude": {
+            "examples": [
+                "77.11 W"
+            ],
+            "ontology": "OBI:0001621",
+            "type": "string",
+            "description": "The longitude coordinates of the geographical location of sample collection.",
+            "classification": "Sample collection and processing",
+            "label": "Geo Loc Longitude",
+            "fill_mode": "batch"
+        },
+        "purpose_sampling": {
+            "Enums": [
+                "Cluster/Outbreak Investigation [GENEPIO:0100001]",
+                "Diagnostic Testing [GENEPIO:0100002]",
+                "Research [GENEPIO:0100003]",
+                "Protocol Testing [GENEPIO:0100024]",
+                "Surveillance [GENEPIO:0100004]",
+                "Not Applicable [GENEPIO:0001619]",
+                "Not Collected [GENEPIO:0001620]",
+                "Not Provided [GENEPIO:0001668]",
+                "Missing [GENEPIO:0001618]",
+                "Restricted Access [GENEPIO:0001810]"
+            ],
+            "ontology": "NCIT_C146997",
+            "type": "string",
+            "description": "The reason that the sample was collected.",
+            "examples": [
+                "Diagnostic Testing [GENEPIO:0100002]"
+            ],
+            "classification": "Sample collection and processing",
+            "label": "Purpose of sampling",
+            "fill_mode": "batch"
+        },
+        "anatomical_material": {
+            "Enums": [
+                "Blood [UBERON:0000178]",
+                "Fluid [UBERON:0006314]",
+                "Fluid (Cerebrospinal (CSF)) [UBERON:0001359]",
+                "Fluid (Pericardial) [UBERON:0002409]",
+                "Fluid (Pleural) [UBERON:0001087]",
+                "Fluid (Vaginal) [UBERON:0036243]",
+                "Fluid (Amniotic) [UBERON:0000173]",
+                "Saliva [UBERON:0001836]",
+                "Tissue [UBERON:0000479]",
+                "Not Applicable [GENEPIO:0001619]",
+                "Not Collected [GENEPIO:0001620]",
+                "Not Provided [GENEPIO:0001668]",
+                "Missing [GENEPIO:0001618]",
+                "Restricted Access [GENEPIO:0001810]"
+            ],
+            "ontology": "GENEPIO:0001211",
+            "type": "string",
+            "description": "A substance obtained from an anatomical part of an organism e.g. tissue, blood.",
+            "examples": [
+                "Blood [UBERON:0000178]"
+            ],
+            "classification": "Sample collection and processing",
+            "label": "Specimen source",
+            "fill_mode": "batch"
+        },
+        "environmental_material": {
+            "Enums": [
+                "Air vent [ENVO:03501208]",
+                "Banknote [ENVO:00003896]",
+                "Bed rail [ENVO:03501209]",
+                "Building Floor [ENVO:01000486]",
+                "Cloth [ENVO:02000058]",
+                "Control Panel [ENVO:03501210]",
+                "Door [ENVO:03501220]",
+                "Door Handle [ENVO:03501211]",
+                "Face Mask [OBI:0002787]",
+                "Face Shield [OBI:0002791]",
+                "Food [FOODON:00002403]",
+                "Food Packaging [FOODON:03490100]",
+                "Glass [ENVO:01000481]",
+                "Handrail [ENVO:03501212]",
+                "Hospital Gown [OBI:0002796]",
+                "Light Switch [ENVO:03501213]",
+                "Locker [ENVO:03501214]",
+                "N95 Mask [OBI:0002790]",
+                "Nurse Call Button [ENVO:03501215]",
+                "Paper [ENVO:03501256]",
+                "Particulate Matter [ENVO:01000060]",
+                "Plastic [ENVO:01000404]",
+                "PPE Gown [GENEPIO:0100025]",
+                "Sewage [ENVO:00002018]",
+                "Sink [ENVO:01000990]",
+                "Soil [ENVO:00001998]",
+                "Stainless Steel [ENVO:03501216]",
+                "Tissue Paper [ENVO:03501217]",
+                "Toilet Bowl [ENVO:03501218]",
+                "Water [ENVO:00002006]",
+                "Wastewater [ENVO:00002001]",
+                "Window [ENVO:03501219]",
+                "Wood [ENVO:00002040]",
+                "Not Applicable [GENEPIO:0001619]",
+                "Not Collected [GENEPIO:0001620]",
+                "Not Provided [GENEPIO:0001668]",
+                "Missing [GENEPIO:0001618]",
+                "Restricted Access [GENEPIO:0001810]"
+            ],
+            "ontology": "GENEPIO:0001223",
+            "type": "string",
+            "description": "A substance obtained from the natural or man-made environment e.g. soil, water, sewage, door handle, bed handrail, face mask.",
+            "examples": [
+                "Face Mask [OBI:0002787]"
+            ],
+            "classification": "Sample collection and processing",
+            "label": "Environmental Material",
+            "fill_mode": "batch"
+        },
+        "environmental_site": {
+            "Enums": [
+                "Acute care facility [ENVO:03501135]",
+                "Animal house [ENVO:00003040]",
+                "Bathroom [ENVO:01000422]",
+                "Clinical assessment centre [ENVO:03501136]",
+                "Conference venue [ENVO:03501127]",
+                "Corridor [ENVO:03501121]",
+                "Daycare [ENVO:01000927]",
+                "Emergency room (ER) [ENVO:03501145]",
+                "Family practice clinic [ENVO:03501186]",
+                "Group home [ENVO:03501196]",
+                "Homeless shelter [ENVO:03501133]",
+                "Hospital [ENVO:00002173]",
+                "Intensive Care Unit (ICU) [ENVO:03501152]",
+                "Long Term Care Facility [ENVO:03501194]",
+                "Patient room [ENVO:03501180]",
+                "Prison [ENVO:03501204]",
+                "Production Facility [ENVO:01000536]",
+                "School [ENVO:03501130]",
+                "Sewage Plant [ENVO:00003043]",
+                "Subway train [ENVO:03501109]",
+                "Wet market [ENVO:03501198]",
+                "Not Applicable [GENEPIO:0001619]",
+                "Not Collected [GENEPIO:0001620]",
+                "Not Provided [GENEPIO:0001668]",
+                "Missing [GENEPIO:0001618]",
+                "Restricted Access [GENEPIO:0001810]"
+            ],
+            "ontology": "GENEPIO:0001232",
+            "type": "string",
+            "description": "An environmental location may describe a site in the natural or built environment e.g. hospital, wet market, bat cave.",
+            "examples": [
+                "Hospital [ENVO:00002173]"
+            ],
+            "classification": "Sample collection and processing",
+            "label": "Environmental System",
+            "fill_mode": "batch"
+        },
         "organism": {
             "Enums": [
                 "Coronaviridae [NCBITaxon:11118]",
@@ -457,6 +674,17 @@
             ],
             "classification": "Sample collection and processing",
             "label": "Organism",
+            "fill_mode": "batch"
+        },
+        "tax_id": {
+            "examples": [
+                "probably 2697049 in all cases"
+            ],
+            "ontology": "GENEPIO_0001724",
+            "type": "string",
+            "description": "The NCBITaxon identifier for the organism being sequenced.",
+            "classification": "Sample collection and processing",
+            "label": "Tax ID",
             "fill_mode": "batch"
         },
         "host_subject_id": {
@@ -478,6 +706,37 @@
             "description": " Status of the host",
             "classification": "Host health state information",
             "label": "Host health state",
+        },
+        "host_common_name": {
+            "Enums": [
+                "Human [NCBITaxon:9606]",
+                "Bat [NCBITaxon:9397]",
+                "Cat [NCBITaxon:9685]",
+                "Chicken [NCBITaxon:9031]",
+                "Civet [NCBITaxon:9673]",
+                "Cow [NCBITaxon:9913]",
+                "Dog [NCBITaxon:9615]",
+                "Lion [NCBITaxon:9689]",
+                "Mink [NCBITaxon:452646]",
+                "Pangolin [NCBITaxon:9973]",
+                "Pig [NCBITaxon:9825]",
+                "Pigeon [NCBITaxon:8930]",
+                "Tiger [NCBITaxon:9694]",
+                "Not Applicable [GENEPIO:0001619]",
+                "Not Collected [GENEPIO:0001620]",
+                "Not Provided [GENEPIO:0001668]",
+                "Missing [GENEPIO:0001618]",
+                "Restricted Access [GENEPIO:0001810]"
+            ],
+            "ontology": "GENEPIO:0001386",
+            "type": "string",
+            "description": "The commonly used name of the host.",
+            "examples": [
+                "Human [NCBITaxon:9606]"
+            ],
+            "classification": "Host information",
+            "label": "Host",
+            "fill_mode": "batch"
         },
         "host_scientific_name": {
             "Enums": [
@@ -631,301 +890,6 @@
             "label": "Sequencing Instrument Model",
             "fill_mode": "batch"
         },
-       
-        "biosample_accession_ENA": {
-            "examples": [
-                "SAMN14180202"
-            ],
-            "ontology": "GENEPIO:0001139",
-            "type": "string",
-            "description": "The identifier assigned to a BioSample in INSDC archives.",
-            "classification": "Database Identifiers",
-            "label": "ENA Sample ID",
-            "fill_mode": "sample"
-        },
-        "virus_name": {
-            "examples": [
-                "hCoV-19/Canada/prov_rona_99/2020"
-            ],
-            "ontology": "GENEPIO:0100282",
-            "type": "string",
-            "description": "The user-defined GISAID virus name assigned to the sequence.",
-            "classification": "Database Identifiers",
-            "label": "GISAID Virus Name",
-            "fill_mode": "sample"
-        },
-       
-        "microbiology_lab_sample_id": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Sample collection and processing",
-            "label": "Sample ID given in the microbiology lab",
-            "fill_mode": "sample"
-        },
-        "public_health_sample_id_sivies": {
-            "examples": [
-                "2022CEU03926"
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Sample collection and processing",
-            "label": "Public Health sample id (SIVIES)",
-            "fill_mode": "sample"
-        },
-        "geo_loc_region": {
-            "examples": [
-                "Derbyshire"
-            ],
-            "ontology": "GENEPIO:0100280",
-            "type": "string",
-            "description": "The county/region of origin of the sample.",
-            "classification": "Sample collection and processing",
-            "label": "Province",
-            "fill_mode": "batch"
-        },
-        "geo_loc_city": {
-            "examples": [
-                "Vancouver"
-            ],
-            "ontology": "GENEPIO:0001189",
-            "type": "string",
-            "description": "The city of origin of the sample.",
-            "classification": "Sample collection and processing",
-            "label": "City",
-            "fill_mode": "batch"
-        },
-        "geo_loc_latitude": {
-            "examples": [
-                "38.98 N"
-            ],
-            "ontology": "OBI:0001620",
-            "type": "string",
-            "description": "The latitude coordinates of the geographical location of sample collection.",
-            "classification": "Sample collection and processing",
-            "label": "Geo Loc Latitude",
-            "fill_mode": "batch"
-        },
-        "geo_loc_longitude": {
-            "examples": [
-                "77.11 W"
-            ],
-            "ontology": "OBI:0001621",
-            "type": "string",
-            "description": "The longitude coordinates of the geographical location of sample collection.",
-            "classification": "Sample collection and processing",
-            "label": "Geo Loc Longitude",
-            "fill_mode": "batch"
-        },
-        "anatomical_material": {
-            "Enums": [
-                "Blood [UBERON:0000178]",
-                "Fluid [UBERON:0006314]",
-                "Fluid (Cerebrospinal (CSF)) [UBERON:0001359]",
-                "Fluid (Pericardial) [UBERON:0002409]",
-                "Fluid (Pleural) [UBERON:0001087]",
-                "Fluid (Vaginal) [UBERON:0036243]",
-                "Fluid (Amniotic) [UBERON:0000173]",
-                "Saliva [UBERON:0001836]",
-                "Tissue [UBERON:0000479]",
-                "Not Applicable [GENEPIO:0001619]",
-                "Not Collected [GENEPIO:0001620]",
-                "Not Provided [GENEPIO:0001668]",
-                "Missing [GENEPIO:0001618]",
-                "Restricted Access [GENEPIO:0001810]"
-            ],
-            "ontology": "GENEPIO:0001211",
-            "type": "string",
-            "description": "A substance obtained from an anatomical part of an organism e.g. tissue, blood.",
-            "examples": [
-                "Blood [UBERON:0000178]"
-            ],
-            "classification": "Sample collection and processing",
-            "label": "Specimen source",
-            "fill_mode": "batch"
-        },
-        "environmental_material": {
-            "Enums": [
-                "Air vent [ENVO:03501208]",
-                "Banknote [ENVO:00003896]",
-                "Bed rail [ENVO:03501209]",
-                "Building Floor [ENVO:01000486]",
-                "Cloth [ENVO:02000058]",
-                "Control Panel [ENVO:03501210]",
-                "Door [ENVO:03501220]",
-                "Door Handle [ENVO:03501211]",
-                "Face Mask [OBI:0002787]",
-                "Face Shield [OBI:0002791]",
-                "Food [FOODON:00002403]",
-                "Food Packaging [FOODON:03490100]",
-                "Glass [ENVO:01000481]",
-                "Handrail [ENVO:03501212]",
-                "Hospital Gown [OBI:0002796]",
-                "Light Switch [ENVO:03501213]",
-                "Locker [ENVO:03501214]",
-                "N95 Mask [OBI:0002790]",
-                "Nurse Call Button [ENVO:03501215]",
-                "Paper [ENVO:03501256]",
-                "Particulate Matter [ENVO:01000060]",
-                "Plastic [ENVO:01000404]",
-                "PPE Gown [GENEPIO:0100025]",
-                "Sewage [ENVO:00002018]",
-                "Sink [ENVO:01000990]",
-                "Soil [ENVO:00001998]",
-                "Stainless Steel [ENVO:03501216]",
-                "Tissue Paper [ENVO:03501217]",
-                "Toilet Bowl [ENVO:03501218]",
-                "Water [ENVO:00002006]",
-                "Wastewater [ENVO:00002001]",
-                "Window [ENVO:03501219]",
-                "Wood [ENVO:00002040]",
-                "Not Applicable [GENEPIO:0001619]",
-                "Not Collected [GENEPIO:0001620]",
-                "Not Provided [GENEPIO:0001668]",
-                "Missing [GENEPIO:0001618]",
-                "Restricted Access [GENEPIO:0001810]"
-            ],
-            "ontology": "GENEPIO:0001223",
-            "type": "string",
-            "description": "A substance obtained from the natural or man-made environment e.g. soil, water, sewage, door handle, bed handrail, face mask.",
-            "examples": [
-                "Face Mask [OBI:0002787]"
-            ],
-            "classification": "Sample collection and processing",
-            "label": "Environmental Material",
-            "fill_mode": "batch"
-        },
-        "environmental_site": {
-            "Enums": [
-                "Acute care facility [ENVO:03501135]",
-                "Animal house [ENVO:00003040]",
-                "Bathroom [ENVO:01000422]",
-                "Clinical assessment centre [ENVO:03501136]",
-                "Conference venue [ENVO:03501127]",
-                "Corridor [ENVO:03501121]",
-                "Daycare [ENVO:01000927]",
-                "Emergency room (ER) [ENVO:03501145]",
-                "Family practice clinic [ENVO:03501186]",
-                "Group home [ENVO:03501196]",
-                "Homeless shelter [ENVO:03501133]",
-                "Hospital [ENVO:00002173]",
-                "Intensive Care Unit (ICU) [ENVO:03501152]",
-                "Long Term Care Facility [ENVO:03501194]",
-                "Patient room [ENVO:03501180]",
-                "Prison [ENVO:03501204]",
-                "Production Facility [ENVO:01000536]",
-                "School [ENVO:03501130]",
-                "Sewage Plant [ENVO:00003043]",
-                "Subway train [ENVO:03501109]",
-                "Wet market [ENVO:03501198]",
-                "Not Applicable [GENEPIO:0001619]",
-                "Not Collected [GENEPIO:0001620]",
-                "Not Provided [GENEPIO:0001668]",
-                "Missing [GENEPIO:0001618]",
-                "Restricted Access [GENEPIO:0001810]"
-            ],
-            "ontology": "GENEPIO:0001232",
-            "type": "string",
-            "description": "An environmental location may describe a site in the natural or built environment e.g. hospital, wet market, bat cave.",
-            "examples": [
-                "Hospital [ENVO:00002173]"
-            ],
-            "classification": "Sample collection and processing",
-            "label": "Environmental System",
-            "fill_mode": "batch"
-        },
-        "collection_device": {
-            "Enums": [
-                "Air filter [ENVO:00003968]",
-                "Blood Collection Tube [OBI:0002859]",
-                "Bronchoscope [OBI:0002826]",
-                "Collection Container [OBI:0002088]",
-                "Collection Cup [GENEPIO:0100026]",
-                "Fibrobronchoscope Brush [OBI:0002825]",
-                "Filter [GENEPIO:0100103]",
-                "Fine Needle [OBI:0002827]",
-                "Microcapillary tube [OBI:0002858]",
-                "Micropipette [OBI:0001128]",
-                "Needle [OBI:0000436]",
-                "Serum Collection Tube [OBI:0002860]",
-                "Sputum Collection Tube [OBI:0002861]",
-                "Suction Catheter [OBI:0002831]",
-                "Swab [GENEPIO:0100027]",
-                "Urine Collection Tube [OBI:0002862]",
-                "Virus Transport Medium [OBI:0002866]",
-                "Not Applicable [GENEPIO:0001619]",
-                "Not Collected [GENEPIO:0001620]",
-                "Not Provided [GENEPIO:0001668]",
-                "Missing [GENEPIO:0001618]",
-                "Restricted Access [GENEPIO:0001810]"
-            ],
-            "ontology": "GENEPIO:0001234",
-            "type": "string",
-            "description": "The instrument or container used to collect the sample e.g. swab.",
-            "examples": [
-                "Swab [GENEPIO:0100027]"
-            ],
-            "classification": "Sample collection and processing",
-            "label": "Collection Device",
-            "fill_mode": "batch"
-        },
-        "tax_id": {
-            "examples": [
-                "probably 2697049 in all cases"
-            ],
-            "ontology": "GENEPIO_0001724",
-            "type": "string",
-            "description": "The NCBITaxon identifier for the organism being sequenced.",
-            "classification": "Sample collection and processing",
-            "label": "Tax ID",
-            "fill_mode": "batch"
-        },
-        "center_name": {
-            "examples": [
-                " KAROLINSKA INSITUTET"
-            ],
-            "ontology": "NCIT_C19983",
-            "type": "string",
-            "description": "The name of the institution",
-            "classification": "Sample collection and processing",
-            "label": "Center Name",
-            "fill_mode": "batch"
-        },
-        "host_common_name": {
-            "Enums": [
-                "Human [NCBITaxon:9606]",
-                "Bat [NCBITaxon:9397]",
-                "Cat [NCBITaxon:9685]",
-                "Chicken [NCBITaxon:9031]",
-                "Civet [NCBITaxon:9673]",
-                "Cow [NCBITaxon:9913]",
-                "Dog [NCBITaxon:9615]",
-                "Lion [NCBITaxon:9689]",
-                "Mink [NCBITaxon:452646]",
-                "Pangolin [NCBITaxon:9973]",
-                "Pig [NCBITaxon:9825]",
-                "Pigeon [NCBITaxon:8930]",
-                "Tiger [NCBITaxon:9694]",
-                "Not Applicable [GENEPIO:0001619]",
-                "Not Collected [GENEPIO:0001620]",
-                "Not Provided [GENEPIO:0001668]",
-                "Missing [GENEPIO:0001618]",
-                "Restricted Access [GENEPIO:0001810]"
-            ],
-            "ontology": "GENEPIO:0001386",
-            "type": "string",
-            "description": "The commonly used name of the host.",
-            "examples": [
-                "Human [NCBITaxon:9606]"
-            ],
-            "classification": "Host information",
-            "label": "Host",
-            "fill_mode": "batch"
-        },
         "purpose_of_sequencing": {
             "Enums": [
                 "Baseline surveillance (random sampling) [GENEPIO:0100005]",
@@ -968,40 +932,6 @@
             "label": "Purpose of Sequencing",
             "fill_mode": "batch"
         },
-        "purpose_sampling": {
-            "Enums": [
-                "Cluster/Outbreak Investigation [GENEPIO:0100001]",
-                "Diagnostic Testing [GENEPIO:0100002]",
-                "Research [GENEPIO:0100003]",
-                "Protocol Testing [GENEPIO:0100024]",
-                "Surveillance [GENEPIO:0100004]",
-                "Not Applicable [GENEPIO:0001619]",
-                "Not Collected [GENEPIO:0001620]",
-                "Not Provided [GENEPIO:0001668]",
-                "Missing [GENEPIO:0001618]",
-                "Restricted Access [GENEPIO:0001810]"
-            ],
-            "ontology": "NCIT_C146997",
-            "type": "string",
-            "description": "The reason that the sample was collected.",
-            "examples": [
-                "Diagnostic Testing [GENEPIO:0100002]"
-            ],
-            "classification": "Sample collection and processing",
-            "label": "Purpose of sampling",
-            "fill_mode": "batch"
-        },
-        "sequencing_sample_id": {
-            "examples": [
-                ""
-            ],
-            "ontology": "GENEPIO:0000079",
-            "type": "string",
-            "description": "If the information is unknown or can not be shared, leave blank.",
-            "classification": "Database Identifiers",
-            "label": "Sample ID given for sequencing",
-            "fill_mode": "sample"
-        },
         "sequencing_date": {
             "examples": [
                 "4/26/2021"
@@ -1014,20 +944,30 @@
             "label": "Sequencing Date",
             "fill_mode": "batch"
         },
-        "rna_extraction_protocol": {
+        "extraction_protocol": {
             "examples": [
-                ""
+                "Opentrons custom protocol"
             ],
             "ontology": "OBI_0302884",
             "type": "string",
-            "description": "",
+            "description": "DNA/RNA extraction protocol",
             "classification": "Sequencing",
-            "label": "Rna Extraction Protocol",
+            "label": "Extraction Protocol",
             "fill_mode": "batch"
         },
-        "library_kit": {
+        "all_in_one_library_kit": {
+             "Enums": [
+                "Ion Xpress",
+                "ABL_DeepChek NGS",
+                "Ion AmpliSeq Kit for Chef DL8",
+                "NEBNext® Fast DNA Library Prep Set for Ion Torrent™",
+                "NEBNext® ARTIC SARS-CoV-2 FS",
+                "Illumina COVIDSeq Test",
+                "ABL DeepChek® Assay WG SC2 V1",
+                "Other"
+            ],
             "examples": [
-                ""
+                "Illumina COVIDSeq Test"
             ],
             "ontology": "GENEPIO_0000085",
             "type": "string",
@@ -1036,9 +976,46 @@
             "label": "Commercial All-in-one library kit",
             "fill_mode": "batch"
         },
+        "library_preparation_kit": {
+            "Enums": [
+                "Illumina DNA PCR-Free Prep",
+                "Illumina DNA Prep",
+                "Illumina Stranded mRNA Prep",
+                "Nextera XT DNA Library Preparation Kit",
+                "TruSeq DNA Nano",
+                "TruSeq DNA Nano Library Prep Kit for NeoPrep",
+                "TruSeq DNA PCR-Free",
+                "TruSeq RNA Library Prep Kit v2",
+                "TruSeq Stranded Total RNA",
+                "TruSeq Stranded mRNA",
+                "Nextera XT",
+                "NEBNex Fast DNA Library Prep Set for Ion Torrent",
+                "Nextera DNA Flex",
+                "Ion AmpliSeq Kit Library Kit Plus",
+                "Ion AmpliSeq Kit Library Kit Plus",
+                "Ion AmpliSeq Library Kit 2.0",
+                "Ion Xpress Plus Fragment Library Kit",
+                "Oxford Nanopore Sequencing Kit",
+                "SQK-RBK110-96",
+                "Nanopore COVID Maxi: 9216 samples",
+                "Nanopore COVID Midi: 2304 samples",
+                "Nanopore COVID Mini: 576 samples",
+                "Vela Diagnostics:ViroKey SQ FLEX Library Prep Reagents",
+                "Other",
+            ]
+            "examples": [
+                "Illumina DNA Prep Tagmentation"
+            ],
+            "ontology": "GENEPIO:0001450",
+            "type": "string",
+            "description": "The name of the DNA library preparation kit used to generate the library being sequenced.",
+            "classification": "Sequencing",
+            "label": "Library Preparation Kit",
+            "fill_mode": "batch"
+        },
         "enrichment_protocol": {
             "examples": [
-                ""
+                "AMPLICON"
             ],
             "ontology": "EFO_0009089",
             "type": "string",
@@ -1058,37 +1035,37 @@
             "label": "If Enrichment Protocol Is Other, Specify",
             "fill_mode": "batch"
         },
-        "amplicon_protocol": {
+        "enrichment_panel": {
             "examples": [
-                ""
+                "ARTIC"
             ],
-            "ontology": "EFO_0003747",
+            "ontology": "0",
             "type": "string",
             "description": "",
             "classification": "Sequencing",
             "label": "Enrichment panel/assay",
             "fill_mode": "batch"
         },
-        "if_amplicon_protocol_if_other_specify": {
+        "enrichment_panel_version": {
             "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "",
-            "classification": "Sequencing",
-            "label": "If Enrichment panel/assay Is Other, Specify",
-            "fill_mode": "batch"
-        },
-        "amplicon_version": {
-            "examples": [
-                ""
+                "ARTIC v4"
             ],
             "ontology": "0",
             "type": "string",
             "description": "",
             "classification": "Sequencing",
             "label": "Enrichment panel/assay version",
+            "fill_mode": "batch"
+        },
+         "amplicon_pcr_primer_scheme": {
+            "examples": [
+                "https://github.com/joshquick/artic-ncov2019/blob/master/primer_schemes/nCoV-2019/V3/nCoV-2019.tsv"
+            ],
+            "ontology": "GENEPIO:0001456",
+            "type": "string",
+            "description": "The specifications of the primers (primer sequences, binding positions, fragment size generated etc) used to generate the amplicons to be sequenced.",
+            "classification": "Sequencing",
+            "label": "Amplicon Pcr Primer Scheme",
             "fill_mode": "batch"
         },
         "number_of_samples_in_run": {
@@ -1133,28 +1110,6 @@
             "description": "",
             "classification": "Sequencing",
             "label": "Sequencing Instrument Platform",
-            "fill_mode": "batch"
-        },
-        "library_preparation_kit": {
-            "examples": [
-                "Nextera XT"
-            ],
-            "ontology": "GENEPIO:0001450",
-            "type": "string",
-            "description": "The name of the DNA library preparation kit used to generate the library being sequenced.",
-            "classification": "Sequencing",
-            "label": "Library Preparation Kit",
-            "fill_mode": "batch"
-        },
-        "amplicon_pcr_primer_scheme": {
-            "examples": [
-                "https://github.com/joshquick/artic-ncov2019/blob/master/primer_schemes/nCoV-2019/V3/nCoV-2019.tsv"
-            ],
-            "ontology": "GENEPIO:0001456",
-            "type": "string",
-            "description": "The specifications of the primers (primer sequences, binding positions, fragment size generated etc) used to generate the amplicons to be sequenced.",
-            "classification": "Sequencing",
-            "label": "Amplicon Pcr Primer Scheme",
             "fill_mode": "batch"
         },
         "library_selection": {
@@ -2537,6 +2492,39 @@
             "classification": "Database Identifiers",
             "label": "Type",
             "fill_mode": "batch"
-        }
+        },
+        "biosample_accession_ENA": {
+            "examples": [
+                "SAMN14180202"
+            ],
+            "ontology": "GENEPIO:0001139",
+            "type": "string",
+            "description": "The identifier assigned to a BioSample in INSDC archives.",
+            "classification": "Database Identifiers",
+            "label": "ENA Sample ID",
+            "fill_mode": "sample"
+        },
+        "virus_name": {
+            "examples": [
+                "hCoV-19/Canada/prov_rona_99/2020"
+            ],
+            "ontology": "GENEPIO:0100282",
+            "type": "string",
+            "description": "The user-defined GISAID virus name assigned to the sequence.",
+            "classification": "Database Identifiers",
+            "label": "GISAID Virus Name",
+            "fill_mode": "sample"
+        },
+               "center_name": {
+            "examples": [
+                " KAROLINSKA INSITUTET"
+            ],
+            "ontology": "NCIT_C19983",
+            "type": "string",
+            "description": "The name of the institution",
+            "classification": "Sample collection and processing",
+            "label": "Center Name",
+            "fill_mode": "batch"
+        },
     }
 }

--- a/relecov_tools/schema/relecov_schema.json
+++ b/relecov_tools/schema/relecov_schema.json
@@ -38,6 +38,39 @@
             "label": "Originating Laboratory",
             "fill_mode": "sample"
         },
+         "collecting_institution_email": {
+            "examples": [
+                "johnnyblogs@lab.ca"
+            ],
+            "ontology": "OBI:0001890",
+            "type": "string",
+            "description": "The email address of the contact responsible for follow-up regarding the sample.",
+            "classification": "Sample collection and processing",
+            "label": "Originating Laboratory Email",
+            "fill_mode": "batch"
+        },
+        "collecting_institution_address": {
+            "examples": [
+                "655 Lab St, Vancouver, British Columbia, V5N 2A2, Canada"
+            ],
+            "ontology": "GENEPIO:0001158",
+            "type": "string",
+            "description": "The mailing address of the agency submitting the sample.",
+            "classification": "Sample collection and processing",
+            "label": "Originating Laboratory Address",
+            "fill_mode": "batch"
+        },
+         "submitting_lab_sample_id": {
+            "examples": [
+                ""
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "Sample ID given by the submitting laboratory",
+            "classification": "Sequencing",
+            "label": "Sample ID given by the submitting laboratory",
+            "fill_mode": "sample"
+        },
         "submitting_institution": {
             "examples": [
                 "Centers for Disease Control and Prevention"
@@ -48,6 +81,28 @@
             "classification": "Sample collection and processing",
             "label": "Submitting Institution",
             "fill_mode": "sample"
+        },
+        "submitting_institution_email": {
+            "examples": [
+                "RespLab@lab.ca"
+            ],
+            "ontology": "GENEPIO:0001165",
+            "type": "string",
+            "description": "The email address of the contact responsible for follow-up regarding the sequence.",
+            "classification": "Sample collection and processing",
+            "label": "Submitting Institution Email",
+            "fill_mode": "batch"
+        },
+        "submitting_institution_address": {
+            "examples": [
+                "123 Sunnybrooke St, Toronto, Ontario, M4P 1L6, Canada"
+            ],
+            "ontology": "GENEPIO:0001167",
+            "type": "string",
+            "description": "The mailing address of the agency submitting the sequence.",
+            "classification": "Sample collection and processing",
+            "label": "Submitting Institution Address",
+            "fill_mode": "batch"
         },
         "sample_collection_date": {
             "examples": [
@@ -60,6 +115,29 @@
             "classification": "Sample collection and processing",
             "label": "Sample Collection Date",
             "fill_mode": "sample"
+        },
+          "sample_received_date": {
+            "examples": [
+                "3/21/2020"
+            ],
+            "ontology": "GENEPIO:0001179",
+            "type": "string",
+            "description": "The date on which the sample was received.",
+            "format": "date",
+            "classification": "Sample collection and processing",
+            "label": "Sample Received Date",
+            "fill_mode": "sample"
+        },
+        "sample_storage_conditions": {
+            "examples": [
+                "24 degrees celsius"
+            ],
+            "ontology": "NCIT_C115535",
+            "type": "string",
+            "description": "The name and version of a particular protocol used for sampling.",
+            "classification": "Sample collection and processing",
+            "label": "Biological Sample Storage Condition",
+            "fill_mode": "batch"
         },
         "geo_loc_country": {
             "Enums": [
@@ -387,12 +465,9 @@
             ],
             "ontology": "GENEPIO:0001398",
             "type": "string",
-            "description": "a unique identifier by which each subject can be referred to, de-identified.",
-            "clasification": "Host information",
+            "description": "An unique identifier by which each subject can be referred to, de-identified.",
+            "classification": "Host information",
             "label": "Host Subject Id",
-            "table": [
-                "sample"
-            ]
         },
         "host_health_state": {
             "examples": [
@@ -401,11 +476,8 @@
             "ontology": "GENEPIO:0001388",
             "type": "string",
             "description": " Status of the host",
-            "clasification": "Host information",
+            "classification": "Host health state information",
             "label": "Host health state",
-            "table": [
-                "sample"
-            ]
         },
         "host_scientific_name": {
             "Enums": [
@@ -459,6 +531,41 @@
             "classification": "Host information",
             "label": "Host disease",
             "fill_mode": "batch"
+        },
+        "host_age": {
+            "ontology": "GENEPIO:0001392",
+            "type": "string",
+            "description": "Age of host at the time of sampling.",
+            "examples": [
+                "79"
+            ],
+            "classification": "Host information",
+            "label": "Host Age",
+            "fill_mode": "sample"
+        },
+        "host_gender": {
+            "Enums": [
+                "Female [NCIT:C46110]",
+                "Male [NCIT:C46109]",
+                "Non-binary Gender [GSSO:000132]",
+                "Transgender (assigned male at birth) [GSSO:004004]",
+                "Transgender (assigned female at birth) [GSSO:004005]",
+                "Undeclared [NCIT:C110959]",
+                "Not Applicable [GENEPIO:0001619]",
+                "Not Collected [GENEPIO:0001620]",
+                "Not Provided [GENEPIO:0001668]",
+                "Missing [GENEPIO:0001618]",
+                "Restricted Access [GENEPIO:0001810]"
+            ],
+            "ontology": "GENEPIO:0001395",
+            "type": "string",
+            "description": "The gender of the host at the time of sample collection.",
+            "examples": [
+                "Male [NCIT:C46109]"
+            ],
+            "classification": "Host information",
+            "label": "Host Gender",
+            "fill_mode": "sample"
         },
         "sequencing_instrument_model": {
             "Enums": [
@@ -524,17 +631,7 @@
             "label": "Sequencing Instrument Model",
             "fill_mode": "batch"
         },
-        "submitting_lab_sample_id": {
-            "examples": [
-                ""
-            ],
-            "ontology": "0",
-            "type": "string",
-            "description": "Sample ID given by the submitting laboratory",
-            "classification": "Sequencing",
-            "label": "Sample ID given by the submitting laboratory",
-            "fill_mode": "sample"
-        },
+       
         "biosample_accession_ENA": {
             "examples": [
                 "SAMN14180202"
@@ -557,108 +654,7 @@
             "label": "GISAID Virus Name",
             "fill_mode": "sample"
         },
-        "collecting_institution_email": {
-            "examples": [
-                "johnnyblogs@lab.ca"
-            ],
-            "ontology": "OBI:0001890",
-            "type": "string",
-            "description": "The email address of the contact responsible for follow-up regarding the sample.",
-            "classification": "Sample collection and processing",
-            "label": "Originating Laboratory Email",
-            "fill_mode": "batch"
-        },
-        "collecting_institution_address": {
-            "examples": [
-                "655 Lab St, Vancouver, British Columbia, V5N 2A2, Canada"
-            ],
-            "ontology": "GENEPIO:0001158",
-            "type": "string",
-            "description": "The mailing address of the agency submitting the sample.",
-            "classification": "Sample collection and processing",
-            "label": "Originating Laboratory Address",
-            "fill_mode": "batch"
-        },
-        "submitting_institution_email": {
-            "examples": [
-                "RespLab@lab.ca"
-            ],
-            "ontology": "GENEPIO:0001165",
-            "type": "string",
-            "description": "The email address of the contact responsible for follow-up regarding the sequence.",
-            "classification": "Sample collection and processing",
-            "label": "Submitting Institution Email",
-            "fill_mode": "batch"
-        },
-        "submitting_institution_address": {
-            "examples": [
-                "123 Sunnybrooke St, Toronto, Ontario, M4P 1L6, Canada"
-            ],
-            "ontology": "GENEPIO:0001167",
-            "type": "string",
-            "description": "The mailing address of the agency submitting the sequence.",
-            "classification": "Sample collection and processing",
-            "label": "Submitting Institution Address",
-            "fill_mode": "batch"
-        },
-        "sample_received_date": {
-            "examples": [
-                "3/21/2020"
-            ],
-            "ontology": "GENEPIO:0001179",
-            "type": "string",
-            "description": "The date on which the sample was received.",
-            "format": "date",
-            "classification": "Sample collection and processing",
-            "label": "Sample Received Date",
-            "fill_mode": "sample"
-        },
-        "sample_storage_conditions": {
-            "examples": [
-                "24 degrees celsius"
-            ],
-            "ontology": "NCIT_C115535",
-            "type": "string",
-            "description": "The name and version of a particular protocol used for sampling.",
-            "classification": "Sample collection and processing",
-            "label": "Biological Sample Storage Condition",
-            "fill_mode": "batch"
-        },
-        "host_age": {
-            "ontology": "GENEPIO:0001392",
-            "type": "string",
-            "description": "Age of host at the time of sampling.",
-            "examples": [
-                "79"
-            ],
-            "classification": "Host information",
-            "label": "Host Age",
-            "fill_mode": "sample"
-        },
-        "host_gender": {
-            "Enums": [
-                "Female [NCIT:C46110]",
-                "Male [NCIT:C46109]",
-                "Non-binary Gender [GSSO:000132]",
-                "Transgender (assigned male at birth) [GSSO:004004]",
-                "Transgender (assigned female at birth) [GSSO:004005]",
-                "Undeclared [NCIT:C110959]",
-                "Not Applicable [GENEPIO:0001619]",
-                "Not Collected [GENEPIO:0001620]",
-                "Not Provided [GENEPIO:0001668]",
-                "Missing [GENEPIO:0001618]",
-                "Restricted Access [GENEPIO:0001810]"
-            ],
-            "ontology": "GENEPIO:0001395",
-            "type": "string",
-            "description": "The gender of the host at the time of sample collection.",
-            "examples": [
-                "Male [NCIT:C46109]"
-            ],
-            "classification": "Host information",
-            "label": "Host Gender",
-            "fill_mode": "sample"
-        },
+       
         "microbiology_lab_sample_id": {
             "examples": [
                 ""

--- a/relecov_tools/schema/relecov_schema.json
+++ b/relecov_tools/schema/relecov_schema.json
@@ -22,7 +22,7 @@
             ],
             "ontology": "GENEPIO:0001123",
             "type": "string",
-            "description": "The user-defined name for the sample.",
+            "description": "The name given for the sample by the collecting institution.",
             "classification": "Database Identifiers",
             "label": "Sample ID given by originating laboratory",
             "fill_mode": "sample"
@@ -33,7 +33,7 @@
             ],
             "ontology": "GENEPIO:0001153",
             "type": "string",
-            "description": "The name of the agency that collected the original sample.",
+            "description": "The name of the agency/institution that collected the sample.",
             "classification": "Sample collection and processing",
             "label": "Originating Laboratory",
             "fill_mode": "sample"
@@ -44,7 +44,7 @@
             ],
             "ontology": "GENEPIO:0001159",
             "type": "string",
-            "description": "The name of the agency that generated the sequence.",
+            "description": "The name of the agency that submitted the sequence to public databases.",
             "classification": "Sample collection and processing",
             "label": "Submitting Institution",
             "fill_mode": "sample"


### PR DESCRIPTION
- Schema has being ordered by classification
- Enums were left in a bunch of properties, they have being filled with enums in metadata_lab_v3.0.xlsx form
- Duplicated properties have been deleted
- Public databases classification has been added and only identifiers are left for ENA and gisaid in the schema.
- Minor fixes: added examples, fixed typos and added descriptions.

*FIXES TODO*
- Anatomical_material, environment_system and environment_material properties don't have same enums in metadata_lab excel and the json schema. I think they are correct in the excel, but I remember we simplified anatomical material in the excel but it was divided in two fields according to the ontology we used. @ErikaKvalem can we check this?
- 