### PR TITLE
New wrapper module & changes in logs reporting

### DIFF
--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -24,6 +24,7 @@ import relecov_tools.gisaid_upload
 import relecov_tools.upload_ena_protocol
 import relecov_tools.pipeline_manager
 import relecov_tools.build_schema
+import relecov_tools.dataprocess_wrapper
 
 log = logging.getLogger()
 
@@ -565,7 +566,8 @@ def logs_to_excel(lab_code, output_folder, files):
     logsum = relecov_tools.log_summary.LogSum(output_location=output_folder)
     merged_logs = logsum.merge_logs(key_name=lab_code, logs_list=all_logs)
     final_logs = logsum.prepare_final_logs(logs=merged_logs)
-    logsum.create_logs_excel(logs=final_logs)
+    excel_outpath = os.path.join(output_folder, lab_code + "_logs_report.xlsx")
+    logsum.create_logs_excel(logs=final_logs, excel_outpath=excel_outpath)
 
 
 @relecov_tools_cli.command(help_priority=16)

--- a/relecov_tools/dataprocess_wrapper.py
+++ b/relecov_tools/dataprocess_wrapper.py
@@ -183,18 +183,27 @@ class ProcessWrapper:
         merged_logs = self.wrapper_logsum.merge_logs(
             key_name=key, logs_list=[{key: folder_logs}, read_meta_logs, validate_logs]
         )
+        stderr.print(f"[green]Merged logs from all processes in {local_folder}")
         sftp_dirs = self.download_manager.relecov_sftp.list_remote_folders(key)
         sftp_dirs_paths = [os.path.join(key, d) for d in sftp_dirs]
         valid_dirs = [d for d in sftp_dirs_paths if d in finished_folders.keys()]
+        # As all folders are merged into one during download, there should only be 1 folder
         if not valid_dirs or len(valid_dirs) >= 2:
-            # As all folders are merged into one during download, there should only be 1 folder
+            # If all samples were valid during download and download_clean is used, the original folder might have been deleted
             log.warning("Couldnt find %s folder in remote sftp. Creating new one", key)
             remote_dir = os.path.join(key, self.date + "_invalid_samples")
             self.download_manager.relecov_sftp.make_dir(remote_dir)
         else:
             remote_dir = valid_dirs[0]
+            stderr.print(f"[blue]Cleaning successfully validated files from {remote_dir}")
+            log.info("Cleaning successfully validated files from remote dir")
+            file_fields = ("sequence_file_R1_fastq", "sequence_file_R2_fastq")
+            valid_sampfiles = [f.get(key) for key in file_fields for f in valid_json_data]
+            valid_files = [f for f in finished_folders[remote_dir] if f in valid_sampfiles]
+            self.download_manager.delete_remote_files(remote_dir, files=valid_files)
+            self.download_manager.delete_remote_files(remote_dir, skip_seqs=True)
+            self.download_manager.clean_remote_folder(remote_dir)
         if invalid_json:
-            stderr.print(f"[green]Merged logs from all processes in {local_folder}")
             logtxt = f"Found {len(invalid_json)} invalid samples in {key}"
             self.wrapper_logsum.add_warning(key=key, entry=logtxt)
             assets = os.path.join(os.path.dirname(os.path.realpath(__file__)), "assets")
@@ -202,20 +211,16 @@ class ProcessWrapper:
                 x for x in os.listdir(assets) if re.search("metadata_templat.*.xlsx", x)
             ][0]
             sftp_path = os.path.join(remote_dir, os.path.basename(metadata_template))
+            log.info("Uploading invalid files and template to %s", remote_dir)
             stderr.print(f"[blue]Uploading invalid files and template to {remote_dir}")
             self.download_manager.relecov_sftp.upload_file(
                 os.path.join(assets, metadata_template), sftp_path
             )
             # Upload all the files that failed validation process back to sftp
             upload_files_from_json(invalid_json, remote_dir)
