### PR TITLE
Added custom validator to extend validation exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Code contributions to the release:
 
 #### Added enhancements
 
+- Added custom validator to extend validation exceptions [#429](https://github.com/BU-ISCIII/relecov-tools/pull/429)
 - Refactor GitHub Actions & Add build-schema Step [#417](https://github.com/BU-ISCIII/relecov-tools/pull/417)
 - Add documentation for `bioinfo_config.json` in README [#415](https://github.com/BU-ISCIII/relecov-tools/pull/415)
 - Added a more robust datatype handling in utils.py read_csv_file_return_dict() method [#379](https://github.com/BU-ISCIII/relecov-tools/pull/379)

--- a/relecov_tools/assets/schema_utils/custom_validators.py
+++ b/relecov_tools/assets/schema_utils/custom_validators.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+
+def validate_with_exceptions(schema, data, errors):
+    """Filter out type errors for:
+    - integer/float fields containing 'Not Provided'
+    - string fields with format: date containing 'Not Provided'"""
+    filtered_errors = []
+
+    for error in errors:
+        property_path = ".".join(str(p) for p in error.path)
+        prop_schema = schema["properties"].get(property_path, {})
+
+        # allow not provided for numeric types
+        if (
+            error.validator == "type"
+            and error.instance == "Not Provided [GENEPIO:0001668]"
+            and prop_schema.get("type") in ["integer", "number"]
+        ):
+            continue
+
+        # allow not provided for date format types
+        if (
+            error.validator == "format"
+            and error.instance == "Not Provided [GENEPIO:0001668]"
+            and prop_schema.get("type") == "string"
+            and prop_schema.get("format") == "date"
+        ):
+            continue
+
+        # Keep all other errors
+        filtered_errors.append(error)
+
+    return


### PR DESCRIPTION
This update enhances the JSON Schema validation process by allowing the string "Not Provided" as a valid input for numeric fields (integer, number) and date-formatted strings (string, format: date). The new implementation integrates validate_with_exceptions(), which filters out specific type errors while ensuring all other validation rules remain enforced. This approach maintains strict schema validation while introducing flexibility for missing values, improving data handling without modifying the schema structure.

Closes #425 