### PR TITLE
Changed sftp_handle to download everything in the output location.

### DIFF
--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -145,7 +145,7 @@ def relecov_tools_cli(verbose, log_file):
     "-o",
     "--output_location",
     default=None,
-    help="Flag: Select location for downloaded files",
+    help="Flag: Select location for downloaded files, overrides config file location",
 )
 @click.option(
     "-t",

--- a/relecov_tools/conf/configuration.json
+++ b/relecov_tools/conf/configuration.json
@@ -31,7 +31,6 @@
             "Host Age",
             "Host Gender",
             "Sequencing Date",
-            "Purpose of Sequencing",
             "Nucleic acid extraction protocol",
             "Commercial All-in-one library kit",
             "Library Preparation Kit",
@@ -48,12 +47,10 @@
             "Capture method",
             "Sequencing technique",
             "Library Layout",
-            "Read Length",
             "Gene Name 1",
             "Diagnostic Pcr Ct Value 1",
             "Gene Name 2",
             "Diagnostic Pcr Ct Value-2",
-            "Broker Name",
             "Authors",
             "Sequence file R1 fastq",
             "Sequence file R2 fastq"
@@ -176,8 +173,7 @@
             "sftp_port": "22"
         },
         "abort_if_md5_mismatch": "False",
-        "storage_local_folder": "/tmp/relecov",
-        "tmp_folder_for_metadata": "/tmp/relecov/tmp",
+        "platform_storage_folder": "tmp/relecov",
         "allowed_sample_extensions": [
             "fastq.gz",
             "fasta"

--- a/relecov_tools/conf/configuration.json
+++ b/relecov_tools/conf/configuration.json
@@ -129,6 +129,27 @@
         "CALLER",
         "LINEAGE"
     ],
