### PR TITLE
Fixed read-bioinfo-metadata module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Code contributions to the release:
 
 #### Fixes
 
+- Fixed read-bioinfo-metadata module [#367](https://github.com/BU-ISCIII/relecov-tools/pull/367)
+
 #### Changed
 
 #### Removed

--- a/relecov_tools/assets/pipeline_utils/viralrecon.py
+++ b/relecov_tools/assets/pipeline_utils/viralrecon.py
@@ -354,7 +354,7 @@ def handle_pangolin_data(files_list, batch_date, output_folder=None):
     return pango_data_processed
 
 
-def parse_long_table(files_list, batch_id, output_folder=None):
+def parse_long_table(files_list, batch_date, output_folder=None):
     """File handler to retrieve data from long table files and convert it into a JSON structured format.
     This function utilizes the LongTableParse class to parse the long table data.
     Since this utility handles and maps data using a custom way, it returns None to be avoid being  transferred to method read_bioinfo_metadata.BioinfoMetadata.mapping_over_table().
@@ -383,7 +383,7 @@ def parse_long_table(files_list, batch_id, output_folder=None):
         # Parsing long table data and saving it
         long_table_data = long_table.parsing_csv()
         # Saving long table data into a file
-        long_table.save_to_file(long_table_data, batch_id)
+        long_table.save_to_file(long_table_data, batch_date)
         stderr.print("[green]\tProcess completed")
     elif len(files_list) > 1:
         method_log_report.update_log_report(
@@ -395,7 +395,7 @@ def parse_long_table(files_list, batch_id, output_folder=None):
     return None
 
 
-def handle_consensus_fasta(files_list, batch_id, output_folder=None):
+def handle_consensus_fasta(files_list, batch_date, output_folder=None):
     """File handler to parse consensus data (fasta) into JSON structured format.
 
     Args:

--- a/relecov_tools/assets/pipeline_utils/viralrecon.py
+++ b/relecov_tools/assets/pipeline_utils/viralrecon.py
@@ -153,10 +153,9 @@ class LongTableParse:
             j_list.append(j_dict)
         return j_list
 
-    def save_to_file(self, j_list):
+    def save_to_file(self, j_list, batch_date):
         """Transform the parsed data into a json file"""
-        date_now = datetime.now().strftime("%Y%m%d%H%M%S")
-        file_name = "long_table_" + date_now + ".json"
+        file_name = "long_table_" + batch_date + ".json"
         file_path = os.path.join(self.output_directory, file_name)
 
         try:
@@ -180,7 +179,7 @@ class LongTableParse:
 
 
 # START util functions
-def handle_pangolin_data(files_list, output_folder=None):
+def handle_pangolin_data(files_list, batch_date, output_folder=None):
     """File handler to parse pangolin data (csv) into JSON structured format.
 
     Args:
@@ -320,7 +319,7 @@ def handle_pangolin_data(files_list, output_folder=None):
     return pango_data_processed
 
 
-def parse_long_table(files_list, output_folder=None):
+def parse_long_table(files_list, batch_id, output_folder=None):
     """File handler to retrieve data from long table files and convert it into a JSON structured format.
     This function utilizes the LongTableParse class to parse the long table data.
     Since this utility handles and maps data using a custom way, it returns None to be avoid being  transferred to method read_bioinfo_metadata.BioinfoMetadata.mapping_over_table().
@@ -349,7 +348,7 @@ def parse_long_table(files_list, output_folder=None):
         # Parsing long table data and saving it
         long_table_data = long_table.parsing_csv()
         # Saving long table data into a file
-        long_table.save_to_file(long_table_data)
+        long_table.save_to_file(long_table_data, batch_id)
         stderr.print("[green]\tProcess completed")
     elif len(files_list) > 1:
         method_log_report.update_log_report(
@@ -361,7 +360,7 @@ def parse_long_table(files_list, output_folder=None):
     return None
 
 
-def handle_consensus_fasta(files_list, output_folder=None):
+def handle_consensus_fasta(files_list, batch_id, output_folder=None):
     """File handler to parse consensus data (fasta) into JSON structured format.
 
     Args:

--- a/relecov_tools/assets/pipeline_utils/viralrecon.py
+++ b/relecov_tools/assets/pipeline_utils/viralrecon.py
@@ -158,25 +158,35 @@ class LongTableParse:
         file_name = "long_table_" + batch_date + ".json"
         file_path = os.path.join(self.output_directory, file_name)
         if os.path.exists(file_path):
-            stderr.print(f"[blue]Long table {file_path} file already exists. Merging new data if possible.")
-            log.info("Long table %s file already exists. Merging new data if possible." % file_path)
+            stderr.print(
+                f"[blue]Long table {file_path} file already exists. Merging new data if possible."
+            )
+            log.info(
+                "Long table %s file already exists. Merging new data if possible."
+                % file_path
+            )
             original_table = relecov_tools.utils.read_json_file(file_path)
             samples_indict = {item["sample_name"]: item for item in original_table}
             for item in j_list:
                 sample_name = item["sample_name"]
                 if sample_name in samples_indict:
                     if samples_indict[sample_name] != item:
-                        stderr.print(f"[red]Same sample has different data in both long tables.")
+                        stderr.print(
+                            f"[red]Same sample has different data in both long tables."
+                        )
                         log.error(
-                            "Sample %s has different data in %s and new long table. Can't merge." % (sample_name, file_path)
-                            )
+                            "Sample %s has different data in %s and new long table. Can't merge."
+                            % (sample_name, file_path)
+                        )
                         return None
                 else:
                     original_table.append(item)
             try:
                 with open(file_path, "w") as fh:
                     fh.write(json.dumps(original_table, indent=4))
-                stderr.print("[green]\tParsed data successfully saved to file:", file_path)
+                stderr.print(
+                    "[green]\tParsed data successfully saved to file:", file_path
+                )
             except Exception as e:
                 stderr.print("[red]\tError saving parsed data to file:", str(e))
 
@@ -184,7 +194,9 @@ class LongTableParse:
             try:
                 with open(file_path, "w") as fh:
                     fh.write(json.dumps(j_list, indent=4))
-                stderr.print("[green]\tParsed data successfully saved to file:", file_path)
+                stderr.print(
+                    "[green]\tParsed data successfully saved to file:", file_path
+                )
             except Exception as e:
                 stderr.print("[red]\tError saving parsed data to file:", str(e))
 
@@ -311,9 +323,9 @@ def handle_pangolin_data(files_list, batch_date, output_folder=None):
                 )
                 # Add custom content in pangolin
                 pango_data_key = next(iter(pango_data))
-                pango_data[pango_data_key]["lineage_analysis_date"] = (
-                    relecov_tools.utils.get_file_date(pango_file)
-                )
+                pango_data[pango_data_key][
+                    "lineage_analysis_date"
+                ] = relecov_tools.utils.get_file_date(pango_file)
                 pango_data[pango_data_key]["pangolin_database_version"] = pango_data_v
                 # Rename key in f_data
                 pango_data_updated = {

--- a/relecov_tools/assets/pipeline_utils/viralrecon.py
+++ b/relecov_tools/assets/pipeline_utils/viralrecon.py
@@ -134,7 +134,7 @@ class LongTableParse:
         j_list = []
         # Grab date from filename
         result_regex = re.search(
-            "variants_long_table(?:_\d{8})?\.csv", os.path.basename(self.file_path)
+            "variants_long_table(?:_\d{14})?\.csv", os.path.basename(self.file_path)
         )
         if result_regex is None:
             stderr.print(

--- a/relecov_tools/assets/pipeline_utils/viralrecon.py
+++ b/relecov_tools/assets/pipeline_utils/viralrecon.py
@@ -322,9 +322,9 @@ def handle_pangolin_data(files_list, batch_date, output_folder=None):
                 )
                 # Add custom content in pangolin
                 pango_data_key = next(iter(pango_data))
-                pango_data[pango_data_key][
-                    "lineage_analysis_date"
-                ] = relecov_tools.utils.get_file_date(pango_file)
+                pango_data[pango_data_key]["lineage_analysis_date"] = (
+                    relecov_tools.utils.get_file_date(pango_file)
+                )
                 pango_data[pango_data_key]["pangolin_database_version"] = pango_data_v
                 # Rename key in f_data
                 pango_data_updated = {

--- a/relecov_tools/assets/pipeline_utils/viralrecon.py
+++ b/relecov_tools/assets/pipeline_utils/viralrecon.py
@@ -188,7 +188,7 @@ class LongTableParse:
                 )
             except Exception as e:
                 stderr.print("[red]\tError saving parsed data to file:", str(e))
-
+                log.error("Error saving parsed data to file: %s", e)
         else:
             try:
                 with open(file_path, "w") as fh:
@@ -198,6 +198,7 @@ class LongTableParse:
                 )
             except Exception as e:
                 stderr.print("[red]\tError saving parsed data to file:", str(e))
+                log.error("Error saving parsed data to file: %s", e)
 
     def parsing_csv(self):
         """

--- a/relecov_tools/assets/pipeline_utils/viralrecon.py
+++ b/relecov_tools/assets/pipeline_utils/viralrecon.py
@@ -157,13 +157,36 @@ class LongTableParse:
         """Transform the parsed data into a json file"""
         file_name = "long_table_" + batch_date + ".json"
         file_path = os.path.join(self.output_directory, file_name)
+        if os.path.exists(file_path):
+            stderr.print(f"[blue]Long table {file_path} file already exists. Merging new data if possible.")
+            log.info("Long table %s file already exists. Merging new data if possible." % file_path)
+            original_table = relecov_tools.utils.read_json_file(file_path)
+            samples_indict = {item["sample_name"]: item for item in original_table}
+            for item in j_list:
+                sample_name = item["sample_name"]
+                if sample_name in samples_indict:
+                    if samples_indict[sample_name] != item:
+                        stderr.print(f"[red]Same sample has different data in both long tables.")
+                        log.error(
+                            "Sample %s has different data in %s and new long table. Can't merge." % (sample_name, file_path)
+                            )
+                        return None
+                else:
+                    original_table.append(item)
+            try:
+                with open(file_path, "w") as fh:
+                    fh.write(json.dumps(original_table, indent=4))
+                stderr.print("[green]\tParsed data successfully saved to file:", file_path)
+            except Exception as e:
+                stderr.print("[red]\tError saving parsed data to file:", str(e))
 
-        try:
-            with open(file_path, "w") as fh:
-                fh.write(json.dumps(j_list, indent=4))
-            stderr.print("[green]\tParsed data successfully saved to file:", file_path)
-        except Exception as e:
-            stderr.print("[red]\tError saving parsed data to file:", str(e))
+        else:
+            try:
+                with open(file_path, "w") as fh:
+                    fh.write(json.dumps(j_list, indent=4))
+                stderr.print("[green]\tParsed data successfully saved to file:", file_path)
+            except Exception as e:
+                stderr.print("[red]\tError saving parsed data to file:", str(e))
 
     def parsing_csv(self):
         """

--- a/relecov_tools/assets/pipeline_utils/viralrecon.py
+++ b/relecov_tools/assets/pipeline_utils/viralrecon.py
@@ -8,7 +8,6 @@ import rich
 import os.path
 
 from pathlib import Path
-from datetime import datetime
 
 import relecov_tools.utils
 from relecov_tools.config_json import ConfigJson
@@ -172,7 +171,7 @@ class LongTableParse:
                 if sample_name in samples_indict:
                     if samples_indict[sample_name] != item:
                         stderr.print(
-                            f"[red]Same sample has different data in both long tables."
+                            f"[red]Same sample {sample_name} has different data in both long tables."
                         )
                         log.error(
                             "Sample %s has different data in %s and new long table. Can't merge."

--- a/relecov_tools/conf/bioinfo_config.json
+++ b/relecov_tools/conf/bioinfo_config.json
@@ -6,6 +6,7 @@
             "header_row_idx": 1,
             "required": true,
             "function": null,
+            "multiple_samples": true,
             "split_by_batch": true,
             "content": {
                 "analysis_date": "analysis_date",
@@ -44,6 +45,7 @@
             "sample_col_idx": 1,
             "header_row_idx": 1,
             "required": true,
+            "multiple_samples": true,
             "split_by_batch": true,
             "function": "parse_long_table",
             "content": {
@@ -84,6 +86,7 @@
             "fn": "summary_variants_metrics_mqc.csv",
             "sample_col_idx": 1,
             "header_row_idx": 1,
+            "multiple_samples": true,
             "required": true,
             "function": null,
             "content": {
@@ -100,6 +103,7 @@
         "workflow_summary": {
             "fn": "multiqc_report.html",
             "required": true,
+            "multiple_samples": true,
             "function": null,
             "content": {
                 "software_version": {

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -800,6 +800,19 @@ class BioinfoMetadata:
         self.validate_software_mandatory_files(files_found_dict)
         # Split files found based on each batch of samples
         data_by_batch = self.split_data_by_batch(self.j_data)
+        batch_dates = []
+        #Get batch date for all the samples
+        for batch_dir, batch_dict in data_by_batch.items():
+            if batch_dir.split("/")[-1] not in batch_dates:
+                batch_dates.append(batch_dir.split("/")[-1])
+
+        if len(batch_dates) == 1:
+            batch_dates = str(batch_dates[0])
+        else:
+            stderr.print(f"[orange]More than one batch date in the same json data. Using current date as batch date.")
+            log.info("]More than one batch date in the same json data. Using current date as batch date.")
+            batch_dates = datetime.now().strftime("%Y%m%d%H%M%S")
+
         # Add bioinfo metadata to j_data
         for batch_dir, batch_dict in data_by_batch.items():
             self.log_report.logsum.feed_key(batch_dir)

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -980,4 +980,10 @@ class BioinfoMetadata:
         self.log_report.logsum.create_error_summary(
             called_module="read-bioinfo-metadata", logs=self.log_report.logsum.logs
         )
+        for batch_dir, batch_dict in data_by_batch.items():
+            self.log_report.logsum.create_error_summary(
+                called_module="read-bioinfo-metadata",
+                filepath=batch_dir,
+                logs=self.log_report.logsum.logs
+            )
         return True

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -233,7 +233,9 @@ class BioinfoMetadata:
         self.log_report.print_log_report(method_name, ["valid", "warning"])
         return
 
-    def add_bioinfo_results_metadata(self, files_dict, j_data, batch_id, output_folder=None):
+    def add_bioinfo_results_metadata(
+        self, files_dict, j_data, batch_id, output_folder=None
+    ):
         """Adds metadata from bioinformatics results to j_data.
         It first calls file_handlers and then maps the handled
         data into j_data.
@@ -370,7 +372,12 @@ class BioinfoMetadata:
                 import_statement = f"import {utils_name}"
                 exec(import_statement)
                 # Get method name and execute it.
-                data = eval(utils_name + "." + func_name + "(file_list, batch_id, output_folder)")
+                data = eval(
+                    utils_name
+                    + "."
+                    + func_name
+                    + "(file_list, batch_id, output_folder)"
+                )
             except Exception as e:
                 self.log_report.update_log_report(
                     self.add_bioinfo_results_metadata.__name__,
@@ -751,12 +758,10 @@ class BioinfoMetadata:
             sample_col = file_df.columns[sample_colpos]
             file_df[sample_col] = file_df[sample_col].astype(str)
             file_df = file_df[file_df[sample_col].isin(batch_samples)]
-            
+
             base, ext = os.path.splitext(os.path.basename(file))
             new_filename = f"{base}_{sufix}{ext}"
-            output_path = os.path.join(
-                output_dir, "analysis_results", new_filename
-            )
+            output_path = os.path.join(output_dir, "analysis_results", new_filename)
             file_df.to_csv(output_path, index=False, sep=extdict.get(file_extension))
             return
 
@@ -771,7 +776,7 @@ class BioinfoMetadata:
             sample_colpos = self.get_sample_idx_colpos(key)
             for file in files:
                 try:
-                    extract_batch_rows_to_file(file,sufix)
+                    extract_batch_rows_to_file(file, sufix)
                 except Exception as e:
                     if self.software_config[key].get("required"):
                         log_type = "error"
@@ -794,17 +799,22 @@ class BioinfoMetadata:
             batch_data (dict): A dictionary containing metadata of the samples.
         Returns:
             None
-        """        
+        """
         merged_metadata = relecov_tools.utils.read_json_file(batch_filepath)
-        prev_metadata_dict = {item["sequencing_sample_id"]: item for item in merged_metadata}
+        prev_metadata_dict = {
+            item["sequencing_sample_id"]: item for item in merged_metadata
+        }
         for item in batch_data:
             sample_id = item["sequencing_sample_id"]
             if sample_id in prev_metadata_dict:
                 # When sample already in metadata, checking whether dictionary is the same
                 if prev_metadata_dict[sample_id] != item:
-                    stderr.print(f"[red] Sample {sample_id} has different data in {batch_filepath} and new metadata. Can't merge.")
+                    stderr.print(
+                        f"[red] Sample {sample_id} has different data in {batch_filepath} and new metadata. Can't merge."
+                    )
                     log.error(
-                        "Sample %s has different data in %s and new metadata. Can't merge." % (sample_id, batch_filepath)
+                        "Sample %s has different data in %s and new metadata. Can't merge."
+                        % (sample_id, batch_filepath)
                     )
                     sys.exit(1)
             else:
@@ -842,11 +852,18 @@ class BioinfoMetadata:
                     continue
                 try:
                     # Dynamically import the function from the specified module
-                    utils_name = f"relecov_tools.assets.pipeline_utils.{self.software_name}"
+                    utils_name = (
+                        f"relecov_tools.assets.pipeline_utils.{self.software_name}"
+                    )
                     import_statement = f"import {utils_name}"
                     exec(import_statement)
                     # Get method name and execute it.
-                    data = eval(utils_name + "." + func_name + "(file_path, batch_date, output_folder)")
+                    data = eval(
+                        utils_name
+                        + "."
+                        + func_name
+                        + "(file_path, batch_date, output_folder)"
+                    )
                 except Exception as e:
                     self.log_report.update_log_report(
                         self.save_splitted_files.__name__,
@@ -855,7 +872,7 @@ class BioinfoMetadata:
                     )
                     sys.exit(self.log_report.print_log_report(method_name, ["error"]))
         return
-    
+
     def get_multiple_sample_files(self):
         method_name = f"{self.add_bioinfo_files_path.__name__}:{self.get_multiple_sample_files.__name__}"
         multiple_sample_files = []
@@ -880,7 +897,7 @@ class BioinfoMetadata:
         # Split files found based on each batch of samples
         data_by_batch = self.split_data_by_batch(self.j_data)
         batch_dates = []
-        #Get batch date for all the samples
+        # Get batch date for all the samples
         for batch_dir, batch_dict in data_by_batch.items():
             if batch_dir.split("/")[-1] not in batch_dates:
                 batch_dates.append(batch_dir.split("/")[-1])
@@ -888,8 +905,12 @@ class BioinfoMetadata:
         if len(batch_dates) == 1:
             batch_dates = str(batch_dates[0])
         else:
-            stderr.print(f"[orange]More than one batch date in the same json data. Using current date as batch date.")
-            log.info("]More than one batch date in the same json data. Using current date as batch date.")
+            stderr.print(
+                f"[orange]More than one batch date in the same json data. Using current date as batch date."
+            )
+            log.info(
+                "]More than one batch date in the same json data. Using current date as batch date."
+            )
             batch_dates = datetime.now().strftime("%Y%m%d%H%M%S")
 
         # Add bioinfo metadata to j_data
@@ -917,8 +938,13 @@ class BioinfoMetadata:
             batch_filename = tag + lab_code + "_" + batch_date + ".json"
             batch_filepath = os.path.join(batch_dir, batch_filename)
             if os.path.exists(batch_filepath):
-                stderr.print(f"[blue]Bioinfo metadata {batch_filepath} file already exists. Merging new data if possible.")
-                log.info("Bioinfo metadata %s file already exists. Merging new data if possible." % batch_filepath)
+                stderr.print(
+                    f"[blue]Bioinfo metadata {batch_filepath} file already exists. Merging new data if possible."
+                )
+                log.info(
+                    "Bioinfo metadata %s file already exists. Merging new data if possible."
+                    % batch_filepath
+                )
                 batch_data = self.merge_metadata(batch_filepath, batch_data)
             else:
                 relecov_tools.utils.write_json_fo_file(batch_data, batch_filepath)
@@ -941,8 +967,13 @@ class BioinfoMetadata:
         stderr.print("[blue]Writting output json file")
         file_path = os.path.join(out_path, batch_filename)
         if os.path.exists(file_path):
-            stderr.print(f"[blue]Bioinfo metadata {file_path} file already exists. Merging new data if possible.")
-            log.info("Bioinfo metadata %s file already exists. Merging new data if possible." % file_path)
+            stderr.print(
+                f"[blue]Bioinfo metadata {file_path} file already exists. Merging new data if possible."
+            )
+            log.info(
+                "Bioinfo metadata %s file already exists. Merging new data if possible."
+                % file_path
+            )
             batch_data = self.merge_metadata(file_path, self.j_data)
         else:
             relecov_tools.utils.write_json_fo_file(self.j_data, file_path)

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -980,10 +980,4 @@ class BioinfoMetadata:
         self.log_report.logsum.create_error_summary(
             called_module="read-bioinfo-metadata", logs=self.log_report.logsum.logs
         )
-        for batch_dir, batch_dict in data_by_batch.items():
-            self.log_report.logsum.create_error_summary(
-                called_module="read-bioinfo-metadata",
-                filepath=batch_dir,
-                logs=self.log_report.logsum.logs
-            )
         return True

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -381,7 +381,9 @@ class BioinfoMetadata:
                 matching_files = [
                     f for f in os.listdir(splitted_path) if pattern.match(f)
                 ]
-                full_paths = [os.path.join(splitted_path, f) for f in matching_files]  # noqua: F841
+                full_paths = [
+                    os.path.join(splitted_path, f) for f in matching_files
+                ]  # noqa: F841
                 try:
                     # Dynamically import the function from the specified module
                     utils_name = (

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -392,7 +392,6 @@ class BioinfoMetadata:
                     import_statement = f"import {utils_name}"
                     exec(import_statement)
                     # Get method name and execute it.
-                    print("lanzar_variants_long_table")
                     data = eval(
                         utils_name
                         + "."

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -381,9 +381,9 @@ class BioinfoMetadata:
                 matching_files = [
                     f for f in os.listdir(splitted_path) if pattern.match(f)
                 ]
-                full_paths = [
+                full_paths = [  # noqa: F841
                     os.path.join(splitted_path, f) for f in matching_files
-                ]  # noqa: F841
+                ]
                 try:
                     # Dynamically import the function from the specified module
                     utils_name = (

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -601,6 +601,7 @@ class BioinfoMetadata:
         """
         method_name = f"{self.add_bioinfo_files_path.__name__}"
         sample_name_error = 0
+        multiple_sample_files = self.get_multiple_sample_files()
         for row in j_data:
             row["bioinfo_metadata_file"] = self.out_filename
             if not row.get("sequencing_sample_id"):
@@ -614,10 +615,13 @@ class BioinfoMetadata:
             for key, values in files_found_dict.items():
                 file_path = "Not Provided [GENEPIO:0001668]"
                 if values:  # Check if value is not empty
-                    for file in values:
-                        if sample_name in file:
-                            file_path = file
-                            break  # Exit loop if match found
+                    if key in multiple_sample_files:
+                        file_path = values[0]
+                    else:
+                        for file in values:
+                            if sample_name in file:
+                                file_path = file
+                                break  # Exit loop if match found
                 path_key = f"{self.software_name}_filepath_{key}"
                 row[path_key] = file_path
                 if self.software_config[key].get("extract"):

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -824,9 +824,9 @@ class BioinfoMetadata:
         relecov_tools.utils.write_json_fo_file(merged_metadata, batch_filepath)
         return merged_metadata
 
-    def save_splitted_files(self, files_dict, batch_date, output_folder=None):
+    def save_merged_files(self, files_dict, batch_date, output_folder=None):
         """
-        Process and save files that where split by batch and that have a function to be processed
+        Process and save files that where split by cod and that have a function to be processed
 
         Args:
             files_dict (dict): A dictionary containing file paths identified for each configuration item.
@@ -836,7 +836,7 @@ class BioinfoMetadata:
         Returns:
             None
         """
-        method_name = f"{self.save_splitted_files.__name__}"
+        method_name = f"{self.save_merged_files.__name__}"
         for key, config in self.software_config.items():
             func_name = config.get("function")
             # Skip configurations that do not match the conditions
@@ -867,7 +867,7 @@ class BioinfoMetadata:
                     )
                 except Exception as e:
                     self.log_report.update_log_report(
-                        self.save_splitted_files.__name__,
+                        self.save_merged_files.__name__,
                         "error",
                         f"Error occurred while parsing '{func_name}': {e}.",
                     )
@@ -963,7 +963,7 @@ class BioinfoMetadata:
         tag = "bioinfo_lab_metadata_"
         stderr.print("[blue]Saving previously splitted files to output directory")
 
-        self.save_splitted_files(files_found_dict, batch_dates, out_path)
+        self.save_merged_files(files_found_dict, batch_dates, out_path)
         batch_filename = tag + batch_dates + ".json"
         stderr.print("[blue]Writting output json file")
         file_path = os.path.join(out_path, batch_filename)

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -831,6 +831,11 @@ class BioinfoMetadata:
                 )
             log.info("Created output json file: %s" % batch_filepath)
             stderr.print(f"[green]Created batch json file: {batch_filepath}")
+
+        year = str(datetime.now().year)
+        out_path = os.path.join(self.output_folder, year)
+        os.makedirs(out_path, exist_ok=True)
+
         stderr.print("[blue]Writting output json file")
         os.makedirs(self.output_folder, exist_ok=True)
         file_path = os.path.join(self.output_folder, self.out_filename)

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -856,6 +856,14 @@ class BioinfoMetadata:
                     sys.exit(self.log_report.print_log_report(method_name, ["error"]))
         return
     
+    def get_multiple_sample_files(self):
+        method_name = f"{self.add_bioinfo_files_path.__name__}:{self.get_multiple_sample_files.__name__}"
+        multiple_sample_files = []
+        for key in self.software_config.keys():
+            if self.software_config[key].get("multiple_samples"):
+                multiple_sample_files.append(key)
+        return multiple_sample_files
+
     def create_bioinfo_file(self):
         """Create the bioinfodata json with collecting information from lab
         metadata json, mapping_stats, and more information from the files

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -381,7 +381,7 @@ class BioinfoMetadata:
                 matching_files = [
                     f for f in os.listdir(splitted_path) if pattern.match(f)
                 ]
-                full_paths = [os.path.join(splitted_path, f) for f in matching_files] # noqua: F841
+                full_paths = [os.path.join(splitted_path, f) for f in matching_files]  # noqua: F841
                 try:
                     # Dynamically import the function from the specified module
                     utils_name = (

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -234,7 +234,7 @@ class BioinfoMetadata:
         return
 
     def add_bioinfo_results_metadata(
-        self, files_dict, j_data, sufix, batch_id, output_folder=None
+        self, files_dict, j_data, sufix, batch_date, output_folder=None
     ):
         """Adds metadata from bioinformatics results to j_data.
         It first calls file_handlers and then maps the handled
@@ -245,7 +245,7 @@ class BioinfoMetadata:
             j_data (list(dict{str:str}): A list of dictionaries containing metadata lab (list item per sample).
             sufix (str): Sufix added to splitted tables file name.
             output_folder (str): Path to save output files generated during handling_files() process.
-            batch_id(str): ID of the batch which corresponds with the data download date.
+            batch_date(str): Number of the batch which corresponds with the data download date.
 
         Returns:
             j_data_mapped: A list of dictionaries with bioinformatics metadata mapped into j_data.
@@ -269,7 +269,7 @@ class BioinfoMetadata:
                 continue
             # Handling files
             data_to_map = self.handling_files(
-                files_dict[key], sufix, output_folder, batch_id
+                files_dict[key], sufix, output_folder, batch_date
             )
             # Mapping data to j_data
             mapping_fields = self.software_config[key].get("content")
@@ -331,7 +331,7 @@ class BioinfoMetadata:
             sys.exit(self.log_report.print_log_report(method_name, ["error"]))
         return data
 
-    def handling_files(self, file_list, sufix, output_folder, batch_id):
+    def handling_files(self, file_list, sufix, output_folder, batch_date):
         """Handles different file formats to extract data regardless of their structure.
         The goal is to extract the data contained in files specified in ${file_list},
         using either 'standard' handlers defined in this class or pipeline-specific file handlers.
@@ -358,6 +358,7 @@ class BioinfoMetadata:
         Args:
             file_list (list): A list of file path/s to be processed.
             output_folder (str): Path to save output files from imported method if necessary
+            batch_date(str): Number of the batch which corresponds with the data download date.
 
         Returns:
             data: A dictionary containing bioinfo metadata handled for each sample.
@@ -394,7 +395,7 @@ class BioinfoMetadata:
                         utils_name
                         + "."
                         + func_name
-                        + "(full_paths, batch_id, output_folder)"
+                        + "(full_paths, batch_date, output_folder)"
                     )
                 except Exception as e:
                     self.log_report.update_log_report(
@@ -416,7 +417,7 @@ class BioinfoMetadata:
                         utils_name
                         + "."
                         + func_name
-                        + "(file_list, batch_id, output_folder)"
+                        + "(file_list, batch_date, output_folder)"
                     )
                 except Exception as e:
                     self.log_report.update_log_report(

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -871,10 +871,9 @@ class BioinfoMetadata:
                         f"Error occurred while parsing '{func_name}': {e}.",
                     )
                     sys.exit(self.log_report.print_log_report(method_name, ["error"]))
-        return
+        return data
 
     def get_multiple_sample_files(self):
-        method_name = f"{self.add_bioinfo_files_path.__name__}:{self.get_multiple_sample_files.__name__}"
         multiple_sample_files = []
         for key in self.software_config.keys():
             if self.software_config[key].get("multiple_samples"):
@@ -906,10 +905,10 @@ class BioinfoMetadata:
             batch_dates = str(batch_dates[0])
         else:
             stderr.print(
-                f"[orange]More than one batch date in the same json data. Using current date as batch date."
+                "[orange]More than one batch date in the same json data. Using current date as batch date."
             )
             log.info(
-                "]More than one batch date in the same json data. Using current date as batch date."
+                "More than one batch date in the same json data. Using current date as batch date."
             )
             batch_dates = datetime.now().strftime("%Y%m%d%H%M%S")
 

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -381,7 +381,7 @@ class BioinfoMetadata:
                 matching_files = [
                     f for f in os.listdir(splitted_path) if pattern.match(f)
                 ]
-                full_paths = [os.path.join(splitted_path, f) for f in matching_files]
+                full_paths = [os.path.join(splitted_path, f) for f in matching_files] # noqua: F841
                 try:
                     # Dynamically import the function from the specified module
                     utils_name = (

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -920,6 +920,7 @@ class BioinfoMetadata:
             stderr.print(f"[blue]Processing data from {batch_dir}")
             batch_data = batch_dict["j_data"]
             stderr.print("[blue]Adding bioinfo metadata to read lab metadata...")
+            self.split_tables_by_batch(files_found_dict, sufix, batch_data, batch_dir)
             batch_data = self.add_bioinfo_results_metadata(
                 files_found_dict, batch_data, batch_date, batch_dir
             )
@@ -932,7 +933,6 @@ class BioinfoMetadata:
             # Adding files path
             stderr.print("[blue]Adding files path to read lab metadata")
             batch_data = self.add_bioinfo_files_path(files_found_dict, batch_data)
-            self.split_tables_by_batch(files_found_dict, batch_data, batch_dir)
             tag = "bioinfo_lab_metadata_"
             batch_filename = tag + lab_code + "_" + batch_date + ".json"
             batch_filepath = os.path.join(batch_dir, batch_filename)

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -268,7 +268,9 @@ class BioinfoMetadata:
                 )
                 continue
             # Handling files
-            data_to_map = self.handling_files(files_dict[key], sufix, output_folder, batch_id)
+            data_to_map = self.handling_files(
+                files_dict[key], sufix, output_folder, batch_id
+            )
             # Mapping data to j_data
             mapping_fields = self.software_config[key].get("content")
             if not mapping_fields:
@@ -372,7 +374,9 @@ class BioinfoMetadata:
             if current_config.get("split_by_batch") is True:
                 file_extension = current_config.get("fn").rsplit(".", 1)[1]
                 base_filename = current_config.get("fn").rsplit(".", 1)[0]
-                pattern = re.compile(f"{base_filename}_{sufix}.{re.escape(file_extension)}")
+                pattern = re.compile(
+                    f"{base_filename}_{sufix}.{re.escape(file_extension)}"
+                )
                 matching_files = [
                     f for f in os.listdir(splitted_path) if pattern.match(f)
                 ]
@@ -402,7 +406,9 @@ class BioinfoMetadata:
             else:
                 try:
                     # Dynamically import the function from the specified module
-                    utils_name = f"relecov_tools.assets.pipeline_utils.{self.software_name}"
+                    utils_name = (
+                        f"relecov_tools.assets.pipeline_utils.{self.software_name}"
+                    )
                     import_statement = f"import {utils_name}"
                     exec(import_statement)
                     # Get method name and execute it.

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -803,6 +803,7 @@ class BioinfoMetadata:
 
             base, ext = os.path.splitext(os.path.basename(file))
             new_filename = f"{base}_{sufix}{ext}"
+            os.makedirs(os.path.join(output_dir, "analysis_results"), exist_ok=True)
             output_path = os.path.join(output_dir, "analysis_results", new_filename)
             file_df.to_csv(output_path, index=False, sep=extdict.get(file_extension))
             return

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -232,7 +232,7 @@ class BioinfoMetadata:
         self.log_report.print_log_report(method_name, ["valid", "warning"])
         return
 
-    def add_bioinfo_results_metadata(self, files_dict, j_data, output_folder=None):
+    def add_bioinfo_results_metadata(self, files_dict, j_data, batch_id, output_folder=None):
         """Adds metadata from bioinformatics results to j_data.
         It first calls file_handlers and then maps the handled
         data into j_data.
@@ -241,6 +241,7 @@ class BioinfoMetadata:
             files_dict (dict{str:str}): A dictionary containing file paths found based on the definitions provided in the bioinformatic JSON file within the software scope (self.software_config).
             j_data (list(dict{str:str}): A list of dictionaries containing metadata lab (list item per sample).
             output_folder (str): Path to save output files generated during handling_files() process.
+            batch_id(str): ID of the batch which corresponds with the data download date.
 
         Returns:
             j_data_mapped: A list of dictionaries with bioinformatics metadata mapped into j_data.
@@ -263,7 +264,7 @@ class BioinfoMetadata:
                 )
                 continue
             # Handling files
-            data_to_map = self.handling_files(files_dict[key], output_folder)
+            data_to_map = self.handling_files(files_dict[key], output_folder, batch_id)
             # Mapping data to j_data
             mapping_fields = self.software_config[key].get("content")
             if not mapping_fields:
@@ -324,7 +325,7 @@ class BioinfoMetadata:
             sys.exit(self.log_report.print_log_report(method_name, ["error"]))
         return data
 
-    def handling_files(self, file_list, output_folder):
+    def handling_files(self, file_list, output_folder, batch_id):
         """Handles different file formats to extract data regardless of their structure.
         The goal is to extract the data contained in files specified in ${file_list},
         using either 'standard' handlers defined in this class or pipeline-specific file handlers.
@@ -368,7 +369,7 @@ class BioinfoMetadata:
                 import_statement = f"import {utils_name}"
                 exec(import_statement)
                 # Get method name and execute it.
-                data = eval(utils_name + "." + func_name + "(file_list, output_folder)")
+                data = eval(utils_name + "." + func_name + "(file_list, batch_id, output_folder)")
             except Exception as e:
                 self.log_report.update_log_report(
                     self.add_bioinfo_results_metadata.__name__,
@@ -801,7 +802,7 @@ class BioinfoMetadata:
             batch_data = batch_dict["j_data"]
             stderr.print("[blue]Adding bioinfo metadata to read lab metadata...")
             batch_data = self.add_bioinfo_results_metadata(
-                files_found_dict, batch_data, batch_dir
+                files_found_dict, batch_data, batch_date, batch_dir
             )
             stderr.print("[blue]Adding software versions to read lab metadata...")
             batch_data = self.get_multiqc_software_versions(

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -892,14 +892,19 @@ class BioinfoMetadata:
         out_path = os.path.join(self.output_folder, year)
         os.makedirs(out_path, exist_ok=True)
 
+        tag = "bioinfo_lab_metadata_"
         stderr.print("[blue]Saving previously splitted files to output directory")
 
         self.save_splitted_files(files_found_dict, batch_dates, out_path)
         batch_filename = tag + batch_dates + ".json"
         stderr.print("[blue]Writting output json file")
-        os.makedirs(self.output_folder, exist_ok=True)
-        file_path = os.path.join(self.output_folder, self.out_filename)
-        relecov_tools.utils.write_json_fo_file(self.j_data, file_path)
+        file_path = os.path.join(out_path, batch_filename)
+        if os.path.exists(file_path):
+            stderr.print(f"[blue]Bioinfo metadata {file_path} file already exists. Merging new data if possible.")
+            log.info("Bioinfo metadata %s file already exists. Merging new data if possible." % file_path)
+            batch_data = self.merge_metadata(file_path, self.j_data)
+        else:
+            relecov_tools.utils.write_json_fo_file(self.j_data, file_path)
         stderr.print(f"[green]Sucessful creation of bioinfo analyis file: {file_path}")
         self.log_report.logsum.create_error_summary(
             called_module="read-bioinfo-metadata", logs=self.log_report.logsum.logs


### PR DESCRIPTION
- Made long table to be written in `--outdir`. Fix issue #351 
- Fixed module to find files not containing sample_name in filename (`viralrecon_filepath_mapping_stats`, `viralrecon_filepath_summary_mqc`, `viralrecon_filepath_variants_long_table`, `viralrecon_filepath_workflow_summary`)
- Added year to `--outdir` to write files
- Added batchID/date to filename instead of current date for `--oudir` and `--batchdir`
- Added current date for tables written in `analysis_results`
- Test whether `variants_long_table `and `bioinfo_lab_metadata `already exist and try to merge new samples, ignores samples already existing that contain exactly the same info.
- Write long table only with samples in the COD to COD folder