### PR TITLE
Fixed bug in schema name and remove option to get other schema for feed database

### DIFF
--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -320,7 +320,6 @@ def launch(user):
 # update_db
 @relecov_tools_cli.command(help_priority=9)
 @click.option("-j", "--json", help="data in json format")
-@click.option("-s", "--schema", help="json schema if relecov is not used")
 @click.option(
     "-t",
     "--type",
@@ -342,10 +341,10 @@ def launch(user):
 )
 @click.option("-u", "--user", help="user name for login")
 @click.option("-p", "--password", help="password for the user to login")
-def update_db(user, password, json, schema, type, databaseServer):
+def update_db(user, password, json, type, databaseServer):
     """feed database with json"""
     feed_database = relecov_tools.feed_database.FeedDatabase(
-        user, password, json, schema, type, databaseServer
+        user, password, json, type, databaseServer
     )
     feed_database.store_data()
 

--- a/relecov_tools/feed_database.py
+++ b/relecov_tools/feed_database.py
@@ -112,12 +112,6 @@ class FeedDatabase:
         """Map the values to the properties send to databasee
         in json schema based on label
         """
-        anatomical_fields = [
-            "anatomical_part",
-            "collection_method",
-            "body_product",
-            "anatomical_material",
-        ]
         # collection_method = self.get_sample_type()
         sample_list = []
         s_fields = list(sample_fields.keys())
@@ -126,23 +120,22 @@ class FeedDatabase:
             for key, value in row.items():
                 found_ontology = re.search(r"(.+) \[\w+:.*", value)
                 if found_ontology:
+                    # remove the ontology data from item value
                     value = found_ontology.group(1)
                 if key in s_project_fields:
                     s_dict[key] = value
                 elif key in s_fields:
                     s_dict[sample_fields[key]] = value
                 else:
+                    # just for debug loginng write the fields that will not
+                    # be inlcuded in iSkyLIMS request
                     log.info("not key %s in iSkyLIMS", key)
             # include the fix value
             fixed_value = self.config_json.get_configuration("iskylims_fixed_values")
             for prop, val in fixed_value.items():
                 s_dict[prop] = val
-            # Using tha anatomical field find out the sampleType
-            sample_type = []
-            for item in anatomical_fields:
-                if s_dict[item] != "Not Applicable":
-                    sample_type.append(s_dict[item])
-            s_dict["sampleType"] = " ".join(sample_type)
+            # Adding tha specimen_source field for setting sampleType
+            s_dict["sampleType"] = row["specimen_source"]
             sample_list.append(s_dict)
         return sample_list
 

--- a/relecov_tools/feed_database.py
+++ b/relecov_tools/feed_database.py
@@ -2,18 +2,14 @@
 import sys
 import os
 import re
-import jsonschema
 import json
 import logging
 import rich.console
-from jsonschema import Draft202012Validator
 import time
 
 import relecov_tools.utils
 from relecov_tools.config_json import ConfigJson
 from relecov_tools.rest_api import RestApi
-
-# import relecov_tools.json_schema
 
 log = logging.getLogger(__name__)
 stderr = rich.console.Console(
@@ -30,7 +26,6 @@ class FeedDatabase:
         user=None,
         passwd=None,
         json_file=None,
-        schema=None,
         type_of_info=None,
         database_server=None,
     ):
@@ -44,7 +39,6 @@ class FeedDatabase:
         self.passwd = passwd
         self.config_json = ConfigJson()
         if json_file is None:
-            self.config_json = ConfigJson()
             json_file = relecov_tools.utils.prompt_path(
                 msg="Select the json file which have the data to map"
             )
@@ -54,25 +48,14 @@ class FeedDatabase:
             sys.exit(1)
         self.json_data = relecov_tools.utils.read_json_file(json_file)
         self.json_file = json_file
-        if schema is None:
-            schema = os.path.join(
-                os.path.dirname(os.path.realpath(__file__)),
-                "schema",
-                self.config_json.get_topic_data("json_schemas", "relecov_schema"),
-            )
-        else:
-            if os.path.isfile(schema):
-                log.error("Relecov schema file %s does not exists", schema)
-                stderr.print(f"[red] Relecov schema  {schema} does not exists")
-                sys.exit(1)
-        rel_schema_json = relecov_tools.utils.read_json_file(schema)
-        try:
-            Draft202012Validator.check_schema(rel_schema_json)
-        except jsonschema.ValidationError:
-            log.error("Schema does not fulfil Draft 202012 Validation ")
-            stderr.print("[red] Schema does not fulfil Draft 202012 Validation")
-            sys.exit(1)
-        self.schema = rel_schema_json
+        schema = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "schema",
+            self.config_json.get_topic_data("json_schemas", "relecov_schema"),
+        )
+
+        self.schema = relecov_tools.utils.read_json_file(schema)
+
         if type_of_info is None:
             type_of_info = relecov_tools.utils.prompt_selection(
                 "Select:",

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -82,7 +82,7 @@ class RelecovMetadata:
         self.json_req_files = config_json.get_topic_data(
             "lab_metadata", "lab_metadata_req_json"
         )
-        self.schema_name = self.relecov_sch_json["schema"]
+        self.schema_name = self.relecov_sch_json["title"]
         self.schema_version = self.relecov_sch_json["version"]
 
     def adding_fixed_fields(self, m_data):

--- a/relecov_tools/schema/relecov_schema.json
+++ b/relecov_tools/schema/relecov_schema.json
@@ -799,11 +799,11 @@
             ],
             "ontology": "0",
             "type": "string",
-            "description": "",
+            "description": "Source of the specimen, merge of anatomical_part, anatomical_material, body_product and collection method.",
             "examples": [
                 ""
             ],
-            "classification": "Source of the specimen, merge of anatomical_part, anatomical_material, body_product and collection method.",
+            "classification": "Sample collection and processing",
             "label": "Specimen source",
             "fill_mode": "batch"
         },


### PR DESCRIPTION
- Change in read_metadata_lab the field where the schema name is collected 
- Remove the option that the schema could be different that the one in the tools
- specimen_source, moved the classification text to description and set in classification Sample collection and processing