### PR TITLE
Changed local path for sftp_handle.py and introduced additional debug info

### DIFF
--- a/relecov_tools/conf/geo_loc_cities.json
+++ b/relecov_tools/conf/geo_loc_cities.json
@@ -11,7 +11,7 @@
         "geo_loc_latitude": "37.3900",
         "geo_loc_longitude": "-5.9900"
     },
-    "Málaga": {
+    "Malaga": {
         "geo_loc_latitude": "36.7194",
         "geo_loc_longitude": "-4.4200"
     },
@@ -139,7 +139,7 @@
         "geo_loc_latitude": "41.1187",
         "geo_loc_longitude": "1.2453"
     },
-    "Cádiz": {
+    "Cadiz": {
         "geo_loc_latitude": "36.5350",
         "geo_loc_longitude": "-6.2975"
     },
@@ -214,10 +214,6 @@
     "Soria": {
         "geo_loc_latitude": "41.7667",
         "geo_loc_longitude": "-2.4667"
-    },
-    "Caceres": {
-        "geo_loc_latitude": "39.4752671",
-        "geo_loc_longitude": "-6.3722951"
     },
     "Pontevedra": {
         "geo_loc_latitude": "42.4333",
@@ -295,10 +291,6 @@
         "geo_loc_latitude": "38.2669",
         "geo_loc_longitude": "-0.6983"
     },
-    "Cadiz": {
-        "geo_loc_latitude": "36.52672",
-        "geo_loc_longitude": "-6.2891"
-    },
     "Gasteiz": {
         "geo_loc_latitude": "42.85",
         "geo_loc_longitude": "-2.6667"
@@ -307,10 +299,6 @@
         "geo_loc_latitude": "36.51543",
         "geo_loc_longitude": "-4.88583"
     },
-    "Malaga": {
-        "geo_loc_latitude": "36.72016",
-        "geo_loc_longitude": "-4.42034"
-    },
     "Almeria": {
         "geo_loc_latitude": "36.72016",
         "geo_loc_longitude": "-4.42034"
@@ -318,5 +306,25 @@
     "El Ejido": {
         "geo_loc_latitude": "36.772153",
         "geo_loc_longitude": "-2.810602"
+    },
+    "Antequera": {
+        "geo_loc_latitude": "37.030842",
+        "geo_loc_longitude": "-4.528663"
+    },
+    "Huercal-Overa":{
+        "geo_loc_latitude": "37.395605",
+        "geo_loc_longitude": "-1.942236"
+    },
+    "Ronda":{
+        "geo_loc_latitude": "36.745518",
+        "geo_loc_longitude": "-5.163095"
+    },
+    "Velez-Malaga":{
+        "geo_loc_latitude": "36.778904",
+        "geo_loc_longitude": "-4.100808"
+    },
+    "Motril":{
+        "geo_loc_latitude": "36.74611111",
+        "geo_loc_longitude": "-3.515"
     }
 }

--- a/relecov_tools/conf/laboratory_address.json
+++ b/relecov_tools/conf/laboratory_address.json
@@ -10,6 +10,84 @@
         "submitting_institution_address": "Crta. Pozuelo Majadahonda S/N,",
         "submitting_institution_email": "info@isciii.es"
     },