-        stderr.print(f"[blue]Cleaning successfully validated files from {remote_dir}")
-        log.info("Cleaning successfully validated files from remote dir")
-        file_fields = ("sequence_file_R1_fastq", "sequence_file_R2_fastq")
-        valid_sampfiles = [f.get(key) for key in file_fields for f in valid_json_data]
-        valid_files = [f for f in finished_folders[remote_dir] if f in valid_sampfiles]
-        self.download_manager.delete_remote_files(remote_dir, files=valid_files)
-        self.download_manager.delete_remote_files(remote_dir, skip_seqs=True)
-        self.download_manager.clean_remote_folder(remote_dir)
+        else:
+            log.info("No invalid samples in %s", key)
+            stderr.print(f"[green]No invalid samples were found for {key} !!!")
         log_filepath = os.path.join(local_folder, str(key) + "_metadata_report.json")
         self.wrapper_logsum.create_error_summary(
             called_module="metadata",

--- a/relecov_tools/dataprocess_wrapper.py
+++ b/relecov_tools/dataprocess_wrapper.py
@@ -195,11 +195,17 @@ class ProcessWrapper:
             self.download_manager.relecov_sftp.make_dir(remote_dir)
         else:
             remote_dir = valid_dirs[0]
-            stderr.print(f"[blue]Cleaning successfully validated files from {remote_dir}")
+            stderr.print(
+                f"[blue]Cleaning successfully validated files from {remote_dir}"
+            )
             log.info("Cleaning successfully validated files from remote dir")
             file_fields = ("sequence_file_R1_fastq", "sequence_file_R2_fastq")
-            valid_sampfiles = [f.get(key) for key in file_fields for f in valid_json_data]
-            valid_files = [f for f in finished_folders[remote_dir] if f in valid_sampfiles]
+            valid_sampfiles = [
+                f.get(key) for key in file_fields for f in valid_json_data
+            ]
+            valid_files = [
+                f for f in finished_folders[remote_dir] if f in valid_sampfiles
+            ]
             self.download_manager.delete_remote_files(remote_dir, files=valid_files)
             self.download_manager.delete_remote_files(remote_dir, skip_seqs=True)
             self.download_manager.clean_remote_folder(remote_dir)

--- a/relecov_tools/dataprocess_wrapper.py
+++ b/relecov_tools/dataprocess_wrapper.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python
+import logging
+import re
+import yaml
+import os
+import sys
+from datetime import datetime
+import json
+import inspect
+import rich.console
+from relecov_tools.download_manager import DownloadManager
+from relecov_tools.read_lab_metadata import RelecovMetadata
+from relecov_tools.json_validation import SchemaValidation
+import relecov_tools.log_summary
+import relecov_tools.utils
+
+log = logging.getLogger(__name__)
+stderr = rich.console.Console(
+    stderr=True,
+    style="dim",
+    highlight=False,
+    force_terminal=relecov_tools.utils.rich_force_colors(),
+)
+
+
+class ProcessWrapper:
+    """
+    Always fill all the arguments for the class in the config file, leave its value
+    if you dont want to use that argument e.g.(target_folders:  ) -> (target_folders = None)
+    """
+
+    def __init__(self, config_file: str = None, output_folder: str = None):
+        if not os.path.isdir(str(output_folder)):
+            sys.exit(FileNotFoundError(f"Output folder {output_folder} is not valid"))
+        else:
+            self.output_folder = output_folder
+        if not os.path.isfile(str(config_file)):
+            sys.exit(FileNotFoundError(f"Config file {config_file} is not a file"))
+        else:
+            try:
+                self.config_data = relecov_tools.utils.read_yml_file(config_file)
+                # Config file should include a key
+            except yaml.YAMLError as e:
+                sys.exit(yaml.YAMLError(f"Invalid config file: {e}"))
+        output_regex = ("out_folder", "output_folder", "output_location")
+        for key, val in self.config_data.items():
+            for arg in output_regex:
+                if val == arg:
+                    self.config_data[key] = self.output_folder
+        self.wrapper_logsum = relecov_tools.log_summary.LogSum(
+            output_location=os.path.join(self.output_folder, "logs")
+        )
+        self.config_data["download"].update({"output_location": output_folder})
+        self.download_params = self.clean_module_params(
+            "DownloadManager", self.config_data["download"]
+        )
+        self.readmeta_params = self.clean_module_params(
+            "RelecovMetadata", self.config_data["read-lab-metadata"]
+        )
+        self.validate_params = self.clean_module_params(
+            "SchemaValidation", self.config_data["validate"]
+        )
+
+    def clean_module_params(self, module, params):
+        active_module = eval(module)
+        module_args = inspect.getfullargspec(active_module.__init__)[0]
+        module_args.remove("self")
+        module_valid_params = {x: y for x, y in params.items() if x in module_args}
+        if not module_valid_params:
+            stderr.print(f"[red]Invalid params for {module} in config file")
+            sys.exit(1)
+        return module_valid_params
+
+    def exec_download(self, download_params):
+        download_manager = DownloadManager(**download_params)
+        download_manager.execute_process()
+        finished_folders = download_manager.finished_folders
+        download_logs = self.wrapper_logsum.prepare_final_logs(
+            logs=download_manager.logsum.logs
+        )
+        self.download_manager = download_manager
+        return finished_folders, download_logs
+
+    def exec_read_metadata(self, readmeta_params):
+        read_metadata = RelecovMetadata(**readmeta_params)
+        read_metadata.create_metadata_json()
+        read_meta_logs = self.wrapper_logsum.prepare_final_logs(
+            logs=read_metadata.logsum.logs
+        )
+        return read_meta_logs
+
+    def exec_validation(self, validate_params):
+        validate_proccess = SchemaValidation(**validate_params)
+        valid_json_data, invalid_json = validate_proccess.validate()
+        validate_logs = self.wrapper_logsum.prepare_final_logs(
+            logs=validate_proccess.logsum.logs
+        )
+        return valid_json_data, invalid_json, validate_logs
+
+    def process_folder(self, finished_folders, key, folder_logs):
+        """_summary_
+
+        Args:
+            finished_folders (_type_): _description_
+            key (_type_): _description_
+            folder_logs (_type_): _description_
+
+        Raises:
+            ValueError: _description_
+            KeyError: _description_
+            ValueError: _description_
+            ValueError: _description_
+
+        Returns:
+            _type_: _description_
+        """
+
+        def upload_files_from_json(invalid_json, remote_dir):
+            """Upload the files in a given json with samples metadata"""
+            for sample in invalid_json:
+                local_dir = sample.get("r1_fastq_filepath")
+                # files_keys = [key for key in sample.keys() if "_file_" in key]
+                sample_files = (
+                    sample.get("sequence_file_R1_fastq"),
+                    sample.get("sequence_file_R2_fastq"),
+                )
+                ftp_files = self.download_manager.relecov_sftp.get_file_list(remote_dir)
+                uploaded_files = []
+                for file in sample_files:
+                    if not file or file in ftp_files:
+                        continue
+                    loc_path = os.path.join(local_dir, file)
+                    sftp_path = os.path.join(remote_dir, file)
+                    log.info("Uploading %s to remote %s" % (loc_path, remote_dir))
+                    uploaded = self.download_manager.relecov_sftp.upload_file(
+                        loc_path, sftp_path
+                    )
+                    if not uploaded:
+                        err = f"Could not upload {loc_path} to {remote_dir}"
+                        self.wrapper_logsum.add_error(sample=sample, entry=err)
+                    else:
+                        uploaded_files.append(file)
+            return uploaded_files
+
+        local_folder = folder_logs.get("path")
+        match_date = re.search(r"\/\d{4}\d{2}\d{2}\d{6}", local_folder)
+        sftp_dirs = self.download_manager.relecov_sftp.list_remote_folders(key)
+        sftp_dirs_paths = [os.path.join(key, d) for d in sftp_dirs]
+        valid_dirs = [d for d in sftp_dirs_paths if d in finished_folders.keys()]
+        if not valid_dirs or len(valid_dirs) >= 2:
+            logtxt = f"Could not find {key} folder in remote sftp. Skipped"
+            raise KeyError(logtxt)
+        # As all folders are merged into one during download, there should only be 1 folder
+        remote_dir = valid_dirs[0]
+        if not local_folder:
+            raise ValueError()
+        files = [os.path.join(local_folder, file) for file in os.listdir(local_folder)]
+        try:
+            metadata_file = [x for x in files if re.search("lab_metadata.*.xlsx", x)][0]
+            samples_file = [x for x in files if re.search("samples_data.*.json", x)][0]
+        except IndexError:
+            raise ValueError(f"No metadata/samples files found after download")
+        self.readmeta_params.update(
+            {
+                "metadata_file": metadata_file,
+                "sample_list_file": samples_file,
+                "output_folder": local_folder,
+            }
+        )
+        read_meta_logs = self.exec_read_metadata(self.readmeta_params)
+        metadata_json = [
+            x for x in os.listdir(local_folder) if re.search("lab_metadata.*.json", x)
+        ]
+        if not metadata_json:
+            raise ValueError(f"No metadata json found after read-lab-metadata")
+        self.validate_params.update(
+            {
+                "json_data_file": os.path.join(local_folder, metadata_json[0]),
+                "metadata": metadata_file,
+                "out_folder": local_folder,
+            }
+        )
+        valid_json_data, invalid_json, validate_logs = self.exec_validation(
+            self.validate_params
+        )
+        merged_logs = self.wrapper_logsum.merge_logs(
+            key_name=key, logs_list=[{key: folder_logs}, read_meta_logs, validate_logs]
+        )
+        stderr.print(f"[green]Merged logs from all processes in {local_folder}")
+        if invalid_json:
+            logtxt = f"Found {len(invalid_json)} invalid samples in {key}"
+            self.wrapper_logsum.add_warning(key=key, entry=logtxt)
+            assets = os.path.join(os.path.dirname(os.path.realpath(__file__)), "assets")
+            metadata_template = [
+                x for x in os.listdir(assets) if re.search("metadata_templat.*.xlsx", x)
+            ][0]
+            sftp_path = os.path.join(remote_dir, os.path.basename(metadata_template))
+            stderr.print(f"[blue]Uploading invalid files and template to {remote_dir}")
+            self.download_manager.relecov_sftp.upload_file(
+                os.path.join(assets, metadata_template), sftp_path
+            )
+            upload_files_from_json(invalid_json, remote_dir)
+        stderr.print(f"[blue]Cleaning successfully validated files from {remote_dir}")
+        log.info("Cleaning successfully validated files from remote dir")
+        file_fields = ("sequence_file_R1_fastq", "sequence_file_R2_fastq")
+        valid_sampfiles = [f.get(key) for key in file_fields for f in valid_json_data]
+        valid_files = [f for f in finished_folders[remote_dir] if f in valid_sampfiles]
+        self.download_manager.delete_remote_files(key, files=valid_files)
+        self.download_manager.delete_remote_files(key, skip_seqs=True)
+        self.download_manager.clean_remote_folder(key)
+        log_filepath = os.path.join(local_folder, str(key) + "_metadata_report.json")
+        self.wrapper_logsum.create_error_summary(
+            called_module="metadata",
+            filepath=log_filepath,
+            logs=merged_logs,
+            to_excel=True,
+        )
+        xlsx_report_files = [
+            f for f in os.listdir(local_folder) if re.search("metadata_report.xlsx", f)
+        ]
+        if xlsx_report_files:
+            log.info("Uploading %s xlsx report to remote %s" % (key, remote_dir))
+            local_xlsx = os.path.join(local_folder, xlsx_report_files[0])
+            remote_xlsx = os.path.join(remote_dir, xlsx_report_files[0])
+            up = self.download_manager.relecov_sftp.upload_file(local_xlsx, remote_xlsx)
+            if not up:
+                log.error(
+                    "Could not upload %s report to remote %s" % (key, local_folder)
+                )
+        else:
+            log.error("Could not find xlsx report for %s in %s" % (key, logs_dir))
+        return merged_logs, valid_json_data
+
+    def run_wrapper(self):
+        """Execute each given process in config file sequentially"""
+        finished_folders, download_logs = self.exec_download(self.download_params)
+        if not finished_folders:
+            stderr.print("[red]No valid folders found to process")
+            sys.exit(1)
+        date = datetime.today().strftime("%Y%m%d%H%M%S")
+        for key, folder_logs in download_logs.items():
+            folder = folder_logs.get("path")
+            if not folder:
+                continue
+            if not folder_logs.get("valid"):
+                continue
+            try:
+                merged_logs, valid_json_data = self.process_folder(
+                    finished_folders, key, folder_logs
+                )
+            except FileNotFoundError as e:
+                log.error(f"Could not process folder {key}: {e}")
+                folder_logs["errors"].append(f"Could not process folder {key}: {e}")
+                log_filepath = os.path.join(folder, str(key) + "_metadata_summary.json")
+                self.wrapper_logsum.create_error_summary(
+                    called_module="metadata",
+                    filepath=log_filepath,
+                    logs={key: folder_logs},
+                    to_excel=False,
+                )
+                continue
+            self.wrapper_logsum.logs[key] = merged_logs[key]
+        self.wrapper_logsum.create_error_summary(
+            called_module="wrapper",
+            to_excel=True,
+        )
+        return

--- a/relecov_tools/json_validation.py
+++ b/relecov_tools/json_validation.py
@@ -60,6 +60,10 @@ class SchemaValidation:
 
         stderr.print("[blue] Reading the json file")
         self.json_data = relecov_tools.utils.read_json_file(json_data_file)
+        if isinstance(self.json_data, dict):
+            stderr.print(f"[red]Invalid json file content in {json_data_file}.")
+            stderr.print("Should be a list of dicts. Create it with read-lab-metadata")
+            sys.exit(1)
         self.metadata = metadata
         try:
             self.sample_id_field = self.get_sample_id_field()

--- a/relecov_tools/json_validation.py
+++ b/relecov_tools/json_validation.py
@@ -258,3 +258,4 @@ class SchemaValidation:
             self.logsum.add_error(entry=log_text)
             stderr.print(f"[red]{log_text}")
         self.logsum.create_error_summary(called_module="validate")
+        return valid_json_data, invalid_json

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -29,10 +29,12 @@ class LogSum:
         unique_key: str = None,
         path: str = None,
     ):
