### PR TITLE
Fix adding_ontology_to_enum when enum has no ontology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Code contributions to the release:
 - Created new `upload-results` for uploading analysis_results folder back to every COD folder in sftp. [#433](https://github.com/BU-ISCIII/relecov-tools/pull/433)
 - Update relecov_schema.json to 3.0.0dev version [#435](https://github.com/BU-ISCIII/relecov-tools/pull/435)
 - Fix viralrecon_filepaths Path in read-bioinfo-metadata Module [#438](https://github.com/BU-ISCIII/relecov-tools/pull/438)
+- Fix adding_ontology_to_enum when enum has no ontology [#439](https://github.com/BU-ISCIII/relecov-tools/pull/439)
 
 #### Fixes
 

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -80,6 +80,16 @@ class RelecovMetadata:
 
         with open(relecov_sch_path, "r") as fh:
             self.relecov_sch_json = json.load(fh)
+
+        try:
+            relecov_tools.assets.schema_utils.jsonschema_draft.check_schema_draft(
+                self.relecov_sch_json, "2020-12"
+            )
+        except Exception as e:
+            log.critical("JSON schema is not valid: %s", str(e))
+            stderr.print(f"[red]Critical error: JSON schema is not valid.\n{str(e)}")
+            raise ValueError(f"JSON schema is not valid: {str(e)}")
+
         self.label_prop_dict = {}
 
         for prop, values in self.relecov_sch_json["properties"].items():

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -284,11 +284,6 @@ class RelecovMetadata:
         """
         enum_dict = {}
         for prop, values in self.relecov_sch_json["properties"].items():
-            if not isinstance(values, dict):
-                continue
-            enum_values = values.get("enum")
-            if not isinstance(enum_values, list):
-                continue
             ontologies_present = any(
                 isinstance(enum, str) and re.search(r" \[\w+:.*\]$", enum)
                 for enum in enum_values

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -289,7 +289,10 @@ class RelecovMetadata:
             enum_values = values.get("enum")
             if not isinstance(enum_values, list):
                 continue
-            ontologies_present = any(isinstance(enum, str) and re.search(r" \[\w+:.*\]$", enum) for enum in enum_values)
+            ontologies_present = any(
+                isinstance(enum, str) and re.search(r" \[\w+:.*\]$", enum)
+                for enum in enum_values
+            )
             if not ontologies_present:
                 continue
             if "enum" in values:

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -284,6 +284,14 @@ class RelecovMetadata:
         """
         enum_dict = {}
         for prop, values in self.relecov_sch_json["properties"].items():
+            if not isinstance(values, dict):
+                continue
+            enum_values = values.get("enum")
+            if not isinstance(enum_values, list):
+                continue
+            ontologies_present = any(isinstance(enum, str) and re.search(r" \[\w+:.*\]$", enum) for enum in enum_values)
+            if not ontologies_present:
+                continue
             if "enum" in values:
                 enum_dict[prop] = {}
                 for enum in values["enum"]:

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -86,9 +86,9 @@ class RelecovMetadata:
                 self.relecov_sch_json, "2020-12"
             )
         except Exception as e:
-            log.critical("JSON schema is not valid: %s", str(e))
-            stderr.print(f"[red]Critical error: JSON schema is not valid.\n{str(e)}")
-            raise ValueError(f"JSON schema is not valid: {str(e)}")
+            log.error("JSON schema is not valid: %s", str(e))
+            stderr.print(f"[red]Error: JSON schema is not valid.\n{str(e)}")
+            raise
 
         self.label_prop_dict = {}
 

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -284,6 +284,7 @@ class RelecovMetadata:
         """
         enum_dict = {}
         for prop, values in self.relecov_sch_json["properties"].items():
+            enum_values = values.get("enum")
             ontologies_present = any(
                 isinstance(enum, str) and re.search(r" \[\w+:.*\]$", enum)
                 for enum in enum_values

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -284,7 +284,7 @@ class RelecovMetadata:
         """
         enum_dict = {}
         for prop, values in self.relecov_sch_json["properties"].items():
-            enum_values = values.get("enum")
+            enum_values = values.get("enum", [])
             ontologies_present = any(
                 isinstance(enum, str) and re.search(r" \[\w+:.*\]$", enum)
                 for enum in enum_values


### PR DESCRIPTION
### PR Description

As it is right now `read-lab-metadata` if the value has no ontology the module tries to add it. But it does this all the time and fails when the enum has no ontology and tries to add one (which it doesn't have).