### PR TITLE
Fix schema generation dependence on --diff parameter (`build-schema` module)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Code contributions to the release:
 - Enhance validation of database definitinon values [#389](https://github.com/BU-ISCIII/relecov-tools/pull/389)
 - Add schema summary method to build-schema module [#391](https://github.com/BU-ISCIII/relecov-tools/pull/391)
 - Implement conditioning on Host_Age and Host_Age_Months [#392](https://github.com/BU-ISCIII/relecov-tools/pull/392)
+- Fix schema generation dependence on --diff parameter [#394](https://github.com/BU-ISCIII/relecov-tools/pull/392)
 
 #### Fixes
 

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -559,7 +559,7 @@ class SchemaBuilder:
             if self.show_diff:
                 return self.print_save_schema_diff(diff_lines)
             else:
-                return
+                return None
 
     def print_save_schema_diff(self, diff_lines=None):
         # Set user's choices

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -556,7 +556,10 @@ class SchemaBuilder:
             stderr.print(
                 "[yellow]Differences found between the existing schema and the newly generated schema."
             )
-            return self.print_save_schema_diff(diff_lines)
+            if self.show_diff:
+                return self.print_save_schema_diff(diff_lines)
+            else:
+                return
 
     def print_save_schema_diff(self, diff_lines=None):
         # Set user's choices
@@ -1092,19 +1095,11 @@ class SchemaBuilder:
         # Verify new schema follows json schema specification rules.
         self.verify_schema(new_schema_json)
 
-        # Compare base vs new schema and saves new JSON schema
-        if self.show_diff:
-            schema_diff = self.get_schema_diff(base_schema_json, new_schema_json)
-        else:
-            schema_diff = None
+        # Compare base vs new schema and print/saves differences (--diff = True)
+        self.get_schema_diff(base_schema_json, new_schema_json)
 
-        if schema_diff:
-            self.save_new_schema(new_schema_json)
-        else:
-            log.info(f"No changes found against base schema ({self.base_schema_path}).")
-            stderr.print(
-                f"[green]No changes found against base schema ({self.base_schema_path})."
-            )
+        # Saves new JSON schema
+        self.save_new_schema(new_schema_json)
 
         # Create metadata lab template
         promp_answ = relecov_tools.utils.prompt_yn_question(


### PR DESCRIPTION
## PR Description

Previously, the schema was generated only when the `--diff` parameter was specified on the command line. 
The evaluation of differences with respect to the base schema and the generation of the new schema have been separated.