### PR TITLE
Fix viralrecon_filepaths Path in `read-bioinfo-metadata` Module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Code contributions to the release:
 - Update download Module to Process Data by Laboratory COD and Project Subfolder [#431](https://github.com/BU-ISCIII/relecov-tools/pull/431)
 - Created new `upload-results` for uploading analysis_results folder back to every COD folder in sftp. [#433](https://github.com/BU-ISCIII/relecov-tools/pull/433)
 - Update relecov_schema.json to 3.0.0dev version [#435](https://github.com/BU-ISCIII/relecov-tools/pull/435)
+- Fix viralrecon_filepaths Path in read-bioinfo-metadata Module [#438](https://github.com/BU-ISCIII/relecov-tools/pull/438)
 
 #### Fixes
 

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -678,9 +678,10 @@ class BioinfoMetadata:
                                 file_path = file
                                 break  # Exit loop if match found
                 path_key = f"{self.software_name}_filepath_{key}"
+                base_execution_path = os.getcwd()
                 if file_path != "Not Provided [GENEPIO:0001668]":
                     analysis_results_path = os.path.join(
-                        self.output_folder,
+                        base_execution_path,
                         "analysis_results",
                         os.path.basename(file_path),
                     )

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -659,6 +659,7 @@ class BioinfoMetadata:
         multiple_sample_files = self.get_multiple_sample_files()
         for row in j_data:
             row["bioinfo_metadata_file"] = self.out_filename
+            base_cod_path = row.get("r1_fastq_filepath")
             if not row.get("sequencing_sample_id"):
                 self.log_report.update_log_report(
                     method_name,
@@ -678,10 +679,9 @@ class BioinfoMetadata:
                                 file_path = file
                                 break  # Exit loop if match found
                 path_key = f"{self.software_name}_filepath_{key}"
-                base_execution_path = os.getcwd()
                 if file_path != "Not Provided [GENEPIO:0001668]":
                     analysis_results_path = os.path.join(
-                        base_execution_path,
+                        base_cod_path,
                         "analysis_results",
                         os.path.basename(file_path),
                     )

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -668,6 +668,13 @@ class BioinfoMetadata:
                 )
                 continue
             sample_name = row["sequencing_sample_id"]
+            if base_cod_path is None:
+                self.log_report.update_log_report(
+                    method_name,
+                    "error",
+                    f"No 'r1_fastq_filepath' found for sample {sample_name}. Unable to generate paths.",
+                )
+                continue
             for key, values in files_found_dict.items():
                 file_path = "Not Provided [GENEPIO:0001668]"
                 if values:  # Check if value is not empty

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -659,7 +659,6 @@ class BioinfoMetadata:
         multiple_sample_files = self.get_multiple_sample_files()
         for row in j_data:
             row["bioinfo_metadata_file"] = self.out_filename
-            base_cod_path = row.get("r1_fastq_filepath")
             if not row.get("sequencing_sample_id"):
                 self.log_report.update_log_report(
                     method_name,
@@ -668,6 +667,7 @@ class BioinfoMetadata:
                 )
                 continue
             sample_name = row["sequencing_sample_id"]
+            base_cod_path = row.get("r1_fastq_filepath")
             if base_cod_path is None:
                 self.log_report.update_log_report(
                     method_name,


### PR DESCRIPTION
### PR Description

Currently the path was generated according to the path included in the --out_dir option but it should really be generated according to the point where the module is executed.