### PR TITLE
Big changes in sftp_handle.py and minor in utils.py and configuration.json

### DIFF
--- a/relecov_tools/conf/configuration.json
+++ b/relecov_tools/conf/configuration.json
@@ -19,6 +19,7 @@
             "GISAID id",
             "Originating Laboratory",
             "Submitting Institution",
+            "Sequencing Institution",
             "Sample Collection Date",
             "Sample Received Date",
             "Purpose of sampling",
@@ -109,7 +110,15 @@
         },
         "required_copy_from_other_field": {
             "isolate_sample_id": "sequencing_sample_id"
-        }
+        },
+        "samples_json_fields": [
+            "fastq_r1_md5",
+            "fastq_r2_md5",
+            "sequence_file_R1_fastq",
+            "sequence_file_R2_fastq",
+            "r1_fastq_filepath",
+            "r2_fastq_filepath"
+        ]
     },
     "long_table_heading": [
         "SAMPLE",

--- a/relecov_tools/conf/configuration.json
+++ b/relecov_tools/conf/configuration.json
@@ -194,36 +194,29 @@
             "sftp_server": "sftprelecov.isciii.es",
             "sftp_port": "22"
         },
+        "metadata_processing": {
+            "header_flag": "CAMPO",
+            "excel_sheet": "METADATA_LAB"
+        },
         "abort_if_md5_mismatch": "False",
-        "platform_storage_folder": "tmp/relecov",
-        "allowed_sample_extensions": [
-            "fastq.gz",
-            "fasta"
-        ],
-        "allowed_R1_delimiters": [
-            "_R1_",
-            "_R1.",
-            ".R1.",
-            "Forward",
-            "forward",
-            "_1_",
-            "_1.",
-            ".1."
-        ],
-        "allowed_R2_delimiters": [
-            "_R2_",
-            "_R2.",
-            ".R2.",
-            "Reverse",
-            "reverse",
-            "_2_",
-            "_2.",
-            ".2."
+        "platform_storage_folder": "/tmp/relecov",
+        "allowed_file_extensions": [
+            ".fastq.gz",
+            ".fastq",
+            ".fq",
+            ".fq.gz",
+            ".fasta",
+            ".fasta.gz"
         ],
         "allowed_download_options": [
             "download_only",
             "download_clean",
             "delete_only"
+        ],
+        "skip_when_found": [
+            "#",
+            "Hash",
+            "Path"
         ]
     },
     "GISAID_configuration": {
@@ -369,7 +362,6 @@
             "sequencing_sample_id": "sequencing_sample_id"
         }
     },
