### PR TITLE
QC is not required in bioinfo_config until its implemented. Fixed datatypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0dev] - 2025-0X-XX : https://github.com/BU-ISCIII/relecov-tools/releases/tag/XXX
+
+### Credits
+
+Code contributions to the release:
+
+- [Pablo Mata](https://github.com/shettland)
+
+### Modules
+
+#### Added enhancements
+
+- Added a more robust datatype handling in utils.py read_csv_file_return_dict() method [#379](https://github.com/BU-ISCIII/relecov-tools/pull/379)
+
+#### Fixes
+
+#### Changed
+
+- Temporarily changed bioinfo_config 'quality_control' requirement to false [#379](https://github.com/BU-ISCIII/relecov-tools/pull/379)
+
+#### Removed
+
+### Requirements
+
 ## [1.4.0] - 2025-01-27 : https://github.com/BU-ISCIII/relecov-tools/releases/tag/v1.4.0
 
 ### Credits

--- a/relecov_tools/conf/bioinfo_config.json
+++ b/relecov_tools/conf/bioinfo_config.json
@@ -27,7 +27,7 @@
             "fn": "quality_control_report(?:_\\d{8})?\\.tsv",
             "sample_col_idx": 1,
             "header_row_idx": 1,
-            "required": true,
+            "required": false,
             "function": null,
             "multiple_samples": true,
             "split_by_batch": true,


### PR DESCRIPTION
Read-bioinfo-metadata was parsing integer IDs as floats sometimes, I changed an utils.py function to make it more consistent with datatypes.

Also changed  "quality_control" key "required" to False in bioinfo_config.json until a way to obtain this data is implemented in buisciii-tools