### PR TITLE
Now json_summary custom log filename includes module called

### DIFF
--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -2,6 +2,7 @@
 import logging
 import json
 import os
+import inspect
 from rich.console import Console
 from datetime import datetime
 from collections import OrderedDict
@@ -100,8 +101,12 @@ class LogSum:
                 for sample in self.logs[key]["samples"].keys():
                     if self.logs[key]["samples"][sample]["errors"]:
                         self.logs[key]["samples"][sample]["valid"] = False
+        called_module = [
+            fr.function for fr in inspect.stack() if "__main__.py" in fr.filename
+        ][0]
         if not filename:
-            filename = datetime.today().strftime("%Y%m%d%-H%M%S") + "_log_summary.json"
+            date = datetime.today().strftime("%Y%m%d%-H%M%S")
+            filename = "_".join([date, called_module, "log_summary.json"])
         summary_path = os.path.join(self.output_location, filename)
         with open(summary_path, "w", encoding="utf-8") as f:
             f.write(json.dumps(self.logs, indent=4, sort_keys=True, ensure_ascii=False))

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -87,7 +87,7 @@ class LogSum:
             self.logs[current_key]["samples"][sample][log_type].append(entry)
         return
 
-    def create_error_summary(self, filename=None):
+    def create_error_summary(self, called_module, filename=None):
         """Dump the log summary dictionary into a file with json format. If any of
         the 'errors' key is not empty, the parent key value 'valid' is set to false.
 
@@ -101,9 +101,13 @@ class LogSum:
                 for sample in self.logs[key]["samples"].keys():
                     if self.logs[key]["samples"][sample]["errors"]:
                         self.logs[key]["samples"][sample]["valid"] = False
-        called_module = [
-            fr.function for fr in inspect.stack() if "__main__.py" in fr.filename
-        ][0]
+        if not called_module:
+            try:
+                called_module = [
+                    f.function for f in inspect.stack() if "__main__.py" in f.filename
+                ][0]
+            except IndexError:
+                called_module = ""
         if not filename:
             date = datetime.today().strftime("%Y%m%d%-H%M%S")
             filename = "_".join([date, called_module, "log_summary.json"])

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -87,7 +87,7 @@ class LogSum:
             self.logs[current_key]["samples"][sample][log_type].append(entry)
         return
 
-    def create_error_summary(self, called_module, filename=None):
+    def create_error_summary(self, called_module=None, filename=None):
         """Dump the log summary dictionary into a file with json format. If any of
         the 'errors' key is not empty, the parent key value 'valid' is set to false.
 

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -219,6 +219,7 @@ class RelecovMetadata:
                         )
                         self.logsum.add_warning(key=sample_id, entry=log_text)
                         continue
+                    # TODO: Include Not Provided as a configuration field
                     fields_to_add = {
                         x: "Not Provided [GENEPIO:0001668]"
                         for x in json_fields["adding_fields"]
@@ -307,7 +308,7 @@ class RelecovMetadata:
                             log_text = f"Invalid date format in sample {str(key)}"
                             self.logsum.add_error(sample_id, log_text)
                             stderr.print(f"[red]{log_text}")
-                            row[key] = None
+                            continue
                 elif "sample id" in key.lower():
                     if isinstance(row[key], float) or isinstance(row[key], int):
                         row[key] = str(int(row[key]))
@@ -321,8 +322,8 @@ class RelecovMetadata:
                         log_text = f"Error when mapping the label {str(e)}"
                         self.logsum.add_error(sample_id, log_text)
                         stderr.print(f"[red]{log_text}")
-
                         continue
+
             valid_metadata_rows.append(property_row)
         return valid_metadata_rows
 

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -354,7 +354,7 @@ class RelecovMetadata:
         )
         stderr.print("[blue]Writting output json file")
         os.makedirs(self.output_folder, exist_ok=True)
-        self.logsum.create_error_summary()
+        self.logsum.create_error_summary(called_module="read-lab-metadata")
         file_path = os.path.join(self.output_folder, file_name)
         relecov_tools.utils.write_json_fo_file(completed_metadata, file_path)
         return True

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -305,9 +305,9 @@ class RelecovMetadata:
                                 dtime.strptime(str(row[key]), "%Y-%m-%d").date()
                             )
                         except ValueError:
-                            log_text = f"Invalid date format in sample {str(key)}"
+                            log_text = f"Invalid date format in {key}: {row[key]}"
                             self.logsum.add_error(sample_id, log_text)
-                            stderr.print(f"[red]{log_text}")
+                            stderr.print(f"[red]{log_text} for sample {sample_id}")
                             continue
                 elif "sample id" in key.lower():
                     if isinstance(row[key], float) or isinstance(row[key], int):


### PR DESCRIPTION
Appart from a small fix in read_lab_metadata (Now when an invalid date is met is doesn't crash, just continues), now the output json file with the custom log from json_summary.py includes the name of the module called (e.g. if its generated from a read-lab-metadata call, the output name will be `DATE_read_lab_metadata_log_summary.json`