+    "Hospital de Antequera":{
+        "collecting_institution_address": "Avenida Poeta Muñoz Rojas, s/n",
+        "collecting_institution_email": "joaquin.dopazo@juntadeandalucia.es",
+        "geo_loc_state": "Andalucia",
+        "geo_loc_region": "Malaga",
+        "geo_loc_city": "Antequera",
+        "geo_loc_country": "Spain",
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
+        "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
+    },
+    "Hospital La Inmaculada - Huércal Overa":{
+        "collecting_institution_address": "Av. de la Dra. Ana Parra, s/n",
+        "collecting_institution_email": "joaquin.dopazo@juntadeandalucia.es",
+        "geo_loc_state": "Andalucia",
+        "geo_loc_region": "Almeria",
+        "geo_loc_city": "Huercal-Overa",
+        "geo_loc_country": "Spain",
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
+        "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
+      
+    },
+    "Hospital de la Serranía":{
+        "collecting_institution_address": "Calle San Pedro, Km 2",
+        "collecting_institution_email": "joaquin.dopazo@juntadeandalucia.es",
+        "geo_loc_state": "Andalucia",
+        "geo_loc_region": "Malaga",
+        "geo_loc_city": "Ronda",
+        "geo_loc_country": "Spain",
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
+        "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
+    },
+    "Hospital La Axarquía":{
+        "collecting_institution_address": "Av. del Sol, 43",
+        "collecting_institution_email": "joaquin.dopazo@juntadeandalucia.es",
+        "geo_loc_state": "Andalucia",
+        "geo_loc_region": "Malaga",
+        "geo_loc_city": "Velez-Malaga",
+        "geo_loc_country": "Spain",
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
+        "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
+    },
+    "Hospital Santa Ana":{
+        "collecting_institution_address": "Av. Enrique Martín Cuevas, s/n",
+        "collecting_institution_email": "joaquin.dopazo@juntadeandalucia.es",
+        "geo_loc_state": "Andalucia",
+        "geo_loc_region": "Granada",
+        "geo_loc_city": "Motril",
+        "geo_loc_country": "Spain",
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
+        "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
+    },
+    "Hospital Regional Universitario de Malaga":{
+        "collecting_institution_address": "Av. de Carlos Haya, 84",
+        "collecting_institution_email": "joaquin.dopazo@juntadeandalucia.es",
+        "geo_loc_state": "Andalucia",
+        "geo_loc_region": "Malaga",
+        "geo_loc_city": "Malaga",
+        "geo_loc_country": "Spain",
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
+        "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
+    },
+    "Hospital Virgen de las Nieves":{
+        "collecting_institution_address": "Av. de las Fuerzas Armadas, 2",
+        "collecting_institution_email": "joaquin.dopazo@juntadeandalucia.es",
+        "geo_loc_state": "Andalucia",
+        "geo_loc_region": "Granada",
+        "geo_loc_city": "Granada",
+        "geo_loc_country": "Spain",
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
+        "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
+    },
     "Complejo Hospitalario de Jaen":{
         "collecting_institution_address": "Avda. del Ejército Español nº10",
         "collecting_institution_email": "joaquin.dopazo@juntadeandalucia.es",
@@ -17,10 +95,9 @@
         "geo_loc_region": "Jaen",
         "geo_loc_city": "Jaen",
         "geo_loc_country": "Spain",
-        "submitting_institution": "Complejo Hospitalario de Jaen",
-        "submitting_institution_address": "Avda. del Ejército Español nº10",
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
         "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
-      
     },
     "Hospital de Poniente":{
         "collecting_institution_address": "Ctra Almerimar, 31",
@@ -29,8 +106,8 @@
         "geo_loc_region": "Almeria",
         "geo_loc_city": "El Ejido",
         "geo_loc_country": "Spain",
-        "submitting_institution": "Hospital de Poniente",
-        "submitting_institution_address": "Ctra Almerimar, 31",
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
         "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
     },
     "Hospital Juan Ramon Jimenez":{
@@ -40,8 +117,8 @@
         "geo_loc_region": "Huelva",
         "geo_loc_city": "Huelva",
         "geo_loc_country": "Spain",
-        "submitting_institution": "Hospital Juan Ramon Jimenez",
-        "submitting_institution_address": "Ronda Norte, s/n",
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
         "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
     },
     "Hospital Reina Sofia":{
@@ -51,11 +128,11 @@
         "geo_loc_region": "Cordoba",
         "geo_loc_city": "Cordoba",
         "geo_loc_country": "Spain",
-        "submitting_institution": "Hospital Reina Sofia",
-        "submitting_institution_address": "Av. Menendez Pidal, s/n",
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
         "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
     },
