### PR TITLE
New files-folder argument and mproved logging messages for read-lab-metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,12 @@ Code contributions to the release:
 
 ### Modules
 
+- Included files-folder option for read-lab-metadata when no samples_data.json is provided [#330](https://github.com/BU-ISCIII/relecov-tools/pull/330)
+
 #### Added enhancements
 
 - Now logs-to-excel can handle logs with multiple keys and includes folder logs [#329](https://github.com/BU-ISCIII/relecov-tools/pull/329)
+- Improved logging messages for duplicated sample IDs in read-lab and download modules [#330](https://github.com/BU-ISCIII/relecov-tools/pull/330)
 
 #### Fixes
 

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -210,7 +210,7 @@ def download(
     "--files-folder",
     default=None,
     type=click.Path(),
-    help="Path to folder where samples files are located"
+    help="Path to folder where samples files are located",
 )
 def read_lab_metadata(metadata_file, sample_list_file, metadata_out, files_folder):
     """

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -205,6 +205,13 @@ def download(
 @click.option(
     "-o", "--metadata-out", type=click.Path(), help="Path to save output metadata file"
 )
+@click.option(
+    "-f",
+    "--files-folder",
+    default=None,
+    type=click.Path(),
+    help="Path to folder where samples files are located"
+)
 def read_lab_metadata(metadata_file, sample_list_file, metadata_out):
     """
     Create the json compliant to the relecov schema from the Metadata file.

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -212,12 +212,12 @@ def download(
     type=click.Path(),
     help="Path to folder where samples files are located"
 )
-def read_lab_metadata(metadata_file, sample_list_file, metadata_out):
+def read_lab_metadata(metadata_file, sample_list_file, metadata_out, files_folder):
     """
     Create the json compliant to the relecov schema from the Metadata file.
     """
     new_metadata = relecov_tools.read_lab_metadata.RelecovMetadata(
-        metadata_file, sample_list_file, metadata_out
+        metadata_file, sample_list_file, metadata_out, files_folder
     )
     relecov_json = new_metadata.create_metadata_json()
     return relecov_json

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -390,7 +390,7 @@ class DownloadManager:
                     stderr.print("[red]Unable to convert to string. ", e)
                     continue
                 if s_name in sample_file_dict:
-                    log_text = f"Found more samples with the same Sample ID given for sequencing. Only the first one will remain."
+                    log_text = "Found more samples with the same Sample ID given for sequencing. Only the first one remains."
                     stderr.print(log_text)
                     self.include_warning(log_text, sample=s_name)
                     continue

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -390,7 +390,7 @@ class DownloadManager:
                     stderr.print("[red]Unable to convert to string. ", e)
                     continue
                 if s_name in sample_file_dict:
-                    log_text = f"Found duplicated sample name: {s_name}. Skipped."
+                    log_text = f"Found more samples with the same Sample ID given for sequencing. Only the first one will remain."
                     stderr.print(log_text)
                     self.include_warning(log_text, sample=s_name)
                     continue
@@ -542,10 +542,10 @@ class DownloadManager:
             mismatch_rev = [fi for fi in set_list if fi not in filtered_files_list]
 
             if mismatch_files:
-                error_text1 = "Files in folder missing in metadata %s"
+                error_text1 = "Files in folder missing in metadata: %s"
                 self.include_warning(error_text1 % str(mismatch_files))
             if mismatch_rev:
-                error_text2 = "Files in metadata missing in folder %s"
+                error_text2 = "Files in metadata missing in folder: %s"
                 self.include_warning(error_text2 % str(mismatch_rev))
             # Try to check if the metadata filename lacks the proper extension
             log.info("Trying to match files without proper file extension")

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -405,19 +405,19 @@ class RelecovMetadata:
             property_row = {}
             try:
                 sample_id = str(row[sample_id_col]).strip()
-                included_sample_ids.append(sample_id)
             except KeyError:
                 self.logsum.add_error(entry=f"No {sample_id_col} found in excel file")
+                continue
+            if sample_id in included_sample_ids:
+                log_text = f"Skipped duplicated sample {sample_id} in row {row_number}. Sequencing sample id must be unique"
+                self.logsum.add_warning(entry=log_text)
                 continue
             if not row[sample_id_col] or "Not Provided" in sample_id:
                 log_text = f"{sample_id_col} not provided in row {row_number}. Skipped"
                 self.logsum.add_warning(entry=log_text)
                 stderr.print(f"[red]{log_text}")
                 continue
-            if sample_id in included_sample_ids:
-                log_text = f"Skipped duplicated sample {sample_id} in row {row_number}. Sequencing sample id must be unique"
-                self.logsum.add_warning(entry=log_text)
-                continue
+            included_sample_ids.append(sample_id)
             for key in row.keys():
                 # skip the first column of the Metadata lab file
                 if header_flag in key:
@@ -495,7 +495,7 @@ class RelecovMetadata:
         completed_metadata = self.adding_ontology_to_enum(extended_metadata)
         if not completed_metadata:
             stderr.print("Metadata was completely empty. No output file generated")
-            sys.exit(1)
+            sys.exit(0)
         file_code = "lab_metadata_" + self.lab_code + "_"
         file_name = file_code + self.date + ".json"
         stderr.print("[blue]Writting output json file")


### PR DESCRIPTION
This pull request introduces a `files-folder `argument to specify the location of sample files when no `samples_data.json` file from download module is provided, enhancing the flexibility of the read-lab-metadata function. It also improves logging, adding messages for cases of duplicate sample IDs and missing files, while handling metadata and file path validation more robustly. The changes streamline error handling and user feedback, making the tool more resilient and user-friendly.