### PR TITLE
Pipeline-manager now splits samples by organism-template first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Code contributions to the release:
 - Update template conditions project dependent [#404](https://github.com/BU-ISCIII/relecov-tools/pull/404)
 - Auto-fill tax_id and host_disease based on organism fields [#407](https://github.com/BU-ISCIII/relecov-tools/pull/407)
 - Implement Pull Request Template [#410](https://github.com/BU-ISCIII/relecov-tools/pull/410)
+- Now pipeline-manager splits by organism-template first [#412](https://github.com/BU-ISCIII/relecov-tools/pull/412)
 
 #### Fixes
 
@@ -38,6 +39,7 @@ Code contributions to the release:
 
 - Temporarily changed bioinfo_config 'quality_control' requirement to false [#379](https://github.com/BU-ISCIII/relecov-tools/pull/379)
 - Improve and fix minor issues in build_schema.py [#404](https://github.com/BU-ISCIII/relecov-tools/pull/404)
+- Changed utils.write_json_fo_file() name to write_json_to_file() [#412](https://github.com/BU-ISCIII/relecov-tools/pull/412)
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Code contributions to the release:
 - Temporarily changed bioinfo_config 'quality_control' requirement to false [#379](https://github.com/BU-ISCIII/relecov-tools/pull/379)
 - Improve and fix minor issues in build_schema.py [#404](https://github.com/BU-ISCIII/relecov-tools/pull/404)
 - Changed utils.write_json_fo_file() name to write_json_to_file() [#412](https://github.com/BU-ISCIII/relecov-tools/pull/412)
+- Changed pipeline-manager --template param to --templates_root, now points to root folder [#412](https://github.com/BU-ISCIII/relecov-tools/pull/412)
 
 #### Removed
 

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -645,9 +645,9 @@ def metadata_homogeneizer(institution, directory, output):
 )
 @click.option(
     "-t",
-    "--template",
+    "--templates_root",
     type=click.Path(),
-    help="select the pipeline template folder to be copied in the output folder",
+    help="Path to folder containing the pipeline templates from buisciii-tools",
 )
 @click.option(
     "-c",
@@ -663,13 +663,13 @@ def metadata_homogeneizer(institution, directory, output):
     default=None,
     help="Folder basenames to process. Target folders names should match the given dates. E.g. ... -f folder1 -f folder2 -f folder3",
 )
-def pipeline_manager(input, template, output, config, folder_names):
+def pipeline_manager(input, templates_root, output, config, folder_names):
     """
     Create the symbolic links for the samples which are validated to prepare for
     bioinformatics pipeline execution.
     """
     new_launch = relecov_tools.pipeline_manager.PipelineManager(
-        input, template, output, config, folder_names
+        input, templates_root, output, config, folder_names
     )
     try:
         new_launch.pipeline_exc()

--- a/relecov_tools/conf/configuration.json
+++ b/relecov_tools/conf/configuration.json
@@ -451,12 +451,33 @@
         "analysis_folder": "ANALYSIS",
         "sample_stored_folder": "RAW",
         "sample_link_folder": "00-reads",
-        "group_by_fields": [
-            "organism",
-            "sequencing_instrument_platform",
-            "enrichment_panel",
-            "enrichment_panel_version"
-        ]
+        "organism_config": {
+            "Severe acute respiratory syndrome coronavirus 2 [LOINC:LA31065-8]": {
+                "pipeline_template": "viralrecon",
+                "service_tag": "SARSCOV2",
+                "group_by_fields": [
+                    "sequencing_instrument_platform",
+                    "enrichment_panel",
+                    "enrichment_panel_version"
+                ]
+            },
+            "Respiratory syncytial virus [SNOMED:6415009]": {
+                "pipeline_template": "IRMA",
+                "service_tag": "GENOMERSV",
+                "group_by_fields": [
+                    "sequencing_instrument_platform",
+                    "enrichment_panel",
+                    "enrichment_panel_version"
+                ]
+            },
+            "Influenza virus [SNOMED:725894000]": {
+                "pipeline_template": "IRMA",
+                "service_tag": "GENOMEFLU",
+                "group_by_fields": [
+                    "sequencing_instrument_platform"
+                ]
+            }
+        }
     },
     "mail_sender":{
         "delivery_template_path_file": "./relecov_tools/templates/",

--- a/relecov_tools/json_validation.py
+++ b/relecov_tools/json_validation.py
@@ -262,7 +262,7 @@ class SchemaValidation:
         file_name = "_".join(["validated", os.path.basename(self.json_data_file)])
         file_path = os.path.join(out_folder, file_name)
         log.info("Saving Json file with the validated samples in %s", file_path)
-        relecov_tools.utils.write_json_fo_file(valid_json_data, file_path)
+        relecov_tools.utils.write_json_to_file(valid_json_data, file_path)
         return
 
     def validate(self):

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -865,7 +865,7 @@ class BioinfoMetadata:
             else:
                 merged_metadata.append(item)
 
-        relecov_tools.utils.write_json_fo_file(merged_metadata, batch_filepath)
+        relecov_tools.utils.write_json_to_file(merged_metadata, batch_filepath)
         return merged_metadata
 
     def save_merged_files(self, files_dict, batch_date, output_folder=None):
@@ -994,7 +994,7 @@ class BioinfoMetadata:
                 )
                 batch_data = self.merge_metadata(batch_filepath, batch_data)
             else:
-                relecov_tools.utils.write_json_fo_file(batch_data, batch_filepath)
+                relecov_tools.utils.write_json_to_file(batch_data, batch_filepath)
             for sample in batch_data:
                 self.log_report.logsum.feed_key(
                     key=batch_dir, sample=sample.get("sequencing_sample_id")
@@ -1025,7 +1025,7 @@ class BioinfoMetadata:
             )
             batch_data = self.merge_metadata(file_path, self.j_data)
         else:
-            relecov_tools.utils.write_json_fo_file(self.j_data, file_path)
+            relecov_tools.utils.write_json_to_file(self.j_data, file_path)
         stderr.print(f"[green]Sucessful creation of bioinfo analyis file: {file_path}")
         self.log_report.logsum.create_error_summary(
             called_module="read-bioinfo-metadata", logs=self.log_report.logsum.logs

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -189,7 +189,7 @@ class RelecovMetadata:
         try:
             filename = "_".join(["samples_data", self.lab_code, self.date + ".json"])
             file_path = os.path.join(self.output_folder, filename)
-            relecov_tools.utils.write_json_fo_file(j_data, file_path)
+            relecov_tools.utils.write_json_to_file(j_data, file_path)
         except Exception:
             log.error("Could not output samples_data.json file to output folder")
         return j_data
@@ -540,5 +540,5 @@ class RelecovMetadata:
         self.logsum.create_error_summary(called_module="read-lab-metadata")
         file_path = os.path.join(self.output_folder, file_name)
         log.info("Writting output json file %s", file_path)
-        relecov_tools.utils.write_json_fo_file(completed_metadata, file_path)
+        relecov_tools.utils.write_json_to_file(completed_metadata, file_path)
         return True

--- a/relecov_tools/upload_ena_protocol.py
+++ b/relecov_tools/upload_ena_protocol.py
@@ -296,7 +296,7 @@ class EnaUpload:
         updated_json_name = (
             os.path.splitext(os.path.basename(self.source_json_file))[0] + suffix
         )
-        relecov_tools.utils.write_json_fo_file(updated_json, updated_json_name)
+        relecov_tools.utils.write_json_to_file(updated_json, updated_json_name)
 
         self.save_tables(updated_schemas_df, date)
         return

--- a/relecov_tools/utils.py
+++ b/relecov_tools/utils.py
@@ -284,7 +284,7 @@ def save_local_md5(file_name, md5_value):
     return True
 
 
-def write_json_fo_file(data, file_name):
+def write_json_to_file(data, file_name):
     """Write metadata to json file"""
     with open(file_name, "w", encoding="utf-8") as fh:
         fh.write(json.dumps(data, indent=4, sort_keys=True, ensure_ascii=False))


### PR DESCRIPTION
With this PR pipeline-manager functionality is enhanced to also select the necessary pipeline template for each sample depending on the organism analyzed. As a starting point, 3 organisms are included in `configuration.json`, but that can be increased in further implementations.

Closes #402