### PR TITLE
Logs-to-excel accepts multiple keys and includes folder logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.X.0] - 202X-XX-XX : https://github.com/BU-ISCIII/relecov-tools/releases/tag/
+
+### Credits
+
+Code contributions to the release:
+
+- [Pablo Mata](https://github.com/Shettland)
+
+### Modules
+
+#### Added enhancements
+
+- Now logs-to-excel can handle logs with multiple keys and includes folder logs [#329](https://github.com/BU-ISCIII/relecov-tools/pull/329)
+
+#### Fixes
+
+#### Changed
+
+#### Removed
+
+### Requirements
+
 ## [1.2.0] - 2024-10-11 : https://github.com/BU-ISCIII/relecov-tools/releases/tag/1.2.0
 
 ### Credits

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -185,7 +185,7 @@ class LogSum:
 
         def reg_remover(string, pattern):
             """Remove annotation between brackets in logs message"""
-            string = string.replace("['", "'").replace("']", "'").replace('"', '')
+            string = string.replace("['", "'").replace("']", "'").replace('"', "")
             string = re.sub(pattern, "", string)
             return string.strip()
 
@@ -203,20 +203,21 @@ class LogSum:
                 samples_logs = logs.get("samples")
             if not samples_logs:
                 logs["Warnings"].append("No samples found to report")
-            
+
             workbook = openpyxl.Workbook()
             # TODO: Include these fields in configuration.json
+            sample_id_field = "Sample ID given for sequencing"
             sheet_names_and_headers = {
                 "Global Report": ["Valid", "Errors", "Warnings"],
-                "Samples Report": ["Sample ID given for sequencing", "Valid", "Errors"],
-                "Other warnings": ["Sample ID given for sequencing", "Valid", "Warnings"]
+                "Samples Report": [sample_id_field, "Valid", "Errors"],
+                "Other warnings": [sample_id_field, "Valid", "Warnings"],
             }
             for name, header in sheet_names_and_headers.items():
                 new_sheet = workbook.create_sheet(name)
                 new_sheet.append(header)
-            regex = r"[\[\]]" # Regex to remove lists brackets
+            regex = r"[\[\]]"  # Regex to remove lists brackets
             workbook["Global Report"].append(
-                [reg_remover(str(x), regex) for k,x in logs.items() if k != "samples"]
+                [reg_remover(str(x), regex) for k, x in logs.items() if k != "samples"]
             )
             regex = r"\[.*?\]"  # Regex to remove ontology annotations between brackets
             for sample, slog in samples_logs.items():
@@ -228,7 +229,7 @@ class LogSum:
                 workbook["Other warnings"].append(warning_row)
             for name in sheet_names_and_headers.keys():
                 relecov_tools.utils.adjust_sheet_size(workbook[name])
-            del workbook['Sheet']
+            del workbook["Sheet"]
             workbook.save(excel_outpath)
             stderr.print(f"[green]Successfully created logs excel in {excel_outpath}")
             return
@@ -236,7 +237,7 @@ class LogSum:
         def translate_fields(samples_logs):
             # TODO Translate logs to spanish using a local translator model like deepl
             return
-        
+
         date = datetime.today().strftime("%Y%m%d%H%M%S")
         lab_code = list(logs.keys())[0]
         if not os.path.exists(os.path.dirname(excel_outpath)):

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -185,14 +185,58 @@ class LogSum:
 
         def reg_remover(string, pattern):
             """Remove annotation between brackets in logs message"""
-            string = string.replace("['", "'").replace("']", "'")
+            string = string.replace("['", "'").replace("']", "'").replace('"', '')
             string = re.sub(pattern, "", string)
             return string.strip()
+
+        def feed_logs_to_excel(key, logs, excel_outpath):
+            """Feed the data from logs into an excel file, creating different
+            sheets depending on the provided list from configuration file"""
+            if not logs.get("samples"):
+                try:
+                    samples_logs = logs[lab_code]["samples"]
+                except (KeyError, AttributeError) as e:
+                    stderr.print(f"[red]Could not convert log summary to excel: {e}")
+                    log.error("Could not convert log summary to excel: %s" % str(e))
+                    return
+            else:
+                samples_logs = logs.get("samples")
+            if not samples_logs:
+                logs["Warnings"].append("No samples found to report")
+            
+            workbook = openpyxl.Workbook()
+            # TODO: Include these fields in configuration.json
+            sheet_names_and_headers = {
+                "Global Report": ["Valid", "Errors", "Warnings"],
+                "Samples Report": ["Sample ID given for sequencing", "Valid", "Errors"],
+                "Other warnings": ["Sample ID given for sequencing", "Valid", "Warnings"]
+            }
+            for name, header in sheet_names_and_headers.items():
+                new_sheet = workbook.create_sheet(name)
+                new_sheet.append(header)
+            regex = r"[\[\]]" # Regex to remove lists brackets
+            workbook["Global Report"].append(
+                [reg_remover(str(x), regex) for k,x in logs.items() if k != "samples"]
+            )
+            regex = r"\[.*?\]"  # Regex to remove ontology annotations between brackets
+            for sample, slog in samples_logs.items():
+                clean_errors = [reg_remover(x, regex) for x in slog["errors"]]
+                error_row = [sample, str(slog["valid"]), "\n ".join(clean_errors)]
+                workbook["Samples Report"].append(error_row)
+                clean_warngs = [reg_remover(x, regex) for x in slog["warnings"]]
+                warning_row = [sample, str(slog["valid"]), "\n ".join(clean_warngs)]
+                workbook["Other warnings"].append(warning_row)
+            for name in sheet_names_and_headers.keys():
+                relecov_tools.utils.adjust_sheet_size(workbook[name])
+            del workbook['Sheet']
+            workbook.save(excel_outpath)
+            stderr.print(f"[green]Successfully created logs excel in {excel_outpath}")
+            return
 
         def translate_fields(samples_logs):
             # TODO Translate logs to spanish using a local translator model like deepl
             return
-
+        
         date = datetime.today().strftime("%Y%m%d%H%M%S")
         lab_code = list(logs.keys())[0]
         if not os.path.exists(os.path.dirname(excel_outpath)):
@@ -204,36 +248,12 @@ class LogSum:
             )
         file_ext = os.path.splitext(excel_outpath)[-1]
         excel_outpath = excel_outpath.replace(file_ext, ".xlsx")
-        if not logs.get("samples"):
-            try:
-                samples_logs = logs[lab_code]["samples"]
-            except (KeyError, AttributeError) as e:
-                stderr.print(f"[red]Could not convert log summary to excel: {e}")
-                log.error("Could not convert log summary to excel: %s" % str(e))
-                return
-        else:
-            samples_logs = logs.get("samples")
-
-        workbook = openpyxl.Workbook()
-        main_worksheet = workbook.active
-        main_worksheet.title = "Samples Report"
-        main_headers = ["Sample ID given for sequencing", "Valid", "Errors"]
-        main_worksheet.append(main_headers)
-        warnings_sheet = workbook.create_sheet("Other warnings")
-        warnings_headers = ["Sample ID given for sequencing", "Valid", "Warnings"]
-        warnings_sheet.append(warnings_headers)
-        regex = r"\[.*?\]"  # Regex to remove annotation between brackets
-        for sample, logs in samples_logs.items():
-            clean_errors = [reg_remover(x, regex) for x in logs["errors"]]
-            error_row = [sample, str(logs["valid"]), "\n ".join(clean_errors)]
-            main_worksheet.append(error_row)
-            clean_warngs = [reg_remover(x, regex) for x in logs["warnings"]]
-            warning_row = [sample, str(logs["valid"]), "\n ".join(clean_warngs)]
-            warnings_sheet.append(warning_row)
-        relecov_tools.utils.adjust_sheet_size(main_worksheet)
-        relecov_tools.utils.adjust_sheet_size(warnings_sheet)
-        workbook.save(excel_outpath)
-        stderr.print(f"[green]Successfully created logs excel in {excel_outpath}")
+        for key, logs in logs.items():
+            if lab_code in excel_outpath:
+                lab_excelpath = excel_outpath.replace(lab_code, key)
+            else:
+                lab_excelpath = excel_outpath.replace(".xlsx", "_" + key + ".xlsx")
+            feed_logs_to_excel(key, logs, lab_excelpath)
         return
 
     def create_error_summary(
@@ -283,7 +303,7 @@ class LogSum:
                         final_logs, filepath.replace("log_summary", "report")
                     )
             except Exception as e:
-                stderr.print(f"[red]Error parsing logs to json format: {e}")
-                log.error("Error parsing logs to json format: %s", str(e))
+                stderr.print(f"[red]Error exporting logs to file: {e}")
+                log.error("Error exporting logs to file: %s", str(e))
                 f.write(str(final_logs))
         return


### PR DESCRIPTION
Just what the title says. Logs-to-excel did not handle logs with multiple main_keys (labs) and did not include the global logs, just logs associated to samples. Now a sheet called "Global Report" includes this generic information of the process.