### PR TITLE
Pre-release 1,3,0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [1.X.0] - 202X-XX-XX : https://github.com/BU-ISCIII/relecov-tools/releases/tag/
+
+### Credits
+
+Code contributions to the release:
+
+### Modules
+
+#### Added enhancements
+
+#### Fixes
+
+#### Changed
+
+#### Removed
+
+### Requirements
+
+## [1.3.0] - 2024-11-26 : https://github.com/BU-ISCIII/relecov-tools/releases/tag/v1.3.0
 
 ### Credits
 
@@ -28,20 +45,24 @@ Code contributions to the release:
 - Integrated jinja2 for template rendering in the mail module. [#328](https://github.com/BU-ISCIII/relecov-tools/pull/328)
 - Configurations for the mail module added to configuration.json [#328](https://github.com/BU-ISCIII/relecov-tools/pull/328)
 - Added static method get_invalid_count in log_summary.py [#328](https://github.com/BU-ISCIII/relecov-tools/pull/328)
+- Included a try-except for every module to catch unexpected errors in __main__.py [#339](https://github.com/BU-ISCIII/relecov-tools/pull/339)
 
 #### Fixes
 
 - Fixed python linting workflow was still waiting for .py files[#335](https://github.com/BU-ISCIII/relecov-tools/pull/335)
+- Now files-folder arg works with relative paths in read-lab-metadata [#339](https://github.com/BU-ISCIII/relecov-tools/pull/339)
+- Now check-gzip-integrity() catches any exception in utils.py as it only needs to return True when file can be decompressed [#339](https://github.com/BU-ISCIII/relecov-tools/pull/339)
 
 #### Changed
 
 - Pipeline-manager fields_to_split is now in configuration.json to group samples by those fields [#331](https://github.com/BU-ISCIII/relecov-tools/pull/331)
+- Homogeneized style of report global report sheet in logs-excel [#339](https://github.com/BU-ISCIII/relecov-tools/pull/339)
 
 #### Removed
 
 ### Requirements
 
-## [1.2.0] - 2024-10-11 : https://github.com/BU-ISCIII/relecov-tools/releases/tag/1.2.0
+## [1.2.0] - 2024-10-11 : https://github.com/BU-ISCIII/relecov-tools/releases/tag/v1.2.0
 
 ### Credits
 
@@ -103,7 +124,7 @@ Code contributions to the release:
 
 ### Requirements
 
-## [1.1.0] - 2024-09-13 : https://github.com/BU-ISCIII/relecov-tools/releases/tag/1.1.0
+## [1.1.0] - 2024-09-13 : https://github.com/BU-ISCIII/relecov-tools/releases/tag/v1.1.0
 
 ### Credits
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ relecov-tools --help
 \    \  /   |__ / |__  |    |___ |    |   |  \    /
 /    /  \   |  \  |    |    |    |    |   |   \  /
 /    |--|   |   \ |___ |___ |___ |___ |___|    \/
-RELECOV-tools version 1.2.0
+RELECOV-tools version 1.3.0
 Usage: relecov-tools [OPTIONS] COMMAND [ARGS]...
 
 Options:

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -193,6 +193,7 @@ def download(
         log.exception(f"EXCEPTION FOUND: {e}")
         raise
 
+
 # metadata
 @relecov_tools_cli.command(help_priority=3)
 @click.option(
@@ -230,6 +231,7 @@ def read_lab_metadata(metadata_file, sample_list_file, metadata_out, files_folde
         log.exception(f"EXCEPTION FOUND: {e}")
         raise
 
+
 # validation
 @relecov_tools_cli.command(help_priority=4)
 @click.option("-j", "--json_file", help="Json file to validate")
@@ -251,6 +253,7 @@ def validate(json_file, json_schema, metadata, out_folder):
     except Exception as e:
         log.exception(f"EXCEPTION FOUND: {e}")
         raise
+
 
 # send-email
 @relecov_tools_cli.command(help_priority=4)
@@ -365,6 +368,7 @@ def map(origin_schema, json_data, destination_schema, schema_file, output):
         log.exception(f"EXCEPTION FOUND: {e}")
         raise
 
+
 # upload to ENA
 @relecov_tools_cli.command(help_priority=6)
 @click.option("-u", "--user", help="user name for login to ena")
@@ -412,6 +416,7 @@ def upload_to_ena(
     except Exception as e:
         log.exception(f"EXCEPTION FOUND: {e}")
         raise
+
 
 # upload to GISAID
 @relecov_tools_cli.command(help_priority=7)
@@ -483,6 +488,7 @@ def upload_to_gisaid(
         log.exception(f"EXCEPTION FOUND: {e}")
         raise
 
+
 @relecov_tools_cli.command(help_priority=9)
 @click.option("-j", "--json", help="data in json format")
 @click.option(
@@ -527,6 +533,7 @@ def update_db(user, password, json, type, platform, server_url, full_update):
         log.exception(f"EXCEPTION FOUND: {e}")
         raise
 
+
 # read metadata bioinformatics
 @relecov_tools_cli.command(help_priority=10)
 @click.option(
@@ -554,6 +561,7 @@ def read_bioinfo_metadata(json_file, input_folder, out_dir, software_name):
         log.exception(f"EXCEPTION FOUND: {e}")
         raise
 
+
 # read metadata bioinformatics
 @relecov_tools_cli.command(help_priority=12)
 @click.option(
@@ -579,6 +587,7 @@ def metadata_homogeneizer(institution, directory, output):
     except Exception as e:
         log.exception(f"EXCEPTION FOUND: {e}")
         raise
+
 
 # creating symbolic links
 @relecov_tools_cli.command(help_priority=13)
@@ -622,6 +631,7 @@ def pipeline_manager(input, template, output, config, folder_names):
         log.exception(f"EXCEPTION FOUND: {e}")
         raise
 
+
 # schema builder
 @relecov_tools_cli.command(help_priority=14)
 @click.option(
@@ -661,6 +671,7 @@ def build_schema(input_file, schema_base, draft_version, diff, out_dir):
     except Exception as e:
         log.exception(f"EXCEPTION FOUND: {e}")
         raise
+
 
 @relecov_tools_cli.command(help_priority=15)
 @click.option(
@@ -710,6 +721,7 @@ def logs_to_excel(lab_code, output_folder, files):
         log.exception(f"EXCEPTION FOUND: {e}")
         raise
 
+
 @relecov_tools_cli.command(help_priority=16)
 @click.option(
     "-c",
@@ -735,6 +747,7 @@ def wrapper(config_file, output_folder):
     except Exception as e:
         log.exception(f"EXCEPTION FOUND: {e}")
         raise
+
 
 if __name__ == "__main__":
     run_relecov_tools()

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -190,8 +190,8 @@ def download(
     try:
         download_manager.execute_process()
     except Exception as e:
-        log.error(f"EXCEPTION FOUND: {e}")
-
+        log.exception(f"EXCEPTION FOUND: {e}")
+        raise
 
 # metadata
 @relecov_tools_cli.command(help_priority=3)
@@ -227,8 +227,8 @@ def read_lab_metadata(metadata_file, sample_list_file, metadata_out, files_folde
     try:
         new_metadata.create_metadata_json()
     except Exception as e:
-        log.error(f"EXCEPTION FOUND: {e}")
-
+        log.exception(f"EXCEPTION FOUND: {e}")
+        raise
 
 # validation
 @relecov_tools_cli.command(help_priority=4)
@@ -249,8 +249,8 @@ def validate(json_file, json_schema, metadata, out_folder):
     try:
         validation.validate()
     except Exception as e:
-        log.error(f"EXCEPTION FOUND: {e}")
-
+        log.exception(f"EXCEPTION FOUND: {e}")
+        raise
 
 # send-email
 @relecov_tools_cli.command(help_priority=4)
@@ -335,8 +335,11 @@ def send_mail(validate_file, receiver_email, attachments, email_psswd):
         raise ValueError("Error: Could not obtain the recipient's email address.")
 
     subject = f"Informe de Validación de Muestras - {institution_name}"
-
-    email_sender.send_email(final_receiver_email, subject, email_body, attachments)
+    try:
+        email_sender.send_email(final_receiver_email, subject, email_body, attachments)
+    except Exception as e:
+        log.exception(f"EXCEPTION FOUND: {e}")
+        raise
 
 
 # mapping to ENA schema
@@ -359,8 +362,8 @@ def map(origin_schema, json_data, destination_schema, schema_file, output):
     try:
         new_schema.map_to_data_to_new_schema()
     except Exception as e:
-        log.error(f"EXCEPTION FOUND: {e}")
-
+        log.exception(f"EXCEPTION FOUND: {e}")
+        raise
 
 # upload to ENA
 @relecov_tools_cli.command(help_priority=6)
@@ -407,8 +410,8 @@ def upload_to_ena(
     try:
         upload_ena.upload()
     except Exception as e:
-        log.error(f"EXCEPTION FOUND: {e}")
-
+        log.exception(f"EXCEPTION FOUND: {e}")
+        raise
 
 # upload to GISAID
 @relecov_tools_cli.command(help_priority=7)
@@ -477,8 +480,8 @@ def upload_to_gisaid(
     try:
         upload_gisaid.gisaid_upload()
     except Exception as e:
-        log.error(f"EXCEPTION FOUND: {e}")
-
+        log.exception(f"EXCEPTION FOUND: {e}")
+        raise
 
 @relecov_tools_cli.command(help_priority=9)
 @click.option("-j", "--json", help="data in json format")
@@ -521,8 +524,8 @@ def update_db(user, password, json, type, platform, server_url, full_update):
     try:
         update_database_obj.update_db()
     except Exception as e:
-        log.error(f"EXCEPTION FOUND: {e}")
-
+        log.exception(f"EXCEPTION FOUND: {e}")
+        raise
 
 # read metadata bioinformatics
 @relecov_tools_cli.command(help_priority=10)
@@ -548,8 +551,8 @@ def read_bioinfo_metadata(json_file, input_folder, out_dir, software_name):
     try:
         new_bioinfo_metadata.create_bioinfo_file()
     except Exception as e:
-        log.error(f"EXCEPTION FOUND: {e}")
-
+        log.exception(f"EXCEPTION FOUND: {e}")
+        raise
 
 # read metadata bioinformatics
 @relecov_tools_cli.command(help_priority=12)
@@ -574,8 +577,8 @@ def metadata_homogeneizer(institution, directory, output):
     try:
         new_parse.converting_metadata()
     except Exception as e:
-        log.error(f"EXCEPTION FOUND: {e}")
-
+        log.exception(f"EXCEPTION FOUND: {e}")
+        raise
 
 # creating symbolic links
 @relecov_tools_cli.command(help_priority=13)
@@ -616,8 +619,8 @@ def pipeline_manager(input, template, output, config, folder_names):
     try:
         new_launch.pipeline_exc()
     except Exception as e:
-        log.error(f"EXCEPTION FOUND: {e}")
-
+        log.exception(f"EXCEPTION FOUND: {e}")
+        raise
 
 # schema builder
 @relecov_tools_cli.command(help_priority=14)
@@ -656,8 +659,8 @@ def build_schema(input_file, schema_base, draft_version, diff, out_dir):
     try:
         schema_update.handle_build_schema()
     except Exception as e:
-        log.error(f"EXCEPTION FOUND: {e}")
-
+        log.exception(f"EXCEPTION FOUND: {e}")
+        raise
 
 @relecov_tools_cli.command(help_priority=15)
 @click.option(
@@ -704,8 +707,8 @@ def logs_to_excel(lab_code, output_folder, files):
         excel_outpath = os.path.join(output_folder, lab_code + "_logs_report.xlsx")
         logsum.create_logs_excel(logs=final_logs, excel_outpath=excel_outpath)
     except Exception as e:
-        log.error(f"EXCEPTION FOUND: {e}")
-
+        log.exception(f"EXCEPTION FOUND: {e}")
+        raise
 
 @relecov_tools_cli.command(help_priority=16)
 @click.option(
@@ -730,8 +733,8 @@ def wrapper(config_file, output_folder):
     try:
         process_wrapper.run_wrapper()
     except Exception as e:
-        log.error(f"EXCEPTION FOUND: {e}")
-
+        log.exception(f"EXCEPTION FOUND: {e}")
+        raise
 
 if __name__ == "__main__":
     run_relecov_tools()

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -64,7 +64,7 @@ def run_relecov_tools():
     )
 
     # stderr.print("[green]                                          `._,._,'\n", highlight=False)
-    __version__ = "1.2.0"
+    __version__ = "1.3.0"
     stderr.print(
         "\n" "[grey39]    RELECOV-tools version {}".format(__version__), highlight=False
     )

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -187,7 +187,10 @@ def download(
         output_location,
         target_folders,
     )
-    download_manager.execute_process()
+    try:
+        download_manager.execute_process()
+    except Exception as e:
+        log.error(f"EXCEPTION FOUND: {e}")
 
 
 # metadata
@@ -221,8 +224,10 @@ def read_lab_metadata(metadata_file, sample_list_file, metadata_out, files_folde
     new_metadata = relecov_tools.read_lab_metadata.RelecovMetadata(
         metadata_file, sample_list_file, metadata_out, files_folder
     )
-    relecov_json = new_metadata.create_metadata_json()
-    return relecov_json
+    try:
+        new_metadata.create_metadata_json()
+    except Exception as e:
+        log.error(f"EXCEPTION FOUND: {e}")
 
 
 # validation
@@ -241,7 +246,10 @@ def validate(json_file, json_schema, metadata, out_folder):
     validation = relecov_tools.json_validation.SchemaValidation(
         json_file, json_schema, metadata, out_folder
     )
-    validation.validate()
+    try:
+        validation.validate()
+    except Exception as e:
+        log.error(f"EXCEPTION FOUND: {e}")
 
 
 # send-email
@@ -348,7 +356,10 @@ def map(origin_schema, json_data, destination_schema, schema_file, output):
     new_schema = relecov_tools.map_schema.MappingSchema(
         origin_schema, json_data, destination_schema, schema_file, output
     )
-    new_schema.map_to_data_to_new_schema()
+    try:
+        new_schema.map_to_data_to_new_schema()
+    except Exception as e:
+        log.error(f"EXCEPTION FOUND: {e}")
 
 
 # upload to ENA
@@ -393,7 +404,10 @@ def upload_to_ena(
         upload_fastq=upload_fastq,
         output_path=output_path,
     )
-    upload_ena.upload()
+    try:
+        upload_ena.upload()
+    except Exception as e:
+        log.error(f"EXCEPTION FOUND: {e}")
 
 
 # upload to GISAID
@@ -460,7 +474,10 @@ def upload_to_gisaid(
         single,
         gzip,
     )
-    upload_gisaid.gisaid_upload()
+    try:
+        upload_gisaid.gisaid_upload()
+    except Exception as e:
+        log.error(f"EXCEPTION FOUND: {e}")
 
 
 @relecov_tools_cli.command(help_priority=9)
@@ -501,7 +518,10 @@ def update_db(user, password, json, type, platform, server_url, full_update):
     update_database_obj = relecov_tools.upload_database.UpdateDatabase(
         user, password, json, type, platform, server_url, full_update
     )
-    update_database_obj.update_db()
+    try:
+        update_database_obj.update_db()
+    except Exception as e:
+        log.error(f"EXCEPTION FOUND: {e}")
 
 
 # read metadata bioinformatics
@@ -525,8 +545,10 @@ def read_bioinfo_metadata(json_file, input_folder, out_dir, software_name):
         out_dir,
         software_name,
     )
-
-    new_bioinfo_metadata.create_bioinfo_file()
+    try:
+        new_bioinfo_metadata.create_bioinfo_file()
+    except Exception as e:
+        log.error(f"EXCEPTION FOUND: {e}")
 
 
 # read metadata bioinformatics
@@ -549,7 +571,10 @@ def metadata_homogeneizer(institution, directory, output):
     new_parse = relecov_tools.metadata_homogeneizer.MetadataHomogeneizer(
         institution, directory, output
     )
-    new_parse.converting_metadata()
+    try:
+        new_parse.converting_metadata()
+    except Exception as e:
+        log.error(f"EXCEPTION FOUND: {e}")
 
 
 # creating symbolic links
@@ -588,7 +613,10 @@ def pipeline_manager(input, template, output, config, folder_names):
     new_launch = relecov_tools.pipeline_manager.PipelineManager(
         input, template, output, config, folder_names
     )
-    new_launch.pipeline_exc()
+    try:
+        new_launch.pipeline_exc()
+    except Exception as e:
+        log.error(f"EXCEPTION FOUND: {e}")
 
 
 # schema builder
@@ -625,7 +653,10 @@ def build_schema(input_file, schema_base, draft_version, diff, out_dir):
     schema_update = relecov_tools.build_schema.SchemaBuilder(
         input_file, schema_base, draft_version, diff, out_dir
     )
-    schema_update.handle_build_schema()
+    try:
+        schema_update.handle_build_schema()
+    except Exception as e:
+        log.error(f"EXCEPTION FOUND: {e}")
 
 
 @relecov_tools_cli.command(help_priority=15)
@@ -667,10 +698,13 @@ def logs_to_excel(lab_code, output_folder, files):
         stderr.print("All provided files were empty.")
         exit(1)
     logsum = relecov_tools.log_summary.LogSum(output_location=output_folder)
-    merged_logs = logsum.merge_logs(key_name=lab_code, logs_list=all_logs)
-    final_logs = logsum.prepare_final_logs(logs=merged_logs)
-    excel_outpath = os.path.join(output_folder, lab_code + "_logs_report.xlsx")
-    logsum.create_logs_excel(logs=final_logs, excel_outpath=excel_outpath)
+    try:
+        merged_logs = logsum.merge_logs(key_name=lab_code, logs_list=all_logs)
+        final_logs = logsum.prepare_final_logs(logs=merged_logs)
+        excel_outpath = os.path.join(output_folder, lab_code + "_logs_report.xlsx")
+        logsum.create_logs_excel(logs=final_logs, excel_outpath=excel_outpath)
+    except Exception as e:
+        log.error(f"EXCEPTION FOUND: {e}")
 
 
 @relecov_tools_cli.command(help_priority=16)
@@ -693,7 +727,10 @@ def wrapper(config_file, output_folder):
     process_wrapper = relecov_tools.dataprocess_wrapper.ProcessWrapper(
         config_file=config_file, output_folder=output_folder
     )
-    process_wrapper.run_wrapper()
+    try:
+        process_wrapper.run_wrapper()
+    except Exception as e:
+        log.error(f"EXCEPTION FOUND: {e}")
 
 
 if __name__ == "__main__":

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -185,6 +185,7 @@ class LogSum:
 
         def reg_remover(string, pattern):
             """Remove annotation between brackets in logs message"""
+            string = str(string)
             string = string.replace("['", "'").replace("']", "'").replace('"', "")
             string = re.sub(pattern, "", string)
             return string.strip()
@@ -217,7 +218,9 @@ class LogSum:
                 new_sheet.append(header)
             regex = r"[\[\]]"  # Regex to remove lists brackets
             workbook["Global Report"].append(
-                [reg_remover(str(x), regex) for k, x in logs.items() if k != "samples"]
+                "\n ".join(
+                    [reg_remover(x, regex) for k, x in logs.items() if k != "samples"]
+                )
             )
             regex = r"\[.*?\]"  # Regex to remove ontology annotations between brackets
             for sample, slog in samples_logs.items():

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -47,9 +47,9 @@ class RelecovMetadata:
             if not os.path.isdir(str(files_folder)):
                 stderr.print("[red]No samples file nor valid files folder provided")
                 sys.exit(1)
+            self.files_folder = os.path.abspath(files_folder)
 
         self.sample_list_file = sample_list_file
-        self.files_folder = files_folder
 
         if sample_list_file is not None and not os.path.exists(sample_list_file):
             log.error("Sample information file %s does not exist ", sample_list_file)

--- a/relecov_tools/utils.py
+++ b/relecov_tools/utils.py
@@ -317,19 +317,24 @@ def compress_file(file):
 
 
 def check_gzip_integrity(file_path):
-    """Check if a compressed file is not corrupted"""
+    """Check if a compressed file can be decompressed"""
     chunksize = 100000000  # 10 Mbytes
     with gzip.open(file_path, "rb") as f:
         try:
             while f.read(chunksize) != b"":
                 pass
-        except gzip.BadGzipFile:
+        except Exception:
             # Not a gzip file
             return False
         # EOFError: Compressed file is truncated
         except EOFError:
             return False
     return True
+
+
+def lower_keys(data):
+    """Transform all keys to lowercase strings in a dictionary"""
+    return {str(key).lower(): v for key, v in data.items()}
 
 
 def rich_force_colors():

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = "1.2.0"
+version = "1.3.0"
 
 with open("README.md") as f:
     readme = f.read()


### PR DESCRIPTION
Changes in the pre-release:
Version has already been updated for the release.

Some hotfix that were needed for the release:

- Now files-folder arg works with relative paths in read-lab-metadata
- Homogeneized style of report global report sheet with the rest of the sheets when logs-to-excel is used (also within wrapper)
- Included a try-except for every module to catch unexpected errors, this is needed to catch any unexpected errors to the log-file that may lead the process to crash.
- Now check-gzip-integrity() catches any exception instead of just the (previously expected to be the only possible error) gzip.BadGzipFile error. This makes some sense as that method is only expected to return True when no exceptions are raised, meaning that the file integrity is intact and it can be decompressed with gzip.


