+    "long_table_parse_aux": {
+        "Chromosome": "CHROM",
+        "Variant": {
+            "pos": "POS", 
+            "alt": "ALT", 
+            "ref": "REF"
+        },
+        "Filter": "FILTER",
+        "VariantInSample": {
+            "dp": "DP",
+            "ref_dp": "REF_DP",
+            "alt_dp": "ALT_DP",
+            "af": "AF"
+        },
+        "Effect": "EFFECT",
+        "VariantAnnotation": {
+            "hgvs_c": "HGVS_C",
+            "hgvs_p": "HGVS_P",
+            "hgvs_p_1_letter": "HGVS_P_1LETTER"
+        }
+    },
     "gisaid_csv_headers": [
         "submitter",
         "covv_virus_name",

--- a/relecov_tools/long_table_parse.py
+++ b/relecov_tools/long_table_parse.py
@@ -93,23 +93,8 @@ class LongTableParse:
         for heading in self.long_table_heading:
             heading_index[heading] = headings_from_csv.index(heading)
 
-        aux_dict = {
-            "Chromosome": "CHROM",
-            "Variant": {"pos": "POS", "alt": "ALT", "ref": "REF"},
-            "Filter": "FILTER",
-            "VariantInSample": {
-                "dp": "DP",
-                "ref_dp": "REF_DP",
-                "alt_dp": "ALT_DP",
-                "af": "AF",
-            },
-            "Effect": "EFFECT",
-            "VariantAnnotation": {
-                "hgvs_c": "HGVS_C",
-                "hgvs_p": "HGVS_P",
-                "hgvs_p_1_letter": "HGVS_P_1LETTER",
-            },
-        }
+        config = ConfigJson()
+        aux_dict = config.get_configuration("long_table_parse_aux")
 
         samp_dict = {}
         for line in lines[1:]:

--- a/relecov_tools/long_table_parse.py
+++ b/relecov_tools/long_table_parse.py
@@ -44,14 +44,14 @@ class LongTableParse:
         if not os.path.exists(self.file_path):
             log.error("Variant long table file %s does not exist ", self.file_path)
             stderr.print(
-                f"[red] Variant long table file {self.file_path}  does not exist"
+                f"[red] Variant long table file {self.file_path} does not exist"
             )
             sys.exit(1)
 
         if not self.file_path.endswith(".csv"):
             log.error("Variant long table file %s is not a csv file ", self.file_path)
             stderr.print(
-                f"[red] Variant long table file  {self.file_path}  must be a csv file"
+                f"[red] Variant long table file {self.file_path} must be a csv file"
             )
             sys.exit(1)
 
@@ -153,9 +153,9 @@ class LongTableParse:
         if result_regex is None:
             log.error("Analysis date not found in filename, aborting")
             stderr.print(
-                f"[red]Error: filename must include analysis date in format YYYYMMDD"
+                "[red]Error: filename must include analysis date in format YYYYMMDD"
             )
-            stderr.print(f"[red]e.g. variants_long_table_20220830.csv")
+            stderr.print("[red]e.g. variants_long_table_20220830.csv")
             sys.exit(1)
         for key, values in samp_dict.items():
             j_dict = {"sample_name": key, "analysis_date": result_regex.group(1)}

--- a/relecov_tools/sftp_handle.py
+++ b/relecov_tools/sftp_handle.py
@@ -48,8 +48,8 @@ class SftpHandle:
         if conf_file is None:
             self.sftp_server = config_json.get_topic_data("sftp_handle", "sftp_server")
             self.sftp_port = config_json.get_topic_data("sftp_handle", "sftp_port")
-            self.storage_local_folder = config_json.get_topic_data(
-                "sftp_handle", "storage_local_folder"
+            self.platform_storage_folder = config_json.get_topic_data(
+                "sftp_handle", "platform_storage_folder"
             )
             self.abort_if_md5_mismatch = (
                 True
@@ -71,10 +71,10 @@ class SftpHandle:
                 self.sftp_port = config["sftp_port"]
                 self.target_folders = config["target_folders"]
                 try:
-                    self.storage_local_folder = config["storage_local_folder"]
+                    self.platform_storage_folder = config["platform_storage_folder"]
                 except KeyError:
-                    self.storage_local_folder = config_json.get_topic_data(
-                        "sftp_handle", "storage_local_folder"
+                    self.platform_storage_folder = config_json.get_topic_data(
+                        "sftp_handle", "platform_storage_folder"
                     )
                 try:
                     self.abort_if_md5_mismatch = (
@@ -97,7 +97,7 @@ class SftpHandle:
                 stderr.print("[red] Invalid configuration file {e} !")
                 sys.exit(1)
         if output_location is not None:
-            self.storage_local_folder = output_location
+            self.platform_storage_folder = output_location
         if self.sftp_user is None:
             self.sftp_user = relecov_tools.utils.prompt_text(msg="Enter the user id")
         if self.sftp_passwd is None:
@@ -182,7 +182,7 @@ class SftpHandle:
         log.info("Creating folder %s to download files", folder)
         result_data = {"unable_to_fetch": [], "fetched_files": []}
         date = datetime.today().strftime("%Y%m%d")
-        local_folder_path = os.path.join(self.storage_local_folder, folder, date)
+        local_folder_path = os.path.join(self.platform_storage_folder, folder, date)
         result_data["local_folder"] = local_folder_path
         os.makedirs(local_folder_path, exist_ok=True)
         log.info("created the folder to download files %s", local_folder_path)
@@ -260,7 +260,7 @@ class SftpHandle:
         """Copy metadata file from folder and create a file with the sample
         names
         """
-        out_folder = self.storage_local_folder
+        out_folder = self.platform_storage_folder
         os.makedirs(out_folder, exist_ok=True)
         prefix_file_name = "_".join(local_folder.split("/")[-2:])
         new_metadata_file = "metadata_lab_" + prefix_file_name + ".xlsx"
@@ -305,7 +305,7 @@ class SftpHandle:
     def create_main_folders(self, root_directory_list):
         """Create the main folder structure if not exists"""
         for folder in root_directory_list:
-            full_folder = os.path.join(self.storage_local_folder, folder)
+            full_folder = os.path.join(self.platform_storage_folder, folder)
             os.makedirs(full_folder, exist_ok=True)
         log.info("Created main folder for process %s", full_folder)
         return True
@@ -413,9 +413,10 @@ class SftpHandle:
             stderr.print("[red] Too many metadata files on " + fetched_folder)
             return False
         target_meta_file = os.path.join(fetched_folder, meta_files[0])
-        out_folder = self.storage_local_folder
-        os.makedirs(out_folder, exist_ok=True)
-        local_meta_file = os.path.join(out_folder, os.path.basename(target_meta_file))
+        os.makedirs(self.platform_storage_folder, exist_ok=True)
+        local_meta_file = os.path.join(
+            self.platform_storage_folder, os.path.basename(target_meta_file)
+        )
         try:
             self.client.get(
                 target_meta_file,
@@ -434,7 +435,7 @@ class SftpHandle:
     def validate_fetched_files(self, fetched_folder):
         """Check if the files in the fetched folder are the ones defined in metadata file"""
         local_meta_file = self.validate_metadata_file(fetched_folder)
-        out_folder = self.storage_local_folder
+        out_folder = self.platform_storage_folder
         if not local_meta_file:
             log.error("Excel file for metadata not found in %s", fetched_folder)
             stderr.print(
@@ -503,11 +504,11 @@ class SftpHandle:
 
     def download(self):
         try:
-            os.makedirs(self.storage_local_folder, exist_ok=True)
+            os.makedirs(self.platform_storage_folder, exist_ok=True)
         except OSError as e:
             log.error("You do not have permissions to create folder %s", e)
             sys.exit(1)
-        os.chdir(self.storage_local_folder)
+        os.chdir(self.platform_storage_folder)
         if not self.open_connection():
             log.error("Unable to establish connection towards sftp server")
             stderr.print("[red] Unable to establish sftp connection")


### PR DESCRIPTION
To fit the goal of the title I did some changes in:
1. [configuration.json](https://github.com/BU-ISCIII/relecov-tools/blob/develop/relecov_tools/conf/configuration.json): changed "storage_local_folder" field name in "stfp_handle" and removed "tmp_metadata_folder" as it has no use now. I also found out some bugs related to wrong column names in "metadata_lab_heading" field so i deleted them too.
2. [sftp_handle.py](https://github.com/BU-ISCIII/relecov-tools/blob/develop/relecov_tools/sftp_handle.py): I deleted "metadata_tmp_folder" as everything is now going to be downloaded and processed in the same location. Also adapted self.storage_local_folder to the new field name in config file. In the process I encountered some bugs related to ad-hoc expected positions in get_sample_fastq_file_names method so I implemented many a few variables to make the code a little more flexible. 

I also reestructured [long_table_parse.py](https://github.com/BU-ISCIII/relecov-tools/blob/develop/relecov_tools/long_table_parse.py)'s parse_file method in order to reduce some lines of code.

Finally, I changed the -help flag info in download's --output_location inside [__main__.py](https://github.com/BU-ISCIII/relecov-tools/blob/develop/relecov_tools/__main__.py) to make it a little bit more informative.