### PR TITLE
Splitted tests in two files, fixed pull-request checkout error

### DIFF
--- a/.github/workflows/test_modules.yml
+++ b/.github/workflows/test_modules.yml
@@ -3,65 +3,11 @@ name: test_modules
 on:
   push:
     branches: "**"
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, closed]
     branches: "**"
 
 jobs:
-  security_check:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Get User Permission
-      id: checkAccess
-      uses: actions-cool/check-user-permission@v2
-      with:
-        require: write
-        username: ${{ github.triggering_actor }}
-    - name: Check User Permission
-      if: steps.checkAccess.outputs.require-result == 'false'
-      run: |
-        echo "${{ github.triggering_actor }} does not have permissions on this repo."
-        echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-        echo "Job originally triggered by ${{ github.actor }}"
-        exit 1
-
-  test_sftp_handle:
-    needs: security_check
-    concurrency:
-      group: ${{ github.repository }}-test_sftp_handle
-      cancel-in-progress: false
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 1
-      matrix:
-        download_options: ["download_only", "download_clean", "delete_only"]
-        target_folders: ["", "-t COD-test-1"]
-
-    steps:
-    - name: Set up Python 3.9.16
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.9.16'
-
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        path: .
-
-    - name: Install package and dependencies
-      run: |
-        pip install -r requirements.txt
-        pip install .
-
-    - name: Run sftp_handle tests
-      run: |
-        python3 tests/test_sftp_handle.py --download_option ${{ matrix.download_options }} ${{ matrix.target_folders }}
-      env:
-        TEST_USER: ${{ secrets.TEST_USER }}
-        TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-        TEST_PORT: ${{ secrets.TEST_PORT }}
-        OUTPUT_LOCATION: ${{ github.workspace }}/tests/
-
   test_map:
     runs-on: ubuntu-latest
     strategy:
@@ -76,7 +22,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        path: .
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Install package and dependencies
       run: |
         pip install -r requirements.txt
@@ -108,7 +54,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        path: .
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Install package and dependencies
       run: |

--- a/.github/workflows/test_sftp_handle.yml
+++ b/.github/workflows/test_sftp_handle.yml
@@ -1,0 +1,64 @@
+name: test_sftp_handle
+
+on:
+    push:
+      branches: "**"
+    pull_request_target:
+      types: [opened, reopened, synchronize, closed]
+      branches: "**"
+    
+jobs:
+  security_check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get User Permission
+      id: checkAccess
+      uses: actions-cool/check-user-permission@v2
+      with:
+        require: write
+        username: ${{ github.triggering_actor }}
+    - name: Check User Permission
+      if: steps.checkAccess.outputs.require-result == 'false'
+      run: |
+        echo "${{ github.triggering_actor }} does not have permissions on this repo."
+        echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+        echo "Job originally triggered by ${{ github.actor }}"
+        exit 1
+      
+  test_sftp_handle:
+    needs: security_check
+    concurrency:
+      group: ${{ github.repository }}-test_sftp_handle
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        download_options: ["download_only", "download_clean", "delete_only"]
+        target_folders: ["", "-t COD-test-1"]
+      
+    steps:
+    - name: Set up Python 3.9.16
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.9.16'
+      
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+      
+    - name: Install package and dependencies
+      run: |
+        pip install -r requirements.txt
+        pip install .
+      
+    - name: Run sftp_handle tests
+      run: |
+        python3 tests/test_sftp_handle.py --download_option ${{ matrix.download_options }} ${{ matrix.target_folders }}
+      env:
+        TEST_USER: ${{ secrets.TEST_USER }}
+        TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+        TEST_PORT: ${{ secrets.TEST_PORT }}
+        OUTPUT_LOCATION: ${{ github.workspace }}/tests/
+      

--- a/.github/workflows/test_sftp_handle.yml
+++ b/.github/workflows/test_sftp_handle.yml
@@ -1,11 +1,11 @@
 name: test_sftp_handle
 
 on:
-    push:
-      branches: "**"
-    pull_request_target:
-      types: [opened, reopened, synchronize, closed]
-      branches: "**"
+  push:
+    branches: "**"
+  pull_request_target:
+    types: [opened, reopened, synchronize, closed]
+    branches: "**"
     
 jobs:
   security_check:


### PR DESCRIPTION
As per the title, there were errors in the tests due to a weird functionality in `actions/checkout` related to `pull_request` option. When this option was activated, the tested code was the one from the repository receiving the pull request instead of the proper code that is going to be merged as seen in [numerous issues](https://github.com/actions/checkout/issues/881). 

I included the changes found in the [documentation](https://github.com/actions/checkout/blob/v3.0.2/README.md#user-content-checkout-pull-request-head-commit-instead-of-merge-commit) related to these issues.

Also, for better security, I only used `pull_request_target` when necessary (sftp_handle tests)