### PR TITLE
Update `read-lab-metadata` module: Auto-fill `tax_id` and `host_disease` based on organism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Code contributions to the release:
 - Implement conditioning on Host_Age and Host_Age_Months [#392](https://github.com/BU-ISCIII/relecov-tools/pull/392)
 - Fix schema generation dependence on --diff parameter [#394](https://github.com/BU-ISCIII/relecov-tools/pull/392)
 - Update template conditions project dependent [#404](https://github.com/BU-ISCIII/relecov-tools/pull/404)
+- Auto-fill tax_id and host_disease based on organism fields [#407](https://github.com/BU-ISCIII/relecov-tools/pull/407)
 
 #### Fixes
 

--- a/relecov_tools/conf/configuration.json
+++ b/relecov_tools/conf/configuration.json
@@ -1,11 +1,22 @@
 {
     "lab_metadata": {
         "fixed_fields": {
-            "host_disease": "COVID-19",
-            "tax_id": "2697049",
-            "organism": "Severe acute respiratory syndrome coronavirus 2",
             "study_type": "Whole Genome Sequencing",
             "collector_name": "Not Provided"
+        },
+        "organism_mapping": {
+            "Severe acute respiratory syndrome coronavirus 2 [LOINC:LA31065-8]": {
+                "tax_id": "2697049",
+                "host_disease": "COVID-19 [SNOMED:840539006]"
+            },
+            "Respiratory syncytial virus [SNOMED:6415009]": {
+                "tax_id": "1281",
+                "host_disease": "Respiratory Syncytial Virus Infection [SNOMED:55735004]"
+            },
+            "Influenza virus [SNOMED:725894000]": {
+                "tax_id": "11320",
+                "host_disease": "Influenza Infection [SNOMED:408687004]"
+            }
         },
         "metadata_lab_heading": [
             "Organism",

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -226,7 +226,9 @@ class RelecovMetadata:
     def adding_fixed_fields(self, m_data):
         """Include fixed data that are always the same for every sample"""
         p_data = self.configuration.get_topic_data("lab_metadata", "fixed_fields")
-        organism_mapping = self.configuration.get_topic_data("lab_metadata", "organism_mapping")
+        organism_mapping = self.configuration.get_topic_data(
+            "lab_metadata", "organism_mapping"
+        )
 
         for idx in range(len(m_data)):
             organism = m_data[idx].get("organism", "")

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -236,8 +236,8 @@ class RelecovMetadata:
                 m_data[idx]["tax_id"] = organism_mapping[organism]["tax_id"]
                 m_data[idx]["host_disease"] = organism_mapping[organism]["host_disease"]
             else:
-                m_data[idx]["tax_id"] = "Unknown"
-                m_data[idx]["host_disease"] = "Unknown"
+                m_data[idx]["tax_id"] = "Unknown [LOINC:LA4489-6]"
+                m_data[idx]["host_disease"] = "Unknown [LOINC:LA4489-6]"
             for key, value in p_data.items():
                 m_data[idx][key] = value
             m_data[idx]["schema_name"] = self.schema_name


### PR DESCRIPTION
### PR Description

This PR enhances the `read-lab-metadata` module by implementing automatic filling of `tax_id` and `host_disease` fields according to the `organism` value.

Key Changes:

- Added a new organism_mapping field to `configuration.json` to define the relationships between `organisms`, `tax_id`, and `host_disease`.
- Updated the `add_fixed_fields` function in the `read-lab-metadata` module to apply the organism_mapping logic.