-        if not os.path.exists(str(output_location)):
-            raise FileNotFoundError(f"Output folder {output_location} does not exist")
-        else:
-            self.output_location = output_location
+        if not os.path.isdir(str(output_location)):
+            try:
+                os.makedirs(output_location, exist_ok=True)
+            except IOError:
+                raise IOError(f"Logs output folder {output_location} does not exist")
+        self.output_location = output_location
         # if unique_key is given, all entries will be saved inside that key by default
         if unique_key:
             self.unique_key = unique_key

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -182,10 +182,11 @@ class LogSum:
             logs (dict, optional): Custom dictionary of logs. Useful to create outputs
             excel_outpath (str): Path to output excel file
         """
+
         def reg_remover(string, pattern):
             """Remove annotation between brackets in logs message"""
             string = string.replace("['", "'").replace("']", "'")
-            string = re.sub(pattern, '', string)
+            string = re.sub(pattern, "", string)
             return string.strip()
 
         def translate_fields(samples_logs):
@@ -221,7 +222,7 @@ class LogSum:
         warnings_sheet = workbook.create_sheet("Other warnings")
         warnings_headers = ["Sample ID given for sequencing", "Valid", "Warnings"]
         warnings_sheet.append(warnings_headers)
-        regex = r"\[.*?\]" # Regex to remove annotation between brackets
+        regex = r"\[.*?\]"  # Regex to remove annotation between brackets
         for sample, logs in samples_logs.items():
             clean_errors = [reg_remover(x, regex) for x in logs["errors"]]
             error_row = [sample, str(logs["valid"]), "\n ".join(clean_errors)]

--- a/relecov_tools/utils.py
+++ b/relecov_tools/utils.py
@@ -19,6 +19,9 @@ from Bio import SeqIO
 from rich.console import Console
 from datetime import datetime
 from tabulate import tabulate
+import openpyxl.utils
+import openpyxl.styles
+
 
 log = logging.getLogger(__name__)
 
@@ -488,3 +491,26 @@ def prompt_create_outdir(
         sys.exit(1)
 
     return global_path
+
+def adjust_sheet_size(sheet, wrap_text=True, col_width=30):
+    """Adjust column width and row heights depending on the max number of
+    characters in each one.
+
+    Args:
+        sheet (openpyxl.worksheet): active openpyxl worksheet object
+        wrap_text (bool): Wether to use excel wrap_text function for each cell. Defaults to True
+        col_width (int): Minimum columns width value. Also used to define maximum
+        number of characters in each cell when wrap_text is True. Defaults to 30.
+    """
+    dims = {}
+    for _, row in enumerate(sheet.iter_rows(min_row=2, max_row=sheet.max_row), start=2):
+        for cell in row:
+            if wrap_text:
+                cell.alignment = openpyxl.styles.Alignment(wrapText=True)
+            if cell.value is not None:
+                max_length = max((dims.get(cell.column, 0), len(str(cell.value))))
+                dims[cell.column] = max_length / col_width
+    for col_num, value in dims.items():
+        if value < col_width:
+            value = col_width
+        sheet.column_dimensions[openpyxl.utils.get_column_letter(col_num)].width = value

--- a/relecov_tools/utils.py
+++ b/relecov_tools/utils.py
@@ -492,6 +492,7 @@ def prompt_create_outdir(
 
     return global_path
 
+
 def adjust_sheet_size(sheet, wrap_text=True, col_width=30):
     """Adjust column width and row heights depending on the max number of
     characters in each one.


### PR DESCRIPTION
This PR includes a new module temporarily called "wrapper" which executes **download**, **read-lab-metadata** and **validate** processes consecutively for each downloaded set of samples. This simplifies the processing workflow as all the provided metadata is validated and a report is generated including all the errors found for each sample which can be sent via email to the corresponding submitter.

Along with this new module come several changes in related modules:

- Those log_summary messages which previously included any field from the schema now include the label instead, as it's what the submitter will see in the xlsx template.
- The excel log report created by `logs-to-excel` now has a cell size adjustment step for large messages
- Multiple error handlings for merge_logs() and create_logs_excel() methods in log_summary.py

Closes #302 