### PR TITLE
Fixing validate crashing with new sheet names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,12 +53,14 @@ Code contributions to the release:
 - Introduced a new Jinja template for successful and error validation reports. [#349](https://github.com/BU-ISCIII/relecov-tools/pull/349)
 - Modified the module logic to dynamically select and render email templates based on user input. [#349](https://github.com/BU-ISCIII/relecov-tools/pull/349)
 - Enhanced email formatting and added a default CC to bioinformatica@isciii.es. [#349](https://github.com/BU-ISCIII/relecov-tools/pull/349)
+- Validate module now takes an optional argument to select the name of the sheet to check in excel file [#357](https://github.com/BU-ISCIII/relecov-tools/pull/357)
 
 #### Fixes
 
 - Fixed python linting workflow was still waiting for .py files[#335](https://github.com/BU-ISCIII/relecov-tools/pull/335)
 - Now files-folder arg works with relative paths in read-lab-metadata [#339](https://github.com/BU-ISCIII/relecov-tools/pull/339)
 - Now check-gzip-integrity() catches any exception in utils.py as it only needs to return True when file can be decompressed [#339](https://github.com/BU-ISCIII/relecov-tools/pull/339)
+- Now validate modules does not crash when no METADATA_LAB sheet is found. [#357](https://github.com/BU-ISCIII/relecov-tools/pull/357)
 
 #### Changed
 

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -245,10 +245,17 @@ def read_lab_metadata(metadata_file, sample_list_file, metadata_out, files_folde
     help="Origin file containing metadata",
 )
 @click.option("-o", "--out_folder", help="Path to save validate json file")
-def validate(json_file, json_schema, metadata, out_folder):
+@click.option(
+    "-e",
+    "--excel_sheet",
+    required=False,
+    default=None,
+    help="Optional: Name of the sheet in excel file to validate.",
+)
+def validate(json_file, json_schema, metadata, out_folder, excel_sheet):
     """Validate json file against schema."""
     validation = relecov_tools.json_validation.SchemaValidation(
-        json_file, json_schema, metadata, out_folder
+        json_file, json_schema, metadata, out_folder, excel_sheet
     )
     try:
         validation.validate()

--- a/relecov_tools/json_validation.py
+++ b/relecov_tools/json_validation.py
@@ -75,8 +75,13 @@ class SchemaValidation:
         except ValueError as e:
             self.sample_id_field = None
             self.SAMPLE_FIELD_ERROR = str(e)
+        conf_subdata = config_json.get_topic_data("sftp_handle", "metadata_processing")
         if excel_sheet is None:
-            self.excel_sheet = "METADATA_LAB"
+            try:
+                self.excel_sheet = conf_subdata["excel_sheet"]
+            except KeyError:
+                log.error("Default metadata sheet name should be in config file")
+                raise
         else:
             self.excel_sheet = excel_sheet
 
@@ -193,11 +198,11 @@ class SchemaValidation:
         for row in invalid_json:
             sample_list.append(str(row[self.sample_id_field]))
         wb = openpyxl.load_workbook(metadata)
-        # TODO: Include this as a key in configuration.json
         try:
             ws_sheet = wb[self.excel_sheet]
         except KeyError:
-            log.error("No sheet with name %s could be found in excel file", str(self.excel_sheet))
+            logtxt = f"No sheet named {self.excel_sheet} could be found in {metadata}"
+            log.error(logtxt)
             raise
         tag = "Sample ID given for sequencing"
         seq_id_col = [idx for idx, cell in enumerate(ws_sheet[1]) if tag in cell.value]

--- a/relecov_tools/json_validation.py
+++ b/relecov_tools/json_validation.py
@@ -22,7 +22,12 @@ stderr = rich.console.Console(
 
 class SchemaValidation:
     def __init__(
-        self, json_data_file=None, json_schema_file=None, metadata=None, out_folder=None
+        self,
+        json_data_file=None,
+        json_schema_file=None,
+        metadata=None,
+        out_folder=None,
+        excel_sheet=None,
     ):
         """Validate json file against the schema"""
 
@@ -70,6 +75,10 @@ class SchemaValidation:
         except ValueError as e:
             self.sample_id_field = None
             self.SAMPLE_FIELD_ERROR = str(e)
+        if excel_sheet is None:
+            self.excel_sheet = "METADATA_LAB"
+        else:
+            self.excel_sheet = excel_sheet
 
     def validate_schema(self):
         """Validate json schema against draft"""
@@ -185,7 +194,11 @@ class SchemaValidation:
             sample_list.append(str(row[self.sample_id_field]))
         wb = openpyxl.load_workbook(metadata)
         # TODO: Include this as a key in configuration.json
-        ws_sheet = wb["METADATA_LAB"]
+        try:
+            ws_sheet = wb[self.excel_sheet]
+        except KeyError:
+            log.error("No sheet with name %s could be found in excel file", str(self.excel_sheet))
+            raise
         tag = "Sample ID given for sequencing"
         seq_id_col = [idx for idx, cell in enumerate(ws_sheet[1]) if tag in cell.value]
         if seq_id_col:

--- a/relecov_tools/json_validation.py
+++ b/relecov_tools/json_validation.py
@@ -30,9 +30,8 @@ class SchemaValidation:
         excel_sheet=None,
     ):
         """Validate json file against the schema"""
-
+        config_json = ConfigJson()
         if json_schema_file is None:
-            config_json = ConfigJson()
             schema_name = config_json.get_topic_data("json_schemas", "relecov_schema")
             json_schema_file = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)), "schema", schema_name


### PR DESCRIPTION
Validate module was crashing when no "METADATA_LAB" sheet was found in the excel file. This PR addresses it by adding a new optional argument, aswell as taking the default value from the config file.