### PR TITLE
Pre-release 1.1.0. Includes fixing github actions

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,8 +1,9 @@
 name: Publish package python distribution to Pypi
 
 on:
-  push:
-    branches: "main"
+  release:
+    types: [published]
+  workflow_dispatch:
 
 jobs:
     build:
@@ -23,14 +24,13 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
 
     publish-to-pypi:
       name: Publish dist to PyPI
-      if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
       needs:
       - build
       runs-on: ubuntu-latest
@@ -41,7 +41,7 @@ jobs:
         id-token: write
       steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
@@ -58,7 +58,7 @@ jobs:
           id-token: write
         steps:
         - name: Download all the dists
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@v4
           with:
             name: python-package-distributions
             path: dist/

--- a/.github/workflows/test_modules.yml
+++ b/.github/workflows/test_modules.yml
@@ -34,7 +34,7 @@ jobs:
       env:
         OUTPUT_LOCATION: ${{ github.workspace }}/tests/
     - name: Upload output file
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: test-output
         path: output.txt
@@ -73,7 +73,7 @@ jobs:
       env:
         OUTPUT_LOCATION: ${{ github.workspace }}/tests/
     - name: Upload output file
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: test-output
         path: output.txt

--- a/.github/workflows/test_sftp_handle.yml
+++ b/.github/workflows/test_sftp_handle.yml
@@ -24,9 +24,18 @@ jobs:
         echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
         echo "Job originally triggered by ${{ github.actor }}"
         exit 1
+
+  sleep_to_ensure_concurrency:
+    needs: security_check
+    runs-on: ubuntu-latest
+    steps:
+    - name: 
+      run: sleep 10s
+      shell: bash
       
   test_sftp_handle:
-    needs: security_check
+    needs: [security_check, sleep_to_ensure_concurrency]
+    if: github.repository_owner == 'BU-ISCIII'
     concurrency:
       group: ${{ github.repository }}-test_sftp_handle
       cancel-in-progress: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0dev] - 2024-09-0X : https://github.com/BU-ISCIII/relecov-tools/releases/tag/1.1.0
+## [1.X.Xdev] - 2024-XX-XX : https://github.com/BU-ISCIII/relecov-tools/releases/tag/1.1.0
+
+### Credits
+
+Code contributions to the hotfix:
+
+### Modules
+
+#### Added enhancements
+
+#### Fixes
+
+#### Changed
+
+#### Removed
+
+### Requirements
+
+## [1.1.0] - 2024-09-13 : https://github.com/BU-ISCIII/relecov-tools/releases/tag/1.1.0
 
 ### Credits
 
@@ -22,12 +40,16 @@ Code contributions to the hotfix:
 - Included a way to extract pango-designation version in read-bioinfo-metadata [#299](https://github.com/BU-ISCIII/relecov-tools/pull/299)
 - Now log_summary.py also creates an excel file with the process logs [#300](https://github.com/BU-ISCIII/relecov-tools/pull/300)
 - Read-bioinfo-metadata splits files and data by batch of samples [#306](https://github.com/BU-ISCIII/relecov-tools/pull/306)
+- Included a sleep time in test_sftp-handle to avoid concurrency check failure [#308](https://github.com/BU-ISCIII/relecov-tools/pull/308)
 
 #### Fixes
 
 - Fixes in launch_pipeline including creation of samples_id.txt and joined validated json [#303](https://github.com/BU-ISCIII/relecov-tools/pull/303)
+- Fixed failing module_tests.yml workflow due to deprecated upload-artifact version [#308](https://github.com/BU-ISCIII/relecov-tools/pull/308)
 
 #### Changed
+
+- Changed pypi_publish action to publish on every release, no need to push tags [#308](https://github.com/BU-ISCIII/relecov-tools/pull/308)
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.X.Xdev] - 2024-XX-XX : https://github.com/BU-ISCIII/relecov-tools/releases/tag/1.1.0
+## [1.X.Xdev] - 2024-XX-XX : https://github.com/BU-ISCIII/relecov-tools/releases/tag/1.X.X
 
 ### Credits
 

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -61,7 +61,7 @@ def run_relecov_tools():
     )
 
     # stderr.print("[green]                                          `._,._,'\n", highlight=False)
-    __version__ = "1.1.0dev"
+    __version__ = "1.1.0"
     stderr.print(
         "\n" "[grey39]    RELECOV-tools version {}".format(__version__), highlight=False
     )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = "1.0.0"
+version = "1.1.0"
 
 with open("README.md") as f:
     readme = f.read()


### PR DESCRIPTION
This PR prepares for release 1.1.0

- Included a sleep time in test_sftp-handle to avoid concurrency check failure (sometimes a process would start even though another one was active)
- Fixed failing module_tests.yml workflow due to deprecated upload-artifact version
- Changed pypi_publish action to publish on every release, no need to push tags anymore

