### PR TITLE
Now read-bioinfo-metadata splits data and extract files for each batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Code contributions to the hotfix:
 
 - Included a way to extract pango-designation version in read-bioinfo-metadata [#299](https://github.com/BU-ISCIII/relecov-tools/pull/299)
 - Now log_summary.py also creates an excel file with the process logs [#300](https://github.com/BU-ISCIII/relecov-tools/pull/300)
-- Read-bioinfo-metadata splits files and data by batch of samples [#301]()
+- Read-bioinfo-metadata splits files and data by batch of samples [#306](https://github.com/BU-ISCIII/relecov-tools/pull/306)
 
 #### Fixes
 

--- a/relecov_tools/assets/pipeline_utils/viralrecon.py
+++ b/relecov_tools/assets/pipeline_utils/viralrecon.py
@@ -173,17 +173,14 @@ class LongTableParse:
         # Parsing longtable file
         parsed_data = self.parse_file()
         j_list = self.convert_to_json(parsed_data)
-        # Saving long table data into a file
-        self.save_to_file(j_list)
-        stderr.print("[green]\tProcess completed")
-        return
+        return j_list
 
 
 # END of Class
 
 
 # START util functions
-def handle_pangolin_data(files_list):
+def handle_pangolin_data(files_list, output_folder=None):
     """File handler to parse pangolin data (csv) into JSON structured format.
 
     Args:
@@ -323,7 +320,7 @@ def handle_pangolin_data(files_list):
     return pango_data_processed
 
 
-def parse_long_table(files_list):
+def parse_long_table(files_list, output_folder=None):
     """File handler to retrieve data from long table files and convert it into a JSON structured format.
     This function utilizes the LongTableParse class to parse the long table data.
     Since this utility handles and maps data using a custom way, it returns None to be avoid being  transferred to method read_bioinfo_metadata.BioinfoMetadata.mapping_over_table().
@@ -345,9 +342,13 @@ def parse_long_table(files_list):
                 method_name, "error", f"{files_list_processed} given file is not a file"
             )
             sys.exit(method_log_report.print_log_report(method_name, ["error"]))
-        long_table = LongTableParse(files_list_processed)
+        
+        long_table = LongTableParse(file_path=files_list_processed, output_directory=output_folder)
         # Parsing long table data and saving it
-        long_table.parsing_csv()
+        long_table_data = long_table.parsing_csv()
+        # Saving long table data into a file
+        long_table.save_to_file(long_table_data)
+        stderr.print("[green]\tProcess completed")
     elif len(files_list) > 1:
         method_log_report.update_log_report(
             method_name,
@@ -358,7 +359,7 @@ def parse_long_table(files_list):
     return None
 
 
-def handle_consensus_fasta(files_list):
+def handle_consensus_fasta(files_list, output_folder=None):
     """File handler to parse consensus data (fasta) into JSON structured format.
 
     Args:

--- a/relecov_tools/assets/pipeline_utils/viralrecon.py
+++ b/relecov_tools/assets/pipeline_utils/viralrecon.py
@@ -146,15 +146,7 @@ class LongTableParse:
             )
             sys.exit(1)
         else:
-            date_regex = re.search(r"(\d{8})", result_regex.group())
-            if date_regex is not None:
-                analysis_date = date_regex.group()
-                stderr.print(f"[green]\tDate {analysis_date} found in {self.file_path}")
-            else:
-                analysis_date = "Not Provided [GENEPIO:0001668]"
-                stderr.print(
-                    f"[yellow]\tWARN:No analysis date found in long table: {self.file_path}"
-                )
+            analysis_date = relecov_tools.utils.get_file_date(self.file_path)
         for key, values in samp_dict.items():
             j_dict = {"sample_name": key, "analysis_date": analysis_date}
             j_dict["variants"] = values

--- a/relecov_tools/assets/pipeline_utils/viralrecon.py
+++ b/relecov_tools/assets/pipeline_utils/viralrecon.py
@@ -342,8 +342,10 @@ def parse_long_table(files_list, output_folder=None):
                 method_name, "error", f"{files_list_processed} given file is not a file"
             )
             sys.exit(method_log_report.print_log_report(method_name, ["error"]))
-        
-        long_table = LongTableParse(file_path=files_list_processed, output_directory=output_folder)
+
+        long_table = LongTableParse(
+            file_path=files_list_processed, output_directory=output_folder
+        )
         # Parsing long table data and saving it
         long_table_data = long_table.parsing_csv()
         # Saving long table data into a file

--- a/relecov_tools/conf/bioinfo_config.json
+++ b/relecov_tools/conf/bioinfo_config.json
@@ -2,10 +2,11 @@
     "viralrecon": {
         "mapping_stats": {
             "fn": "mapping_illumina(?:_\\d{8})?\\.tab",
-            "sample_col_idx": 5,
+            "sample_col_idx": 2,
             "header_row_idx": 1,
             "required": true,
             "function": null,
+            "split_by_batch": true,
             "content": {
                 "analysis_date": "analysis_date",
                 "depth_of_coverage_value": "medianDPcoveragevirus",
@@ -26,6 +27,7 @@
             "header_row_idx": 1,
             "required": false,
             "function": "handle_pangolin_data",
+            "extract": true,
             "content": {
                 "variant_name": "scorpio_call",
                 "lineage_name": "lineage",
@@ -42,6 +44,7 @@
             "sample_col_idx": 1,
             "header_row_idx": 1,
             "required": true,
+            "split_by_batch": true,
             "function": "parse_long_table",
             "content": {
                 "sample" : "SAMPLE",
@@ -67,6 +70,7 @@
             "fn": ".consensus.fa",
             "required": false,
             "function": "handle_consensus_fasta",
+            "extract": true,
             "content": {
                 "consensus_sequence_name" : "sequence_name",
                 "consensus_genome_length" : "genome_length",
@@ -85,6 +89,13 @@
             "content": {
                 "ns_per_100_kbp": "# Ns per 100kb consensus"
             }
+        },
+        "other_files": {
+            "fn": "^(?!.*tbi$).*.filtered.vcf.gz",
+            "required": false,
+            "function": null,
+            "extract": true,
+            "content": {}
         },
         "workflow_summary": {
             "fn": "multiqc_report.html",

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -310,6 +310,11 @@ class BioinfoMetadata:
             )
             return data
         elif conf_tab_name.endswith(".gz"):
+            self.log_report.update_log_report(
+                method_name,
+                "warning",
+                f".gz files are not supported yet for data extraction: {conf_tab_name}",
+            )
             data = {}
         else:
             self.log_report.update_log_report(

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -71,7 +71,7 @@ class BioinfoReportLog:
 
 
 # TODO: Add method to validate bioinfo_config.json file requirements.
-class BioinfoMetadata():
+class BioinfoMetadata:
     def __init__(
         self,
         readlabmeta_json_file=None,
@@ -117,7 +117,6 @@ class BioinfoMetadata():
         else:
             self.input_folder = input_folder
 
-
         # Parse bioinfo configuration
         self.bioinfo_json_file = os.path.join(
             os.path.dirname(__file__), "conf", "bioinfo_config.json"
@@ -140,7 +139,6 @@ class BioinfoMetadata():
             sys.exit(
                 self.log_report.print_log_report(self.__init__.__name__, ["error"])
             )
-
 
     def get_available_software(self, json):
         """Get list of available software in configuration
@@ -286,7 +284,7 @@ class BioinfoMetadata():
                 continue
         self.log_report.print_log_report(method_name, ["valid", "warning"])
         return j_data_mapped
-    
+
     def handling_tables(self, file_list, conf_tab_name):
         """Reads a tabular file in different formats and returns a dictionary containing
         the corresponding data for each sample.
@@ -306,7 +304,9 @@ class BioinfoMetadata():
         extdict = {".csv": ",", ".tsv": "\t", ".tab": "\t"}
         if file_ext in extdict.keys():
             data = relecov_tools.utils.read_csv_file_return_dict(
-                file_name=file_list[0], sep=extdict.get(file_ext), key_position=sample_idx_colpos
+                file_name=file_list[0],
+                sep=extdict.get(file_ext),
+                key_position=sample_idx_colpos,
             )
             return data
         elif conf_tab_name.endswith(".gz"):
@@ -321,8 +321,8 @@ class BioinfoMetadata():
         return data
 
     def handling_files(self, file_list, output_folder):
-        """Handles different file formats to extract data regardless of their structure. 
-        The goal is to extract the data contained in files specified in ${file_list}, 
+        """Handles different file formats to extract data regardless of their structure.
+        The goal is to extract the data contained in files specified in ${file_list},
         using either 'standard' handlers defined in this class or pipeline-specific file handlers.
         (inspired from ./metadata_homogenizer.py)
 
@@ -340,8 +340,8 @@ class BioinfoMetadata():
                 },
                 ...
             }
-            Note: ensure that 'field1','field2','field3' corresponds with the values 
-            especified in the 'content' section of each software configuration scope 
+            Note: ensure that 'field1','field2','field3' corresponds with the values
+            especified in the 'content' section of each software configuration scope
             (see: conf/bioinfo_config.json).
 
         Args:
@@ -618,10 +618,10 @@ class BioinfoMetadata():
                 row[path_key] = file_path
                 if self.software_config[key].get("extract"):
                     self.extract_file(
-                        file=file_path, 
+                        file=file_path,
                         dest_folder=row.get("r1_fastq_filepath"),
                         sample_name=sample_name,
-                        path_key=path_key
+                        path_key=path_key,
                     )
         self.log_report.print_log_report(method_name, ["warning"])
         if sample_name_error == 0:
@@ -675,7 +675,7 @@ class BioinfoMetadata():
 
         Args:
             file (str): Path the file that is going to be copied
-            dest_folder (str): Folder with files from batch of samples 
+            dest_folder (str): Folder with files from batch of samples
             sample_name (str, optional): Name of the sample in metadata. Defaults to None.
             path_key (str, optional): Metadata field for the file. Defaults to None.
 
@@ -691,20 +691,18 @@ class BioinfoMetadata():
             self.log_report.update_log_report(
                 self.extract_file.__name__,
                 "warning",
-                 f'File for {path_key} not provided in sample {sample_name}',
+                f"File for {path_key} not provided in sample {sample_name}",
             )
             return False
         try:
             shutil.copy(file, out_filepath)
         except (IOError, PermissionError) as e:
             self.log_report.update_log_report(
-                self.extract_file.__name__,
-                "warning",
-                f"Could not extract {file}: {e}"
+                self.extract_file.__name__, "warning", f"Could not extract {file}: {e}"
             )
             return False
         return True
-    
+
     def split_data_by_batch(self, j_data):
         """Split metadata from json for each batch of samples found according to folder location of the samples.
 
@@ -713,7 +711,7 @@ class BioinfoMetadata():
             j_data (list(dict)): List of dictionaries, one per sample, including metadata for that sample
 
         Returns:
-            data_by_batch (dict(list(dict))): Dictionary containing parts of j_data corresponding to each 
+            data_by_batch (dict(list(dict))): Dictionary containing parts of j_data corresponding to each
             different folder with samples (batch) included in the original json metadata used as input
         """
         unique_batchs = set([x.get("r1_fastq_filepath") for x in j_data])
@@ -732,6 +730,7 @@ class BioinfoMetadata():
             batch_data (list(dict)): Metadata corresponding to a single folder with samples (folder)
             output_dir (str): Output location for the generated tabular file
         """
+
         def extract_batch_rows_to_file(file):
             """Create a new table file only with rows matching samples in batch_data"""
             file_extension = os.path.splitext(file)[1]
@@ -746,6 +745,7 @@ class BioinfoMetadata():
             )
             file_df.to_csv(output_path, index=False, sep=extdict.get(file_extension))
             return
+
         method_name = self.split_tables_by_batch.__name__
         namekey = "sequencing_sample_id"
         batch_samples = [row.get(namekey) for row in batch_data]
@@ -766,7 +766,7 @@ class BioinfoMetadata():
                     self.log_report.update_log_report(
                         method_name,
                         log_type,
-                        f"Could not create batch table for {file}: {e}"
+                        f"Could not create batch table for {file}: {e}",
                     )
         self.log_report.print_log_report(method_name, ["valid", "warning", "error"])
         return

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -4,10 +4,13 @@ import sys
 import logging
 import rich.console
 import re
+import shutil
 from bs4 import BeautifulSoup
 
+import pandas as pd
 import relecov_tools.utils
 from relecov_tools.config_json import ConfigJson
+from relecov_tools.log_summary import LogSum
 
 log = logging.getLogger(__name__)
 stderr = rich.console.Console(
@@ -19,11 +22,12 @@ stderr = rich.console.Console(
 
 
 class BioinfoReportLog:
-    def __init__(self, log_report=None):
+    def __init__(self, log_report=None, output_folder="/tmp/"):
         if not log_report:
             self.report = {"error": {}, "valid": {}, "warning": {}}
         else:
             self.report = log_report
+        self.logsum = LogSum(output_location=output_folder)
 
     def update_log_report(self, method_name, status, message):
         """Update the progress log report with the given method name, status, and message.
@@ -44,9 +48,11 @@ class BioinfoReportLog:
             return self.report
         elif status == "error":
             self.report["error"].setdefault(method_name, []).append(message)
+            self.logsum.add_error(key=method_name, entry=message)
             return self.report
         elif status == "warning":
             self.report["warning"].setdefault(method_name, []).append(message)
+            self.logsum.add_warning(key=method_name, entry=message)
             return self.report
         else:
             raise ValueError("Invalid status provided.")
@@ -65,7 +71,7 @@ class BioinfoReportLog:
 
 
 # TODO: Add method to validate bioinfo_config.json file requirements.
-class BioinfoMetadata(BioinfoReportLog):
+class BioinfoMetadata():
     def __init__(
         self,
         readlabmeta_json_file=None,
@@ -74,8 +80,13 @@ class BioinfoMetadata(BioinfoReportLog):
         software=None,
     ):
         # Init process log
-        super().__init__()
-        self.log_report = BioinfoReportLog()
+        if output_folder is None:
+            self.output_folder = relecov_tools.utils.prompt_path(
+                msg="Select the output folder"
+            )
+        else:
+            self.output_folder = os.path.realpath(output_folder)
+        self.log_report = BioinfoReportLog(output_folder=output_folder)
 
         # Parse read-lab-meta-data
         if readlabmeta_json_file is None:
@@ -92,7 +103,8 @@ class BioinfoMetadata(BioinfoReportLog):
                 self.log_report.print_log_report(self.__init__.__name__, ["error"])
             )
         self.readlabmeta_json_file = readlabmeta_json_file
-
+        meta_basename = os.path.basename(self.readlabmeta_json_file).split(".")[0]
+        self.out_filename = "bioinfo_" + meta_basename + ".json"
         # Initialize j_data object
         stderr.print("[blue]Reading lab metadata json")
         self.j_data = self.collect_info_from_lab_json()
@@ -104,12 +116,7 @@ class BioinfoMetadata(BioinfoReportLog):
             )
         else:
             self.input_folder = input_folder
-        if output_folder is None:
-            self.output_folder = relecov_tools.utils.prompt_path(
-                msg="Select the output folder"
-            )
-        else:
-            self.output_folder = output_folder
+
 
         # Parse bioinfo configuration
         self.bioinfo_json_file = os.path.join(
@@ -134,6 +141,7 @@ class BioinfoMetadata(BioinfoReportLog):
                 self.log_report.print_log_report(self.__init__.__name__, ["error"])
             )
 
+
     def get_available_software(self, json):
         """Get list of available software in configuration
 
@@ -154,9 +162,14 @@ class BioinfoMetadata(BioinfoReportLog):
             files_found: A dictionary containing file paths found based on the definitions provided in the bioinformatic JSON file within the software scope (self.software_config).
         """
         method_name = f"{self.scann_directory.__name__}"
-        total_files = sum(len(files) for _, _, files in os.walk(self.input_folder))
+        total_files = 0
         files_found = {}
-
+        all_scanned_things = []
+        for root, dirs, files in os.walk(self.input_folder, topdown=True):
+            # Skipping nextflow's work junk directory
+            dirs[:] = [d for d in dirs if "work" not in root.split("/")]
+            total_files = total_files + len(files)
+            all_scanned_things.append((root, files))
         for topic_key, topic_scope in self.software_config.items():
             if "fn" not in topic_scope:  # try/except fn
                 self.log_report.update_log_report(
@@ -165,14 +178,15 @@ class BioinfoMetadata(BioinfoReportLog):
                     f"No 'fn' (file pattern) found in '{self.software_name}.{topic_key}'.",
                 )
                 continue
-            for root, _, files in os.walk(self.input_folder, topdown=True):
+            for tup in all_scanned_things:
                 matching_files = [
-                    os.path.join(root, file_name)
-                    for file_name in files
+                    os.path.join(tup[0], file_name)
+                    for file_name in tup[1]
                     if re.search(topic_scope["fn"], file_name)
                 ]
                 if len(matching_files) >= 1:
                     files_found[topic_key] = matching_files
+                    break
         if len(files_found) < 1:
             self.log_report.update_log_report(
                 method_name,
@@ -184,7 +198,7 @@ class BioinfoMetadata(BioinfoReportLog):
             self.log_report.update_log_report(
                 self.scann_directory.__name__,
                 "valid",
-                f"Scannig process succeed. Scanned {total_files} files.",
+                f"Scanning process succeed. Scanned {total_files} files.",
             )
             self.log_report.print_log_report(method_name, ["valid", "warning"])
             return files_found
@@ -220,15 +234,15 @@ class BioinfoMetadata(BioinfoReportLog):
         self.log_report.print_log_report(method_name, ["valid", "warning"])
         return
 
-    def add_bioinfo_results_metadata(self, files_dict, j_data):
+    def add_bioinfo_results_metadata(self, files_dict, j_data, output_folder=None):
         """Adds metadata from bioinformatics results to j_data.
         It first calls file_handlers and then maps the handled
         data into j_data.
 
         Args:
             files_dict (dict{str:str}): A dictionary containing file paths found based on the definitions provided in the bioinformatic JSON file within the software scope (self.software_config).
-
             j_data (list(dict{str:str}): A list of dictionaries containing metadata lab (list item per sample).
+            output_folder (str): Path to save output files generated during handling_files() process.
 
         Returns:
             j_data_mapped: A list of dictionaries with bioinformatics metadata mapped into j_data.
@@ -251,8 +265,11 @@ class BioinfoMetadata(BioinfoReportLog):
                 )
                 continue
             # Handling files
-            data_to_map = self.handling_files(files_dict[key])
+            data_to_map = self.handling_files(files_dict[key], output_folder)
             # Mapping data to j_data
+            mapping_fields = self.software_config[key].get("content")
+            if not mapping_fields:
+                continue
             if data_to_map:
                 j_data_mapped = self.mapping_over_table(
                     j_data=j_data,
@@ -269,9 +286,44 @@ class BioinfoMetadata(BioinfoReportLog):
                 continue
         self.log_report.print_log_report(method_name, ["valid", "warning"])
         return j_data_mapped
+    
+    def handling_tables(self, file_list, conf_tab_name):
+        """Reads a tabular file in different formats and returns a dictionary containing
+        the corresponding data for each sample.
 
-    def handling_files(self, file_list):
-        """Handles different file formats to extract data regardless of their structure. The goal is to extract the data contained in files specified in ${file_list}, using either 'standard' handlers defined in this class or pipeline-specific file handlers.
+        Args:
+            file_list (list): A list of file path/s to be processed.
+            conf_tab_name (str): Name of the table in the defined config file.
+
+        Returns:
+            data (dict): A dictionary containing metadata as defined in handling_files.
+        """
+        method_name = f"{self.add_bioinfo_results_metadata.__name__}:{self.handling_tables.__name__}"
+        file_ext = os.path.splitext(conf_tab_name)[1]
+        # Parsing key position
+        sample_idx_colpos = self.get_sample_idx_colpos(self.current_config_key)
+        # TODO: What if you need to process one table for each sample?
+        extdict = {".csv": ",", ".tsv": "\t", ".tab": "\t"}
+        if file_ext in extdict.keys():
+            data = relecov_tools.utils.read_csv_file_return_dict(
+                file_name=file_list[0], sep=extdict.get(file_ext), key_position=sample_idx_colpos
+            )
+            return data
+        elif conf_tab_name.endswith(".gz"):
+            data = {}
+        else:
+            self.log_report.update_log_report(
+                method_name,
+                "error",
+                f"Unrecognized defined file name extension '{file_ext}' in '{conf_tab_name}'.",
+            )
+            sys.exit(self.log_report.print_log_report(method_name, ["error"]))
+        return data
+
+    def handling_files(self, file_list, output_folder):
+        """Handles different file formats to extract data regardless of their structure. 
+        The goal is to extract the data contained in files specified in ${file_list}, 
+        using either 'standard' handlers defined in this class or pipeline-specific file handlers.
         (inspired from ./metadata_homogenizer.py)
 
             A file handler method must generate a data structure as follow:
@@ -288,57 +340,31 @@ class BioinfoMetadata(BioinfoReportLog):
                 },
                 ...
             }
-            Note: ensure that 'field1','field2','field3' corresponds with the values especifies in the 'content' section of each software configuration scope (see: conf/bioinfo_config.json).
+            Note: ensure that 'field1','field2','field3' corresponds with the values 
+            especified in the 'content' section of each software configuration scope 
+            (see: conf/bioinfo_config.json).
 
         Args:
             file_list (list): A list of file path/s to be processed.
+            output_folder (str): Path to save output files from imported method if necessary
 
         Returns:
             data: A dictionary containing bioinfo metadata handled for each sample.
         """
         method_name = f"{self.add_bioinfo_results_metadata.__name__}:{self.handling_files.__name__}"
         file_name = self.software_config[self.current_config_key].get("fn")
-        file_extension = os.path.splitext(file_name)[1]
-        # Parsing key position
-        try:
-            self.software_config[self.current_config_key]["sample_col_idx"]
-            sample_idx_possition = (
-                self.software_config[self.current_config_key]["sample_col_idx"] - 1
-            )
-        except KeyError:
-            sample_idx_possition = None
-            self.log_report.update_log_report(
-                method_name,
-                "warning",
-                f"No sample-index-column defined in '{self.software_name}.{self.current_config_key}'. Using default instead.",
-            )
         # Parsing files
         func_name = self.software_config[self.current_config_key]["function"]
         if func_name is None:
-            if file_name.endswith(".csv"):
-                data = relecov_tools.utils.read_csv_file_return_dict(
-                    file_name=file_list[0], sep=",", key_position=sample_idx_possition
-                )
-                return data
-            elif file_name.endswith(".tsv") or file_name.endswith(".tab"):
-                data = relecov_tools.utils.read_csv_file_return_dict(
-                    file_name=file_list[0], sep="\t", key_position=sample_idx_possition
-                )
-            else:
-                self.log_report.update_log_report(
-                    method_name,
-                    "error",
-                    f"Unrecognized defined file name extension '{file_extension}' in '{file_name}'.",
-                )
-                sys.exit(self.log_report.print_log_report(method_name, ["error"]))
+            data = self.handling_tables(file_list=file_list, conf_tab_name=file_name)
         else:
             try:
                 # Dynamically import the function from the specified module
                 utils_name = f"relecov_tools.assets.pipeline_utils.{self.software_name}"
-                import_statement = f"from {utils_name} import {func_name}"
+                import_statement = f"import {utils_name}"
                 exec(import_statement)
                 # Get method name and execute it.
-                data = eval(func_name + "(file_list)")
+                data = eval(utils_name + "." + func_name + "(file_list, output_folder)")
             except Exception as e:
                 self.log_report.update_log_report(
                     self.add_bioinfo_results_metadata.__name__,
@@ -367,16 +393,14 @@ class BioinfoMetadata(BioinfoReportLog):
         for row in j_data:
             # TODO: We should consider an independent module that verifies that sample's name matches this pattern.
             #       If we add warnings within this module, every time mapping_over_table is invoked it will print redundant warings
-            sample_match = re.match(r"^[^_]+", row["sequence_file_R1_fastq"])
-            if sample_match:
-                sample_name = sample_match.group()
-            else:
+            if not row.get("sequencing_sample_id"):
                 self.log_report.update_log_report(
                     method_name,
                     "warning",
-                    f'Regex failed to find extract sample name from: {row["sequence_file_R1_fastq"]}. Skipping...',
+                    f'Sequencing_sample_id missing in {row.get("collecting_sample_id")}... Skipping...',
                 )
                 continue
+            sample_name = row["sequencing_sample_id"]
             if sample_name in map_data.keys():
                 for field, value in mapping_fields.items():
                     try:
@@ -485,17 +509,14 @@ class BioinfoMetadata(BioinfoReportLog):
         field_errors = {}
         for row in j_data:
             # Get sample name to track whether version assignment was successful or not.
-            sample_match = re.match(r"^[^_]+", row["sequence_file_R1_fastq"])
-            if sample_match:
-                sample_name = sample_match.group()
-            else:
+            if not row.get("sequencing_sample_id"):
                 self.log_report.update_log_report(
                     method_name,
                     "warning",
-                    f'Regex failed to find extract sample name from: {row["sequence_file_R1_fastq"]}. Skipping...',
+                    f'Sequencing_sample_id missing in {row.get("collecting_sample_id")}... Skipping...',
                 )
                 continue
-
+            sample_name = row["sequencing_sample_id"]
             # Append software version and name
             software_content_details = self.software_config["workflow_summary"].get(
                 "content"
@@ -546,6 +567,7 @@ class BioinfoMetadata(BioinfoReportLog):
         try:
             f_values = self.software_config["fixed_values"]
             for row in j_data:
+                row["bioinfo_metadata_file"] = self.out_filename
                 for field, value in f_values.items():
                     row[field] = value
             self.log_report.update_log_report(
@@ -576,27 +598,31 @@ class BioinfoMetadata(BioinfoReportLog):
         method_name = f"{self.add_bioinfo_files_path.__name__}"
         sample_name_error = 0
         for row in j_data:
-            sample_match = re.match(r"^[^_]+", row["sequence_file_R1_fastq"])
-            if sample_match:
-                sample_name = sample_match.group()
-            else:
+            row["bioinfo_metadata_file"] = self.out_filename
+            if not row.get("sequencing_sample_id"):
                 self.log_report.update_log_report(
                     method_name,
                     "warning",
-                    f'Regex failed to find extract sample name from: {row["sequence_file_R1_fastq"]}. Skipping...',
+                    f'Sequencing_sample_id missing in {row.get("collecting_sample_id")}... Skipping...',
                 )
                 continue
-            for key, value in files_found_dict.items():
+            sample_name = row["sequencing_sample_id"]
+            for key, values in files_found_dict.items():
                 file_path = "Not Provided [GENEPIO:0001668]"
-                if value:  # Check if value is not empty
-                    for file in value:
+                if values:  # Check if value is not empty
+                    for file in values:
                         if sample_name in file:
                             file_path = file
                             break  # Exit loop if match found
-                else:
-                    file_path = value[0]
                 path_key = f"{self.software_name}_filepath_{key}"
                 row[path_key] = file_path
+                if self.software_config[key].get("extract"):
+                    self.extract_file(
+                        file=file_path, 
+                        dest_folder=row.get("r1_fastq_filepath"),
+                        sample_name=sample_name,
+                        path_key=path_key
+                    )
         self.log_report.print_log_report(method_name, ["warning"])
         if sample_name_error == 0:
             self.log_report.update_log_report(
@@ -627,6 +653,124 @@ class BioinfoMetadata(BioinfoReportLog):
             sys.exit(self.log_report.print_log_report(method_name, ["error"]))
         return json_lab_data
 
+    def get_sample_idx_colpos(self, config_key):
+        """Extract which column contain sample names for that specific file from config
+
+        Returns:
+            sample_idx_possition: column number which contains sample names
+        """
+        try:
+            sample_idx_colpos = self.software_config[config_key]["sample_col_idx"] - 1
+        except (KeyError, TypeError):
+            sample_idx_colpos = 0
+            self.log_report.update_log_report(
+                "get_sample_idx_colpos",
+                "warning",
+                f"No valid sample-index-column defined in '{self.software_name}.{config_key}'. Using default instead.",
+            )
+        return sample_idx_colpos
+
+    def extract_file(self, file, dest_folder, sample_name=None, path_key=None):
+        """Copy input file to the given destination, include sample name and key in log
+
+        Args:
+            file (str): Path the file that is going to be copied
+            dest_folder (str): Folder with files from batch of samples 
+            sample_name (str, optional): Name of the sample in metadata. Defaults to None.
+            path_key (str, optional): Metadata field for the file. Defaults to None.
+
+        Returns:
+            bool: True if the process was successful, else False
+        """
+        dest_folder = os.path.join(dest_folder, "analysis_results")
+        os.makedirs(dest_folder, exist_ok=True)
+        out_filepath = os.path.join(dest_folder, os.path.basename(file))
+        if os.path.isfile(out_filepath):
+            return True
+        if file == "Not Provided [GENEPIO:0001668]":
+            self.log_report.update_log_report(
+                self.extract_file.__name__,
+                "warning",
+                 f'File for {path_key} not provided in sample {sample_name}',
+            )
+            return False
+        try:
+            shutil.copy(file, out_filepath)
+        except (IOError, PermissionError) as e:
+            self.log_report.update_log_report(
+                self.extract_file.__name__,
+                "warning",
+                f"Could not extract {file}: {e}"
+            )
+            return False
+        return True
+    
+    def split_data_by_batch(self, j_data):
+        """Split metadata from json for each batch of samples found according to folder location of the samples.
+
+        Args:
+            files_found_dict (dict): A dictionary containing file paths identified for each configuration item.
+            j_data (list(dict)): List of dictionaries, one per sample, including metadata for that sample
+
+        Returns:
+            data_by_batch (dict(list(dict))): Dictionary containing parts of j_data corresponding to each 
+            different folder with samples (batch) included in the original json metadata used as input
+        """
+        unique_batchs = set([x.get("r1_fastq_filepath") for x in j_data])
+        data_by_batch = {batch_dir: {} for batch_dir in unique_batchs}
+        for batch_dir in data_by_batch.keys():
+            data_by_batch[batch_dir]["j_data"] = [
+                samp for samp in j_data if samp.get("r1_fastq_filepath") == batch_dir
+            ]
+        return data_by_batch
+
+    def split_tables_by_batch(self, files_found_dict, batch_data, output_dir):
+        """Filter table content to output a new table containing only the samples present in given metadata
+
+        Args:
+            files_found_dict (dict): A dictionary containing file paths identified for each configuration item.
+            batch_data (list(dict)): Metadata corresponding to a single folder with samples (folder)
+            output_dir (str): Output location for the generated tabular file
+        """
+        def extract_batch_rows_to_file(file):
+            """Create a new table file only with rows matching samples in batch_data"""
+            file_extension = os.path.splitext(file)[1]
+            file_df = pd.read_csv(
+                file, sep=extdict.get(file_extension), header=header_pos
+            )
+            sample_col = file_df.columns[sample_colpos]
+            file_df[sample_col] = file_df[sample_col].astype(str)
+            file_df = file_df[file_df[sample_col].isin(batch_samples)]
+            output_path = os.path.join(
+                output_dir, "analysis_results", os.path.basename(file)
+            )
+            file_df.to_csv(output_path, index=False, sep=extdict.get(file_extension))
+            return
+        method_name = self.split_tables_by_batch.__name__
+        namekey = "sequencing_sample_id"
+        batch_samples = [row.get(namekey) for row in batch_data]
+        extdict = {".csv": ",", ".tsv": "\t", ".tab": "\t"}
+        for key, files in files_found_dict.items():
+            if not self.software_config[key].get("split_by_batch"):
+                continue
+            header_pos = self.software_config[key].get("header_row_idx", 1) - 1
+            sample_colpos = self.get_sample_idx_colpos(key)
+            for file in files:
+                try:
+                    extract_batch_rows_to_file(file)
+                except Exception as e:
+                    if self.software_config[key].get("required"):
+                        log_type = "error"
+                    else:
+                        log_type = "warning"
+                    self.log_report.update_log_report(
+                        method_name,
+                        log_type,
+                        f"Could not create batch table for {file}: {e}"
+                    )
+        self.log_report.print_log_report(method_name, ["valid", "warning", "error"])
+        return
+
     def create_bioinfo_file(self):
         """Create the bioinfodata json with collecting information from lab
         metadata json, mapping_stats, and more information from the files
@@ -636,31 +780,44 @@ class BioinfoMetadata(BioinfoReportLog):
             bool: True if the bioinfo file creation process was successful.
         """
         # Find and validate bioinfo files
-        stderr.print("[blue]Sanning input directory...")
+        stderr.print("[blue]Scanning input directory...")
         files_found_dict = self.scann_directory()
         stderr.print("[blue]Validating required files...")
         self.validate_software_mandatory_files(files_found_dict)
+        # Split files found based on each batch of samples
+        data_by_batch = self.split_data_by_batch(self.j_data)
         # Add bioinfo metadata to j_data
-        stderr.print("[blue]Adding bioinfo metadata to read lab metadata...")
-        self.j_data = self.add_bioinfo_results_metadata(files_found_dict, self.j_data)
-        stderr.print("[blue]Adding software versions to read lab metadata...")
-        self.j_data = self.get_multiqc_software_versions(
-            files_found_dict["workflow_summary"], self.j_data
-        )
-        stderr.print("[blue]Adding fixed values")
-        self.j_data = self.add_fixed_values(self.j_data)
-        # Adding files path
-        stderr.print("[blue]Adding files path to read lab metadata")
-        self.j_data = self.add_bioinfo_files_path(files_found_dict, self.j_data)
-        # Generate readlab + bioinfolab processed metadata.
-        file_name = (
-            "bioinfo_"
-            + os.path.splitext(os.path.basename(self.readlabmeta_json_file))[0]
-            + ".json"
-        )
+        for batch_dir, batch_dict in data_by_batch.items():
+            stderr.print(f"[blue]Processing data from {batch_dir}")
+            batch_data = batch_dict["j_data"]
+            stderr.print("[blue]Adding bioinfo metadata to read lab metadata...")
+            batch_data = self.add_bioinfo_results_metadata(
+                files_found_dict, batch_data, batch_dir
+            )
+            stderr.print("[blue]Adding software versions to read lab metadata...")
+            batch_data = self.get_multiqc_software_versions(
+                files_found_dict["workflow_summary"], batch_data
+            )
+            stderr.print("[blue]Adding fixed values")
+            batch_data = self.add_fixed_values(batch_data)
+            # Adding files path
+            stderr.print("[blue]Adding files path to read lab metadata")
+            batch_data = self.add_bioinfo_files_path(files_found_dict, batch_data)
+            self.split_tables_by_batch(files_found_dict, batch_data, batch_dir)
+            lab_code = batch_dir.split("/")[-2]
+            batch_date = batch_dir.split("/")[-1]
+            tag = "bioinfo_lab_metadata_"
+            batch_filename = tag + lab_code + "_" + batch_date + ".json"
+            batch_filepath = os.path.join(batch_dir, batch_filename)
+            relecov_tools.utils.write_json_fo_file(batch_data, batch_filepath)
+            log.info("Created output json file: %s" % batch_filepath)
+            stderr.print(f"[green]Created batch json file: {batch_filepath}")
         stderr.print("[blue]Writting output json file")
         os.makedirs(self.output_folder, exist_ok=True)
-        file_path = os.path.join(self.output_folder, file_name)
+        file_path = os.path.join(self.output_folder, self.out_filename)
         relecov_tools.utils.write_json_fo_file(self.j_data, file_path)
-        stderr.print("[green]Sucessful creation of bioinfo analyis file")
+        stderr.print(f"[green]Sucessful creation of bioinfo analyis file: {file_path}")
+        self.log_report.logsum.create_error_summary(
+            called_module="read-bioinfo-metadata", logs=self.log_report.logsum.logs
+        )
         return True

--- a/relecov_tools/utils.py
+++ b/relecov_tools/utils.py
@@ -14,6 +14,7 @@ import yaml
 import gzip
 import re
 import shutil
+import csv
 from itertools import islice
 from Bio import SeqIO
 from rich.console import Console
@@ -92,16 +93,22 @@ def read_excel_file(f_name, sheet_name, header_flag, leave_empty=True):
     return ws_data, heading_row
 
 
-def read_csv_file_return_dict(file_name, sep, key_position=None):
+def read_csv_file_return_dict(file_name, sep=None, key_position=None):
     """Read csv or tsv file, according to separator, and return a dictionary
     where the main key is the first column, if key position is None otherwise
-    the index value of the key position is used as key
+    the index value of the key position is used as key. If sep is None then
+    try to assert a separator automaticallly depending on file extension.
     """
     try:
         with open(file_name, "r") as fh:
             lines = fh.readlines()
     except FileNotFoundError:
         raise
+    if sep is None:
+        file_extension = os.path.splitext(file_name)[1]
+        extdict = {".csv": ",", ".tsv": "\t", ".tab": "\t"}
+        # Use space as a default separator, None would also be valid
+        sep = extdict.get(file_extension, " ")
     heading = lines[0].strip().split(sep)
     if len(heading) == 1:
         return {"ERROR": "not valid format"}
@@ -410,7 +417,7 @@ def print_log_report(
         tabulate(
             table_data,
             headers=["Log type", "Category", "Message"],
-            tablefmt="fancy_grid",
+            tablefmt="presto",
         )
     )
 

--- a/relecov_tools/utils.py
+++ b/relecov_tools/utils.py
@@ -334,7 +334,7 @@ def get_file_date(file_path):
         # Convert the modification time to a datetime object
         file_date = datetime.fromtimestamp(mtime)
         # Format date
-        formatted_date = file_date.strftime("%Y/%m/%d")
+        formatted_date = file_date.strftime("%Y%m%d")
         return formatted_date
     except FileNotFoundError:
         # Handle file not found error

--- a/relecov_tools/utils.py
+++ b/relecov_tools/utils.py
@@ -14,7 +14,6 @@ import yaml
 import gzip
 import re
 import shutil
-import csv
 from itertools import islice
 from Bio import SeqIO
 from rich.console import Console
@@ -264,6 +263,22 @@ def compress_file(file):
         return True
     except FileNotFoundError:
         return False
+
+
+def check_gzip_integrity(file_path):
+    """Check if a compressed file is not corrupted"""
+    chunksize = 100000000  # 10 Mbytes
+    with gzip.open(file_path, "rb") as f:
+        try:
+            while f.read(chunksize) != b"":
+                pass
+        except gzip.BadGzipFile:
+            # Not a gzip file
+            return False
+        # EOFError: Compressed file is truncated
+        except EOFError:
+            return False
+    return True
 
 
 def rich_force_colors():


### PR DESCRIPTION
In-depth description:

- Now before starting with data processing, `j_data` is separated into smaller copies, according to `r1_fastq_filepath` unique values found in the samples and all the process is iterated over each of these set of samples.
- `output_folder` is now a mandatory arg to include in each method called by the auxiliar script (in this case `viralrecon.py`). This was needed in order to extract `long_table*.json ` file to its respective batch folder
- `handling_tables()` is a now separated from `handling_files()` as an independent method, just for readability
- Changed file pattern matching to `sequencing_sample_id` as now `pipeline_manager` names files using that field.
- Each validated file is now extracted during `add_bioinfo_files_path()`
- Included two new fields in `bioinfo_config.json`: "extract" and "split_by_batch"
- `"extract"` should be set to true for those files in the config key that need to be copied to the original folder with samples
- `"split_by_batch"` indicates those tables that have information for all the samples, and should be split into smaller copies of the table only with the samples for each batch into their respective folder.
- These two fields are used as markers for the new methods: `extract_file()` and `split_table_by_batch()`

Other changes:
- Now a json file with process logs is created using `LogSum` class from `log_summary.py`
- Reduced scann_directory() time consumption by simplifying os.walk() to be executed only one time
- `read_csv_file_return_dict` from `utils.py` now tries to detect separator using file extension if no `sep` argument is given

`test_modules.yml `workflow actions will fail until we update the version for `upload-artifact` used in them. I'll include it in the next PR