-    "Plataforma de Medicina Computacional, Fundación Progreso y Salud"{
+    "Plataforma de Medicina Computacional, Fundación Progreso y Salud":{
         "collecting_institution_address": "Avda. Américo Vespucio, 15",
         "collecting_institution_email": "joaquin.dopazo@juntadeandalucia.es",
         "geo_loc_state": "Andalucia",
@@ -63,7 +140,7 @@
         "geo_loc_city": "Sevilla",
         "geo_loc_country": "Spain",
         "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
-        "submitting_institution_address": "Avda. Américo Vespucio, 15",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
         "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
     },
     "Hospital Puerta del Mar": {
@@ -73,8 +150,8 @@
         "geo_loc_region": "Cadiz",
         "geo_loc_city": "Cadiz",
         "geo_loc_country": "Spain",
-        "submitting_institution": "Hospital Puerta del Mar",
-        "submitting_institution_address": "Av. Ana de Viya, 21",
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
         "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
     },
     "Hospital Costa del Sol": {
@@ -84,8 +161,8 @@
         "geo_loc_region": "Malaga",
         "geo_loc_city": "Marbella",
         "geo_loc_country": "Spain",
-        "submitting_institution": "Hospital Costa del Sol",
-        "submitting_institution_address": "A-7, Km 187",
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
         "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
     },
     "Hospital Virgen de la Victoria": {
@@ -95,8 +172,8 @@
         "geo_loc_region": "Malaga",
         "geo_loc_city": "Malaga",
         "geo_loc_country": "Spain",
-        "submitting_institution": "Hospital Virgen de la Victoria",
-        "submitting_institution_address": "Campus de Teatinos, S/N",
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
         "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
     },
     "Complejo Hospitalario Torrecardenas": {
@@ -106,8 +183,8 @@
         "geo_loc_region": "Almeria",
         "geo_loc_city": "Almeria",
         "geo_loc_country": "Spain",
-        "submitting_institution": "Complejo Hospitalario Torrecardenas",
-        "submitting_institution_address": "C. Hermandad de Donantes de Sangre, s/n",
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
         "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
     },
     "Hospital Universitario San Cecilio": {
@@ -117,9 +194,9 @@
         "geo_loc_region": "Granada",
         "geo_loc_city": "Granada",
         "geo_loc_country": "Spain",
-        "submitting_institution": "Hospital Universitario San Cecilio",
-        "submitting_institution_address": "Av. del Conocimiento S/N",
-        "submitting_institution_email": "fegarcia@ugr.es"
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
+        "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
     },
     "Microbiología HUC San Cecilio": {
         "collecting_institution_address": "Av. del Conocimiento S/N",
@@ -128,9 +205,9 @@
         "geo_loc_region": "Granada",
         "geo_loc_city": "Granada",
         "geo_loc_country": "Spain",
-        "submitting_institution": "Microbiología HUC San Cecilio",
-        "submitting_institution_address": "Av. del Conocimiento S/N",
-        "submitting_institution_email": "fegarcia@ugr.es"
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
+        "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
     },
     "Microbiología. Hospital Universitario Virgen del Rocio": {
         "collecting_institution_address": "Avenida Manuel Siurot s/n",
@@ -139,9 +216,9 @@
         "geo_loc_region": "Sevilla",
         "geo_loc_city": "Sevilla",
         "geo_loc_country": "Spain",
-        "submitting_institution": "Microbiología. Hospital Universitario Virgen del Rocio",
-        "submitting_institution_address": "Avenida Manuel Siurot s/n",
-        "submitting_institution_email": "josea.lepe.sspa@juntadeandalucia.es"
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
+        "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
     },
     "Hospital Universitario Virgen del Rocio": {
         "collecting_institution_address": "Avenida Manuel Siurot s/n",
@@ -150,9 +227,9 @@
         "geo_loc_region": "Sevilla",
         "geo_loc_city": "Sevilla",
         "geo_loc_country": "Spain",
-        "submitting_institution": "Hospital Universitario Virgen del Rocio",
-        "submitting_institution_address": "Avenida Manuel Siurot s/n",
-        "submitting_institution_email": "josea.lepe.sspa@juntadeandalucia.es"
+        "submitting_institution": "Plataforma de Medicina Computacional, Fundación Progreso y Salud",
+        "submitting_institution_address": "Avda. Américo Vespucio, 15, Sevilla",
+        "submitting_institution_email": "joaquin.dopazo@juntadeandalucia.es"
     },
     "Hospital Clínico Universitario Lozano Blesa": {
         "collecting_institution_address": "S. Juan Bosco, 15",
@@ -298,25 +375,25 @@
         "submitting_institution_email": ""
     },
     "Hospital General La Mancha Centro": {
-        "collecting_institution_address": "Av. Constitución, 3, Alcázar de San Juan",
+        "collecting_institution_address": "Av. Constitución, 3, Alcazar de San Juan",
         "collecting_institution_email": "",
         "geo_loc_state": "Castilla-La Mancha",
         "geo_loc_region": "Ciudad Real",
-        "geo_loc_city": "Alcázar de San Juan",
+        "geo_loc_city": "Alcazar de San Juan",
         "geo_loc_country": "Spain",
         "submitting_institution": "Hospital General La Mancha Centro",
-        "submitting_institution_address": "Av. Constitución, 3, Alcázar de San Juan",
+        "submitting_institution_address": "Av. Constitución, 3, Alcazar de San Juan",
         "submitting_institution_email": ""
     },
     "Hospital Virgen de Altagracia": {
-        "collecting_institution_address": "Avda. D. Emiliano García Roldán, s/n, Manzanares,",
+        "collecting_institution_address": "Avda. D. Emiliano García Roldan, s/n, Manzanares,",
         "collecting_institution_email": "",
         "geo_loc_state": "Castilla-La Mancha",
         "geo_loc_region": "Ciudad Real",
         "geo_loc_city": "Manzanares",
         "geo_loc_country": "Spain",
         "submitting_institution": "Hospital Virgen de Altagracia",
-        "submitting_institution_address": "Avda. D. Emiliano García Roldán, s/n, Manzanares,",
+        "submitting_institution_address": "Avda. D. Emiliano García Roldan, s/n, Manzanares,",
         "submitting_institution_email": ""
     },
     "Hospital General de Valdepeñas": {
@@ -330,14 +407,14 @@
         "submitting_institution_address": "Av. de los Estudiantes, s/n, Valdepeñas",
         "submitting_institution_email": ""
     },
-    "Hospital Público Santa Bárbara": {
+    "Hospital Público Santa Barbara": {
         "collecting_institution_address": "C. Malagón s/n",
         "collecting_institution_email": "",
         "geo_loc_state": "Castilla-La Mancha",
         "geo_loc_region": "Ciudad Real",
         "geo_loc_city": "Puertollano",
         "geo_loc_country": "Spain",
-        "submitting_institution": "Hospital Público Santa Bárbara",
+        "submitting_institution": "Hospital Público Santa Barbara",
         "submitting_institution_address": "C. Malagón s/n",
         "submitting_institution_email": ""
     },

--- a/relecov_tools/json_validation.py
+++ b/relecov_tools/json_validation.py
@@ -73,6 +73,7 @@ class SchemaValidation:
         validated_json_data = []
         invalid_json = []
         errors = {}
+        error_keys = {}
         stderr.print("[blue] Start processing the json file")
         for item_row in self.json_data:
             # validate(instance=item_row, schema=json_schema)
@@ -81,11 +82,11 @@ class SchemaValidation:
             else:
                 # Count error types
                 for error in validator.iter_errors(item_row):
+                    error_keys[error.message] = error.absolute_path[0]
                     if error.message in errors.keys():
                         errors[error.message] += 1
                     else:
                         errors[error.message] = 1
-
                 # log.error("Invalid sample data %s", error.message)
                 # append row with errors
                 invalid_json.append(item_row)
@@ -98,7 +99,8 @@ class SchemaValidation:
             stderr.print(
                 "[red]"
                 + str(errors[error_type])
-                + " samples failed validation:\n"
+                + " samples failed validation for "
+                + f"{error_keys[error_type]}:\n"
                 + error_type
             )
             stderr.print("[red] --------------------")

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -164,17 +164,17 @@ class RelecovMetadata:
                 if str(error.args[0]).lower() == "not provided":
                     log.error("Label was not provided, auto-completing columns")
                     stderr.print(
-                        f"Label {map_field} was not provided in sample {idx}, \
-                        auto-completing with Not Provided"
+                        f"Label {map_field} was not provided in sample {idx}, "
+                        + "auto-completing with Not Provided"
                     )
                 else:
                     log.error(
-                        f"Unknown map_field value {error} for json data: \
-                        {str(map_field)}. Aborting"
+                        f"Unknown map_field value {error} for json data: "
+                        + f"{str(map_field)}. Aborting"
                     )
                     stderr.print(
-                        f"[red] Unknown value {error} for: {map_field}\
-                        in sample {idx}. Aborting"
+                        f"[red] Unknown value {error} for: {map_field} "
+                        + f"in sample {idx}. Aborting"
                     )
                     sys.exit(1)
                 fields_to_add = {
@@ -200,7 +200,7 @@ class RelecovMetadata:
         # Include Sample information data from sample json file
         stderr.print("[blue] Processing sample data file")
         s_json = {}
-        s_json["map_field"] = "collecting_lab_sample_id"
+        s_json["map_field"] = "submitting_lab_sample_id"
         s_json["adding_fields"] = [
             "fastq_r1_md5",
             "fastq_r2_md5",


### PR DESCRIPTION
Download function was deleting the local folder even when the selected output location was an existing folder with files. Therefore, I changed the way `local_folder_path` is set in `get_files_from_sftp_folder` function from [sftp_handle.py](https://github.com/BU-ISCIII/relecov-tools/blob/develop/relecov_tools/sftp_handle.py) along with small print changes and a new error handler that I had to include for debugging and an overall cleaning of redundant functions. 
I also included additional info into the validation report message from [json_validation.py](https://github.com/BU-ISCIII/relecov-tools/blob/develop/relecov_tools/json_validation.py) and changed a print that was repeated in two different functions to ease debugging in [read_lab_metadata.py](https://github.com/BU-ISCIII/relecov-tools/blob/develop/relecov_tools/read_lab_metadata.py).

Moreover, I also introduced new fields/locations into [laboratory_address.json](https://github.com/BU-ISCIII/relecov-tools/blob/develop/relecov_tools/conf/laboratory_address.json) and [geo_loc_cities.json](https://github.com/BU-ISCIII/relecov-tools/blob/develop/relecov_tools/conf/geo_loc_cities.json) .