### PR TITLE
Fixed linting was still waiting for .py files

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -2,11 +2,10 @@ name: python_lint
 
 on:
   push:
-    paths:
-      - '**.py'
+    branches: "**"
   pull_request:
-    paths:
-      - '**.py'
+    types: [opened, reopened, synchronize, closed]
+    branches: "**"
 
 jobs:
   flake8_py3:
@@ -19,6 +18,8 @@ jobs:
           architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@master
+        with:
+          fetch-depth: 0
       - name: Install flake8
         run: pip install flake8
       - name: Check for Python file changes
@@ -40,6 +41,8 @@ jobs:
     steps:
         - name: Setup
           uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
         - name: Install black in jupyter
           run: pip install black[jupyter]
         - name: Check for Python file changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Code contributions to the release:
 
 #### Fixes
 
+- Fixed python linting workflow was still waiting for .py files[#335](https://github.com/BU-ISCIII/relecov-tools/pull/335)
+
 #### Changed
 
 - Pipeline-manager fields_to_split is now in configuration.json to group samples by those fields [#331](https://github.com/BU-ISCIII/relecov-tools/pull/331)


### PR DESCRIPTION
As per the title, github workflow 'python_lint.yml' was still waiting for .py files in the PR, this is now fixed