### PR TITLE
Hotfix for tmp folder creation in remote home

### DIFF
--- a/relecov_tools/sftp_handle.py
+++ b/relecov_tools/sftp_handle.py
@@ -202,7 +202,8 @@ class SftpHandle:
 
         if recursive:
             directory_list = recursive_list(folder_name)
-            directory_list.append(folder_name)
+            if "." != folder_name:
+                directory_list.append(folder_name)
             return directory_list
         try:
             directory_list = [

--- a/relecov_tools/sftp_handle.py
+++ b/relecov_tools/sftp_handle.py
@@ -202,7 +202,7 @@ class SftpHandle:
 
         if recursive:
             directory_list = recursive_list(folder_name)
-            if "." != folder_name:
+            if folder_name != ".":
                 directory_list.append(folder_name)
             return directory_list
         try:

--- a/relecov_tools/upload_ena_protocol.py
+++ b/relecov_tools/upload_ena_protocol.py
@@ -232,9 +232,6 @@ class EnaUpload:
 
     def xml_submission(self, json_data, schemas_dataframe, batch_index=None):
         """The metadata is submitted in an xml format"""
-        import pdb
-
-        pdb.set_trace()
         schema_targets = extract_targets(self.action, schemas_dataframe)
 
         tool = self.config_json.get_configuration("ENA_fields")["tool"]
@@ -266,9 +263,7 @@ class EnaUpload:
         schema_xmls["submission"] = submission_xml
 
         stderr.print(f"\nProcessing submission to ENA server: {self.url}")
-        import pdb
 
-        pdb.set_trace()
         receipt = send_schemas(schema_xmls, self.url, self.user, self.passwd).text
         if not os.path.exists(self.output_path):
             os.mkdir(self.output_path)

--- a/relecov_tools/utils.py
+++ b/relecov_tools/utils.py
@@ -64,9 +64,12 @@ def read_excel_file(f_name, sheet_name, header_flag, leave_empty=True):
     """
     wb_file = openpyxl.load_workbook(f_name, data_only=True)
     ws_metadata_lab = wb_file[sheet_name]
-    heading_row = [
-        idx + 1 for idx, x in enumerate(ws_metadata_lab.values) if header_flag in x
-    ][0]
+    try:
+        heading_row = [
+            idx + 1 for idx, x in enumerate(ws_metadata_lab.values) if header_flag in x
+        ][0]
+    except IndexError:
+        raise KeyError(f"Header flag '{header_flag}' could not be found in {f_name}")
     heading = [str(i.value).strip() for i in ws_metadata_lab[heading_row] if i.value]
     ws_data = []
     for row in islice(ws_metadata_lab.values, heading_row, ws_metadata_lab.max_row):


### PR DESCRIPTION
As per the title, last PR created a bug that left a temporary folder in remote's home location. Which is fixed in this PR along with minimal changes in utils.read-excel() when no header flag is found and import pdb() removals in upload-to-ena