### PR TITLE
Fixed some issues in download module

### DIFF
--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -35,6 +35,8 @@ stderr = rich.console.Console(
     stderr=True, force_terminal=relecov_tools.utils.rich_force_colors()
 )
 
+__version__ = "1.3.0"
+
 
 def run_relecov_tools():
     # Set up the rich traceback
@@ -64,7 +66,6 @@ def run_relecov_tools():
     )
 
     # stderr.print("[green]                                          `._,._,'\n", highlight=False)
-    __version__ = "1.3.0"
     stderr.print(
         "\n" "[grey39]    RELECOV-tools version {}".format(__version__), highlight=False
     )
@@ -135,6 +136,7 @@ def relecov_tools_cli(verbose, log_file):
             )
         )
         log.addHandler(log_fh)
+        log.info(f"RELECOV-tools version {__version__}")
 
 
 # sftp

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -1174,20 +1174,22 @@ class DownloadManager:
                     corrupted.append(file)
 
             for sample_id, files in list(valid_filedict.items()):
-                if any(files.get(key) in corrupted for key in ["sequence_file_R1_fastq", "sequence_file_R2_fastq"]):
+                if any(
+                    files.get(key) in corrupted
+                    for key in ["sequence_file_R1_fastq", "sequence_file_R2_fastq"]
+                ):
                     for file_name in files.values():
                         path = os.path.join(local_folder, file_name)
                         try:
                             os.remove(path)
-                            log.info("File %s was removed because it was corrupted", file_name)
+                            log.info(
+                                "File %s was removed because it was corrupted",
+                                file_name,
+                            )
                         except (FileNotFoundError, PermissionError, OSError) as e:
-                            error_text = (
-                                "Could not remove corrupted file %s: %s"
-                            )
+                            error_text = "Could not remove corrupted file %s: %s"
                             log.error(error_text % (path, e))
-                            stderr.print(
-                                f"[red]{error_text % (path, e)}"
-                            )
+                            stderr.print(f"[red]{error_text % (path, e)}")
 
             not_md5sum = []
             if remote_md5sum:

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -1193,10 +1193,10 @@ class DownloadManager:
                 files_md5_dict = {}
                 for path in clean_pathlist:
                     f_name = os.path.basename(path)
-                    if f_name in successful_files:
-                        files_md5_dict[f_name] = hash_dict[f_name]
-                    elif f_name in corrupted:
+                    if f_name in corrupted:
                         clean_fetchlist.remove(f_name)
+                    elif f_name in successful_files:
+                        files_md5_dict[f_name] = hash_dict[f_name]
                     else:
                         if not str(f_name).rstrip(".gz") in files_to_compress:
                             error_text = "File %s not found in md5sum. Creating hash"

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -1181,6 +1181,12 @@ class DownloadManager:
             else:
                 clean_fetchlist = seqs_fetchlist
             clean_pathlist = [os.path.join(local_folder, fi) for fi in clean_fetchlist]
+
+            for file in clean_fetchlist:
+                full_f_path = os.path.join(local_folder, file)
+                if not relecov_tools.utils.check_gzip_integrity(full_f_path):
+                    corrupted.append(file)
+
             not_md5sum = []
             if remote_md5sum:
                 # Get hashes from provided md5sum, create them for those not provided
@@ -1204,10 +1210,6 @@ class DownloadManager:
                     relecov_tools.utils.calculate_md5(path) for path in clean_pathlist
                 ]
                 files_md5_dict = dict(zip(clean_fetchlist, md5_hashes))
-            for file in files_md5_dict.keys():
-                full_f_path = os.path.join(local_folder, file)
-                if not relecov_tools.utils.check_gzip_integrity(full_f_path):
-                    corrupted.append(file)
             files_md5_dict = {
                 x: y for x, y in files_md5_dict.items() if x not in corrupted
             }


### PR DESCRIPTION
- We move forward the gzip compression check.  
- Corrupted files are removed from "clean_fetchlist" before checking if they are in "successful_files."  
- If the samples are corrupted, instead of moving them to a corrupted folder, both R1 and R2 are deleted from the folder to request them again.
- Added relecov-tools version to log

Fixes issue #344
Partially fixed issue #336 