-    "md5_file_name": "md5_check_file.csv",
     "ENA_fields": {
         "ENA_configuration": {
             "study_alias": "RELECOV",

--- a/relecov_tools/gisaid_upload.py
+++ b/relecov_tools/gisaid_upload.py
@@ -103,9 +103,9 @@ class GisaidUpload:
     def complete_mand_fields(self, dataframe):
         """Complete mandatory empty fields with 'unknown'"""
         dataframe.loc[dataframe["covv_gender"] == "", "covv_gender"] = "unknown"
-        dataframe.loc[
-            dataframe["covv_patient_age"] == "", "covv_patient_age"
-        ] = "unknown"
+        dataframe.loc[dataframe["covv_patient_age"] == "", "covv_patient_age"] = (
+            "unknown"
+        )
 
         authors = [authors_field for authors_field in dataframe["covv_authors"]]
         if "" in authors or "unknown" in authors:
@@ -115,17 +115,17 @@ class GisaidUpload:
             )
             sys.exit(1)
 
-        dataframe.loc[
-            dataframe["covv_subm_lab_addr"] == "", "covv_subm_lab_addr"
-        ] = "unknown"
+        dataframe.loc[dataframe["covv_subm_lab_addr"] == "", "covv_subm_lab_addr"] = (
+            "unknown"
+        )
         dataframe.loc[dataframe["covv_subm_lab"] == "", "covv_subm_lab"] = "unknown"
-        dataframe.loc[
-            dataframe["covv_orig_lab_addr"] == "", "covv_orig_lab_addr"
-        ] = "unknown"
+        dataframe.loc[dataframe["covv_orig_lab_addr"] == "", "covv_orig_lab_addr"] = (
+            "unknown"
+        )
         dataframe.loc[dataframe["covv_orig_lab"] == "", "covv_orig_lab"] = "unknown"
-        dataframe.loc[
-            dataframe["covv_patient_status"] == "", "covv_patient_status"
-        ] = "unknown"
+        dataframe.loc[dataframe["covv_patient_status"] == "", "covv_patient_status"] = (
+            "unknown"
+        )
         dataframe.loc[dataframe["covv_type"] == "", "covv_type"] = "betacoronavirus"
         dataframe.loc[dataframe["covv_passage"] == "", "covv_passage"] = "Original"
 

--- a/relecov_tools/sftp_handle.py
+++ b/relecov_tools/sftp_handle.py
@@ -548,7 +548,6 @@ class SftpHandle:
         """
         local_meta_file = self.get_metadata_file(remote_folder, local_folder)
         out_folder = os.path.dirname(local_meta_file)
-        allowed_extensions = self.allowed_file_ext
         remote_files_list = [
             os.path.basename(file) for file in self.get_file_list(remote_folder)
         ]
@@ -585,18 +584,6 @@ class SftpHandle:
             sample_files_dict = self.process_filedict(
                 sample_files_dict, filtered_files_list
             )
-            """ext_dict = {}
-            for sample, values in sample_files_dict.items():
-                ext_dict[sample] = {
-                    key: (file if str(val) in file else None)
-                    for key, val in values.items()
-                    for file in filtered_files_list
-                }
-                # remove sample if it has missing files
-                if not all(x in filtered_files_list for x in ext_dict[sample].values()):
-                    log.warning("Sample %s skipped: missing files in sftp", sample)
-                    del ext_dict[sample]"""
-            """sample_files_dict = copy.deepcopy(ext_dict)"""
         if not any(value for value in sample_files_dict.values()):
             raise FileNotFoundError("No files from metadata found in ", remote_folder)
         return sample_files_dict, local_meta_file
@@ -711,11 +698,6 @@ class SftpHandle:
                 for file in clean_fetchlist:
                     if val in file:
                         processed_dict[sample][key] = file
-            """processed_dict[sample] = {
-                key: (file if str(val) in file else None)
-                    for key, val in vals.items()
-                    for file in clean_fetchlist
-                }"""
             # remove sample if it has missing files
             if not all(x in clean_fetchlist for x in processed_dict[sample].values()):
                 log.warning("Sample %s skipped: missing files in sftp", sample)

--- a/relecov_tools/sftp_handle.py
+++ b/relecov_tools/sftp_handle.py
@@ -815,7 +815,7 @@ class SftpHandle:
                     if f_name in successful_files:
                         files_md5_dict[f_name] = hash_dict[f_name]
                     else:
-                        log.info("Generating md5 hash for %s", f_name)
+                        log.warning("File %s not found in md5sum. Creating it", f_name)
                         files_md5_dict[f_name] = relecov_tools.utils.calculate_md5(path)
             else:
                 md5_hashes = [

--- a/relecov_tools/sftp_handle.py
+++ b/relecov_tools/sftp_handle.py
@@ -548,6 +548,7 @@ class SftpHandle:
         """
         local_meta_file = self.get_metadata_file(remote_folder, local_folder)
         out_folder = os.path.dirname(local_meta_file)
+        allowed_extensions = self.allowed_file_ext
         remote_files_list = [
             os.path.basename(file) for file in self.get_file_list(remote_folder)
         ]

--- a/relecov_tools/sftp_handle.py
+++ b/relecov_tools/sftp_handle.py
@@ -420,7 +420,7 @@ class SftpHandle:
             stderr.print("[red]Differences: ", diffs)
             sys.exit(1)
         index_sampleID = metadata_header.index(
-            "Sample ID given by the submitting laboratory"
+            "Sample ID given for sequencing"
         )
         index_fastq_r1 = metadata_header.index("Sequence file R1 fastq")
         index_fastq_r2 = metadata_header.index("Sequence file R2 fastq")

--- a/relecov_tools/sftp_handle.py
+++ b/relecov_tools/sftp_handle.py
@@ -177,7 +177,7 @@ class SftpHandle:
             directory_list = [
                 item.filename for item in content_list if stat.S_ISDIR(item.st_mode)
             ]
-        except AttributeError as e:
+        except AttributeError:
             return False
         return directory_list
 
@@ -716,7 +716,7 @@ class SftpHandle:
                 )
                 # retrasmision of files in folder
                 if req_retransmition:
