### PR TITLE
Added Quality Control functionality to read-bioinfo-metadata module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Code contributions to the release:
 - Added a IonTorrent flow cell for validation [#363](https://github.com/BU-ISCIII/relecov-tools/pull/363)
 - Added solution to timeout in upload-to-ena module [#368](https://github.com/BU-ISCIII/relecov-tools/pull/368)
 - Added log functionality to build-schema module [#340](https://github.com/BU-ISCIII/relecov-tools/pull/340)
+- Added quality control functionality to read-bioinfo-metadata [#373](https://github.com/BU-ISCIII/relecov-tools/pull/373)
 
 #### Fixes
 

--- a/relecov_tools/conf/bioinfo_config.json
+++ b/relecov_tools/conf/bioinfo_config.json
@@ -23,6 +23,23 @@
                 "read_length": "read_length"
             }
         },
+        "quality_control": {
+            "fn": "quality_control_report(?:_\\d{8})?\\.tsv",
+            "sample_col_idx": 1,
+            "header_row_idx": 1,
+            "required": true,
+            "function": null,
+            "multiple_samples": true,
+            "split_by_batch": true,
+            "content": {
+                "per_sgene_ambiguous": "S-Gene_Ambiguous_Percentage",
+                "per_sgene_coverage": "S-Gene_Coverage_Percentage",
+                "per_ldmutations": "% LDMutations",
+                "number_of_sgene_frameshifts": "S-Gene_Frameshifts",
+                "number_of_unambiguous_bases": "Total_Unambiguous_Bases",
+                "number_of_Ns": "Total_Ns_count"
+            }
+        },
         "mapping_pangolin": {
             "fn": ".pangolin(?:.*?)?\\.csv$",
             "header_row_idx": 1,

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -1009,9 +1009,7 @@ class BioinfoMetadata:
         batch_filename = tag + batch_dates + ".json"
         stderr.print("[blue]Writting output json file")
         file_path = os.path.join(out_path, batch_filename)
-        qc_statement = (
-            f"relecov_tools.assets.pipeline_utils.{self.software_name}.quality_control_evaluation(self.j_data)"
-        )
+        qc_statement = f"relecov_tools.assets.pipeline_utils.{self.software_name}.quality_control_evaluation(self.j_data)"
         exec(qc_statement)
         if os.path.exists(file_path):
             stderr.print(

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -1009,6 +1009,10 @@ class BioinfoMetadata:
         batch_filename = tag + batch_dates + ".json"
         stderr.print("[blue]Writting output json file")
         file_path = os.path.join(out_path, batch_filename)
+        qc_statement = (
+            f"relecov_tools.assets.pipeline_utils.{self.software_name}.quality_control_evaluation(self.j_data)"
+        )
+        exec(qc_statement)
         if os.path.exists(file_path):
             stderr.print(
                 f"[blue]Bioinfo metadata {file_path} file already exists. Merging new data if possible."

--- a/relecov_tools/schema/relecov_schema.json
+++ b/relecov_tools/schema/relecov_schema.json
@@ -3353,6 +3353,39 @@
             "label": "%Ns",
             "fill_mode": "batch"
         },
+        "per_sgene_ambiguous": {
+            "examples": [
+              "e.g 0"
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "",
+            "clasification": "Bioinformatics and QC metrics fields",
+            "label": "S-Gene_Ambiguous_Percentage",
+            "fill_mode": "batch"
+        },
+        "per_sgene_coverage": {
+            "examples": [
+              "e.g 99"
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "",
+            "clasification": "Bioinformatics and QC metrics fields",
+            "label": "S-Gene_Coverage_Percentage",
+            "fill_mode": "batch"
+        },
+        "per_ldmutations": {
+            "examples": [
+              "e.g 87"
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "",
+            "clasification": "Bioinformatics and QC metrics fields",
+            "label": "% LDMutations",
+            "fill_mode": "batch"
+        },
         "ns_per_100_kbp": {
             "examples": [
                 "300"
@@ -3384,6 +3417,39 @@
             "description": "The number of missense variants",
             "classification": "Bioinformatic Variants",
             "label": "Number of variants with effect",
+            "fill_mode": "batch"
+        },
+        "number_of_sgene_frameshifts": {
+            "examples": [
+                "0"
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "The number of frameshift in sgene",
+            "classification": "Bioinformatics and QC metrics fields",
+            "label": "Number of frameshift in sgene",
+            "fill_mode": "batch"
+        },
+        "number_of_unambiguous_bases": {
+            "examples": [
+                "30000"
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "The number of unambiguous bases",
+            "classification": "Bioinformatics and QC metrics fields",
+            "label": "Number of unambiguous bases",
+            "fill_mode": "batch"
+        },
+        "number_of_Ns": {
+            "examples": [
+                "100"
+            ],
+            "ontology": "0",
+            "type": "string",
+            "description": "The number of Ns",
+            "classification": "Bioinformatics and QC metrics fields",
+            "label": "Number of Ns",
             "fill_mode": "batch"
         },
         "lineage_name": {


### PR DESCRIPTION
A new field has been implemented to the lab metatada json that defines if the selected/generated QC values meet the established thresholds.