### PR TITLE
Removed duplicated sequence/fastq_md5

### DIFF
--- a/relecov_tools/schema/relecov_schema.json
+++ b/relecov_tools/schema/relecov_schema.json
@@ -1875,29 +1875,6 @@
             "label": "Filepath R2 fastq",
             "fill_mode": "batch"
         },
-        "fastq_r1_md5": {
-            "examples": [
-                "b5242d60471e5a5a97b35531dbbe8c30"
-            ],
-            "ontology": "MS_1000568",
-            "type": "string",
-            "description": "Checksum value to validate successful file transmission",
-            "classification": "Bioinformatics and QC metrics fields",
-            "label": "Fastq md5 r1",
-            "fill_mode": "sample",
-            "minLenght": "1"
-        },
-        "fastq_r2_md5": {
-            "examples": [
-                "b5242d60471e5a5a97b35531dbbe8c30"
-            ],
-            "ontology": "MS_1000569",
-            "type": "string",
-            "description": "Checksum value to validate successful file transmission",
-            "classification": "Bioinformatics and QC metrics fields",
-            "label": "Sequence fastq R2 md5",
-            "fill_mode": "sample"
-        },
         "fast5_filename": {
             "examples": [
                 "batch1a_sequences.fast5"


### PR DESCRIPTION
Information for md5 was duplicated with similar names.

fastq_r1_md5 and astq_r2_md5 were removed.
We keep:

- sequence_file_R1_md5
- sequence_file_R2_md5