-                    stderr.print(f"[Orange] Error during download, trying again...")
+                    stderr.print("[Yellow] Error during download, trying again...")
                     self.get_remote_folder_files(
                         folder, local_folder, req_retransmition
                     )

--- a/relecov_tools/sftp_handle.py
+++ b/relecov_tools/sftp_handle.py
@@ -419,9 +419,7 @@ class SftpHandle:
             )
             stderr.print("[red]Differences: ", diffs)
             sys.exit(1)
-        index_sampleID = metadata_header.index(
-            "Sample ID given for sequencing"
-        )
+        index_sampleID = metadata_header.index("Sample ID given for sequencing")
         index_fastq_r1 = metadata_header.index("Sequence file R1 fastq")
         index_fastq_r2 = metadata_header.index("Sequence file R2 fastq")
         for row in islice(ws_metadata_lab.values, header_row, ws_metadata_lab.max_row):

--- a/relecov_tools/utils.py
+++ b/relecov_tools/utils.py
@@ -179,6 +179,9 @@ def read_md5_checksum(file_name, avoid_chars=list()):
     ]
     # md5sum should always have 2 columns: hash - path
     md5_lines = [line for line in clean_lines if len(line) == 2]
+    if not md5_lines:
+        return False
+    # split paths for both windows "\" and linux "/" using regex [\\/]
     hash_dict = {re.split(r"[\\/]", line[1])[-1]: line[0].lower() for line in md5_lines}
     return hash_dict
 

--- a/relecov_tools/utils.py
+++ b/relecov_tools/utils.py
@@ -12,6 +12,7 @@ import openpyxl
 import yaml
 import gzip
 import re
+import shutil
 from itertools import islice
 from Bio import SeqIO
 from rich.console import Console


### PR DESCRIPTION
[sftp_handle.py](https://github.com/BU-ISCIII/relecov-tools/blob/develop/relecov_tools/sftp_handle.py) was not verifying the md5 values of the remote files correctly so it had to be fixed. Moreover, I included several testings to extract data from three possible md5checksum configurations: The one from linux `md5sum * > md5checksum.csv` another one from windows which includes headers ("Hash" and "Path") and windows paths (meaning "\" instead of "/") and a last one that has asterisks before the paths coming from third-party softwares.

I also included handling of uncompressed files in order to reduce the space occupied by these downloaded files, and made the code more robust on a general basis by including better error handling and retries for corrupted files (which were previously skipped somehow) and removed the verification or R1/R2 delimiters as it was redundant and obscure.

In order to do so I had to include a few methods in [utils.py](https://github.com/BU-ISCIII/relecov-tools/blob/develop/relecov_tools/utils.py) and some fields into [configuration.json](https://github.com/BU-ISCIII/relecov-tools/blob/develop/relecov_tools/conf/configuration.json) such as the header and sheet for the metadata template in excel format.

These changes should close #242 and close #246 and close #249