### PR TITLE
Hotfix for download_manager & enhancements for pipeline-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.0] - 2024-09-XX : https://github.com/BU-ISCIII/relecov-tools/releases/tag/1.2.0
+## [1.2.0] - 2024-09-0X : https://github.com/BU-ISCIII/relecov-tools/releases/tag/1.2.0
 
 ### Credits
 
@@ -16,6 +16,8 @@ Code contributions to the release:
 
 ### Modules
 
+- Included wrapper module to launch download, read-lab-metadata and validate processes sequentially 
+
 #### Added enhancements
 
 - Now also check for gzip file integrity after download. Moved cleaning process to end of workflow [#313](https://github.com/BU-ISCIII/relecov-tools/pull/313)
@@ -24,10 +26,14 @@ Code contributions to the release:
 - samples_data json file is no longer mandatory as input in read-lab-metadata [#314](https://github.com/BU-ISCIII/relecov-tools/pull/314)
 - Included handling of alternative column names to support two distinct headers using the same schema in read-lab-metadata [#314](https://github.com/BU-ISCIII/relecov-tools/pull/314)
 - Included a new hospital (Hospital Universitario Araba) to laboratory_address.json [#315](https://github.com/BU-ISCIII/relecov-tools/pull/315) 
+- More accurate cleaning process, skipping only sequencing files instead of whole folder [#321](https://github.com/BU-ISCIII/relecov-tools/pull/321)
+- Now single logs summaries are also created for each folder during download [#321](https://github.com/BU-ISCIII/relecov-tools/pull/321)
+- Introduced handling for missing/dup files and more accurate information in prompt for pipeline_manager [#321](https://github.com/BU-ISCIII/relecov-tools/pull/321)
 
 #### Fixes
 
 - Fixed wrong city name in relecov_tools/conf/laboratory_address.json [#320](https://github.com/BU-ISCIII/relecov-tools/pull/320)
+- Fixed wrong single-paired layout detection in metadata due to Capital letters [#321](https://github.com/BU-ISCIII/relecov-tools/pull/321)
 
 #### Changed
 
@@ -37,12 +43,13 @@ Code contributions to the release:
 - Now python lint only triggers when PR includes python files [#320](https://github.com/BU-ISCIII/relecov-tools/pull/320)
 - Moved concurrency to whole workflow instead of each step in test_sftp-handle.yml [#320](https://github.com/BU-ISCIII/relecov-tools/pull/320)
 - Updated test_sftp-handle.yml testing datasets [#320](https://github.com/BU-ISCIII/relecov-tools/pull/320)
-
+- Now download skips folders containing "invalid_samples" in its name [#321](https://github.com/BU-ISCIII/relecov-tools/pull/321)
 
 #### Removed
 
 - Removed duplicated tests with pushes after PR was merged in test_sftp-handle [#312](https://github.com/BU-ISCIII/relecov-tools/pull/312)
 - Deleted deprecated auto-release in pypi_publish as it does not work with tag pushes anymore [#312](https://github.com/BU-ISCIII/relecov-tools/pull/312)
+- Removed first sleep time for reconnection decorator in sftp_client.py, sleep time now increases in the second attempt [#321](https://github.com/BU-ISCIII/relecov-tools/pull/321)
 
 ### Requirements
 

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -863,6 +863,9 @@ class DownloadManager:
         log.info("Setting %s remote folders...", str(len(target_folders.keys())))
         stderr.print(f"[blue]Setting {len(target_folders.keys())} remote folders...")
         for folder in sorted(target_folders.keys()):
+            if "invalid_samples" in folder:
+                log.warning("Skipped invalid_samples folder %s", folder)
+                continue
             self.current_folder = folder
             # Include the folder in the final process log summary
             self.include_new_key()

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -1212,8 +1212,19 @@ class DownloadManager:
             )
             if self.logsum.logs.get(self.current_folder):
                 self.logsum.logs[self.current_folder].update({"path": local_folder})
+                try:
+                    folder_basename = os.path.basename(local_folder.rstrip("/"))
+                    log_name = folder_basename + "_download_log_summary.json"
+                    self.logsum.create_error_summary(
+                        filepath=os.path.join(local_folder, log_name),
+                        logs={
+                            self.current_folder: self.logsum.logs[self.current_folder]
+                        },
+                    )
+                except Exception as e:
+                    log.error("Could not create logsum for %s: %s" % (folder, str(e)))
             stderr.print(f"[green]Finished processing {folder}")
-            self.finished_folders[folder] = clean_fetchlist
+            self.finished_folders[folder] = list(files_md5_dict.keys())
         return
 
     def include_new_key(self, sample=None):

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -389,23 +389,22 @@ class DownloadManager:
                 except ValueError as e:
                     stderr.print("[red]Unable to convert to string. ", e)
                     continue
-                if s_name not in sample_file_dict:
-                    sample_file_dict[s_name] = {}
-                else:
+                if s_name in sample_file_dict:
                     log_text = f"Found duplicated sample name: {s_name}. Skipped."
                     stderr.print(log_text)
                     self.include_warning(log_text, sample=s_name)
                     continue
-                if row[index_layout] == "paired" and row[index_fastq_r2] is None:
+                if row[index_layout] == "Paired" and row[index_fastq_r2] is None:
                     error_text = "Sample %s is paired-end, but no R2 given"
                     self.include_error(error_text % str(row[index_sampleID]), s_name)
                     row_complete = False
-                if row[index_layout] == "single" and row[index_fastq_r2] is not None:
+                if row[index_layout] == "Single" and row[index_fastq_r2] is not None:
                     error_text = "Sample %s is single-end, but R1&R2 given"
                     self.include_error(error_text % str(row[index_sampleID]), s_name)
                     row_complete = False
                 if row_complete:
                     if row[index_fastq_r1] is not None:
+                        sample_file_dict[s_name] = {}
                         # TODO: move these keys to configuration.json
                         sample_file_dict[s_name]["sequence_file_R1_fastq"] = row[
                             index_fastq_r1
@@ -418,7 +417,6 @@ class DownloadManager:
                         log_text = "Fastq_R1 not defined in Metadata for sample %s"
                         stderr.print(f"[red]{str(log_text % s_name)}")
                         self.include_error(entry=str(log_text % s_name), sample=s_name)
-                        del sample_file_dict[s_name]
             else:
                 self.include_warning(entry=f"Row {counter} skipped. No sample ID given")
         # Remove duplicated files

--- a/relecov_tools/pipeline_manager.py
+++ b/relecov_tools/pipeline_manager.py
@@ -5,12 +5,10 @@ import os
 import re
 import shutil
 import sys
-import copy
 from collections import Counter
 
 import rich.console
 import relecov_tools.utils
-from relecov_tools.log_summary import LogSum
 
 log = logging.getLogger(__name__)
 stderr = rich.console.Console(

--- a/relecov_tools/sftp_client.py
+++ b/relecov_tools/sftp_client.py
@@ -62,7 +62,7 @@ class SftpRelecov:
     def reconnect_if_fail(n_times, sleep_time):
         def decorator(func):
             def retrier(self, *args, **kwargs):
-                more_sleep_time = sleep_time
+                more_sleep_time = 0
                 retries = 0
                 while retries < n_times:
                     try:


### PR DESCRIPTION
This PR includes the following changes:
For download_manager:

- Now single logs summaries are also created for each folder
- Fixed wrong single-paired layout detection in metadata due to Capital letters
- More accurate cleaning process, skipping only sequencing files instead of whole folder
- Now skips remote folders named "invalid_samples" as they are already processed
- Hotfix for wrong dict processing that would lead to a crash when any file failed validation using the given md5 in an md5sum file 
- Sftp_client.py: Removed first sleep time for reconnection decorator, sleep time now increases in the second attempt

Pipeline_manager:
- Introduced handling for missing/dup files and more accurate information in prompt