### PR TITLE
Included new functionalities in download process to clean sftp server

### DIFF
--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -142,6 +142,16 @@ def relecov_tools_cli(verbose, log_file):
     help="Configuration file (not params file)",
 )
 @click.option(
+    "-d",
+    "--download_option",
+    default=None,
+    multiple=False,
+    help="Select the download option: [download_only, download_clean, delete_only]. \
+        download_only will only download the files \
+        download_clean will remove files from sftp after download \
+        delete_only will only delete the files",
+)
+@click.option(
     "-o",
     "--output_location",
     default=None,
@@ -153,7 +163,7 @@ def relecov_tools_cli(verbose, log_file):
     is_flag=False,
     flag_value="ALL",
     default=None,
-    help="Flag: Select which folders will be downloaded giving [paths] or via prompt",
+    help="Flag: Select which folders will be targeted giving [paths] or via prompt",
 )
 def download(
     user,
@@ -161,8 +171,9 @@ def download(
     conf_file,
     user_relecov,
     password_relecov,
+    download_option,
     output_location,
-    target_folders,
+    target_folders
 ):
     """Download files located in sftp server."""
     sftp_connection = relecov_tools.sftp_handle.SftpHandle(
@@ -171,11 +182,11 @@ def download(
         conf_file,
         user_relecov,
         password_relecov,
+        download_option,
         output_location,
-        target_folders,
+        target_folders
     )
-    sftp_connection.download()
-
+    sftp_connection.execute_process()
 
 # metadata
 @relecov_tools_cli.command(help_priority=3)

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -188,6 +188,7 @@ def download(
     )
     sftp_connection.execute_process()
 
+
 # metadata
 @relecov_tools_cli.command(help_priority=3)
 @click.option(

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -173,7 +173,7 @@ def download(
     password_relecov,
     download_option,
     output_location,
-    target_folders
+    target_folders,
 ):
     """Download files located in sftp server."""
     sftp_connection = relecov_tools.sftp_handle.SftpHandle(
@@ -184,7 +184,7 @@ def download(
         password_relecov,
         download_option,
         output_location,
-        target_folders
+        target_folders,
     )
     sftp_connection.execute_process()
 

--- a/relecov_tools/conf/configuration.json
+++ b/relecov_tools/conf/configuration.json
@@ -218,6 +218,11 @@
             "_2_",
             "_2.",
             ".2."
+        ],
+        "allowed_download_options": [
+            "download_only",
+            "download_clean",
+            "delete_only"
         ]
     },
     "GISAID_configuration": {

--- a/relecov_tools/sftp_handle.py
+++ b/relecov_tools/sftp_handle.py
@@ -105,7 +105,7 @@ class SftpHandle:
             except KeyError as e:
                 log.error("Invalid configuration file %s", e)
                 stderr.print(f"[red] Invalid configuration file {e} !")
-                sys.exit(1)     
+                sys.exit(1)
         if output_location is not None:
             if os.path.isdir(output_location):
                 self.platform_storage_folder = output_location
@@ -536,7 +536,7 @@ class SftpHandle:
         for folder in target_folders:
             list_files = self.get_file_list(folder)
             if len(list_files) > 0:
-                folders_to_process[folder] = list_files                  
+                folders_to_process[folder] = list_files
             else:
                 log.info("%s is empty")
                 continue
@@ -546,7 +546,7 @@ class SftpHandle:
             self.close_connection()
             sys.exit(0)
         return folders_to_process
-    
+
     def delete_targets(self, target_folders):
         log.info("Initiating delete_only process")
         folders_to_delete = target_folders
@@ -604,10 +604,10 @@ class SftpHandle:
             )
             for record in json_sample_data:
                 pass
-            if option == "clean": 
+            if option == "clean":
                 self.delete_targets(folder)
         return
-    
+
     def execute_process(self):
         if not self.open_connection():
             log.error("Unable to establish connection towards sftp server")


### PR DESCRIPTION
The objective of this PR is to introduce tools that can be used to clean the remote sftp server.
To accomplish this goal, I introduced a new option "download_option" in [__main__.py](https://github.com/BU-ISCIII/relecov-tools/blob/develop/relecov_tools/__main__.py)'s download function. The three download options are: download_only, download_clean and delete_only. They can be used along with --target_folders to select which folders will be processed.
- download_only will only download the files
- download_clean will remove files from sftp after download 
- delete_only will only delete the files,
As a ways to reduce the number of lines in the code, I introduced these options in [configuration.json](https://github.com/BU-ISCIII/relecov-tools/blob/develop/relecov_tools/conf/configuration.json) in a new field inside sftp_handle.
I included a lot of changes in [sftp_handle.py](https://github.com/BU-ISCIII/relecov-tools/blob/develop/relecov_tools/sftp_handle.py) such as new arguments (download_option), new functions (select_target_folders, select_process, delete_targets) and overall some code reestructuring.
