### PR TITLE
Remove `Wrapper` Testing from GitHub Actions Workflow

### DIFF
--- a/.github/workflows/test_sftp_modules.yml
+++ b/.github/workflows/test_sftp_modules.yml
@@ -63,39 +63,3 @@ jobs:
         TEST_PORT: ${{ secrets.TEST_PORT }}
         OUTPUT_LOCATION: ${{ github.workspace }}/tests/
 
-  test_wrapper:
-    runs-on: ubuntu-latest
-    needs: test_download
-    if: github.repository_owner == 'BU-ISCIII'
-    strategy:
-      max-parallel: 1
-      matrix:
-        download_options: ["download_only", "download_clean"]
-                        
-    steps:
-    - name: Set up Python 3.9.16
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.9.16'
-            
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: 0
-                        
-    - name: Install package and dependencies
-      run: |
-        pip install -r requirements.txt
-        pip install .
-                        
-    - name: Run Wrapper tests
-      run: |
-        python3 tests/test_wrapper_handle.py --download_option ${{ matrix.download_options }}
-      env:
-        TEST_USER: ${{ secrets.TEST_USER }}
-        TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-        TEST_PORT: ${{ secrets.TEST_PORT }}
-        OUTPUT_LOCATION: ${{ github.workspace }}/tests/
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Code contributions to the release:
 - Add repeated samples to test data [#413](https://github.com/BU-ISCIII/relecov-tools/pull/413)
 - Add create_summary_tables.py to assets to process data from a given epidemiological week [#418](https://github.com/BU-ISCIII/relecov-tools/pull/418)
 - Add wrapper to github actions (test_sftp_modules) [#409](https://github.com/BU-ISCIII/relecov-tools/pull/409)
+- Remove wrapper from github actions (test_sftp_modules) [#421](https://github.com/BU-ISCIII/relecov-tools/pull/421)
 
 #### Fixes
 


### PR DESCRIPTION
### PR Description

This PR removes the wrapper testing step from the GitHub Actions workflow in `relecov-tools`. The decision was made because the wrapper fails to log in to the SFTP server, causing a time-out and preventing the workflow from completing successfully.

Changes:

Removed the `wrapper testing` step from the GitHub Actions workflow.