### PR TITLE
Fix `read-bioinfo-metadata`: Evaluate `qc_test` at Batch Level and Handle `Non-Evaluable` %LDMutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Code contributions to the release:
 - Fix adding_ontology_to_enum when enum has no ontology [#439](https://github.com/BU-ISCIII/relecov-tools/pull/439)
 - Update relecov_schema.json and read-bioinfo-metadata to v3.0.0 [#442](https://github.com/BU-ISCIII/relecov-tools/pull/442)
 - Now logs-to-excel also creates a Json file with merged logs [#445](https://github.com/BU-ISCIII/relecov-tools/pull/445)
+- Fix read-bioinfo-metadata: Evaluate qc_test at Batch Level and Handle Non-Evaluable %LDMutations [#447](https://github.com/BU-ISCIII/relecov-tools/pull/447)
 
 #### Fixes
 

--- a/relecov_tools/assets/pipeline_utils/viralrecon.py
+++ b/relecov_tools/assets/pipeline_utils/viralrecon.py
@@ -448,17 +448,51 @@ def handle_consensus_fasta(files_list, batch_date, output_folder=None):
 
 
 def quality_control_evaluation(data):
-    """Evaluate the quality of the samples and add the field 'qc_test' to each 'data' entry."""
+    """Evaluates QC status for each sample based on predefined thresholds.
+
+    Parameters:
+    -----------
+    data : list of dict
+        List of sample metadata dictionaries containing metrics such as coverage,
+        ambiguity, number of Ns, %LDMutations, etc.
+
+    Returns:
+    --------
+    list of dict
+        The same list with an added 'qc_test' field per sample:
+        - 'pass' if all evaluable conditions are met
+        - 'fail' if any condition fails
+        - Ignores non-evaluable values like 'Data Not Evaluable [NCIT:C186292]'
+    """
+    log_report = BioinfoReportLog()
+    method_name = f"{quality_control_evaluation.__name__}"
+    
+    def safe_float(x):
+        try:
+            return float(x)
+        except (ValueError, TypeError):
+            return None
+
+    def safe_int(x):
+        try:
+            return int(x)
+        except (ValueError, TypeError):
+            return None
+
     conditions = {
-        "per_sgene_ambiguous": lambda x: float(x) < 10,
-        "per_sgene_coverage": lambda x: float(x) > 98,
-        "per_ldmutations": lambda x: float(x) > 60,
-        "number_of_sgene_frameshifts": lambda x: int(x) == 0,
-        "number_of_unambiguous_bases": lambda x: int(x) > 24000,
-        "number_of_Ns": lambda x: int(x) < 5000,
-        "qc_filtered": lambda x: int(x) > 50000,
-        "per_reads_host": lambda x: float(x) < 20,
+        "per_sgene_ambiguous": lambda x: safe_float(x) is not None and safe_float(x) < 10,
+        "per_sgene_coverage": lambda x: safe_float(x) is not None and safe_float(x) > 98,
+        "per_ldmutations": lambda x: (
+            True if isinstance(x, str) and "Not Evaluable" in x
+            else safe_float(x) is not None and safe_float(x) > 60
+        ),
+        "number_of_sgene_frameshifts": lambda x: safe_int(x) is not None and safe_int(x) == 0,
+        "number_of_unambiguous_bases": lambda x: safe_int(x) is not None and safe_int(x) > 24000,
+        "number_of_Ns": lambda x: safe_int(x) is not None and safe_int(x) < 5000,
+        "qc_filtered": lambda x: safe_int(x) is not None and safe_int(x) > 50000,
+        "per_reads_host": lambda x: safe_float(x) is not None and safe_float(x) < 20,
     }
+
     for sample in data:
         try:
             qc_status = "pass"
@@ -468,9 +502,9 @@ def quality_control_evaluation(data):
                     qc_status = "fail"
                     break
             sample["qc_test"] = qc_status
-        except ValueError as e:
+            log_report.update_log_report(method_name, "valid", f"{sample.get('sequencing_sample_id')} evaluated: {qc_status}")
+        except Exception as e:
             sample["qc_test"] = "fail"
-            print(
-                f"Error processing sample {sample.get('sequencing_sample_id', 'unknown')}: {e}"
-            )
+            sample_id = sample.get("sequencing_sample_id", "unknown")
+            log_report.update_log_report(method_name, "warning", f"Error evaluating sample {sample_id}: {e}")
     return data

--- a/relecov_tools/assets/pipeline_utils/viralrecon.py
+++ b/relecov_tools/assets/pipeline_utils/viralrecon.py
@@ -466,7 +466,7 @@ def quality_control_evaluation(data):
     """
     log_report = BioinfoReportLog()
     method_name = f"{quality_control_evaluation.__name__}"
-    
+
     def safe_float(x):
         try:
             return float(x)
@@ -480,14 +480,19 @@ def quality_control_evaluation(data):
             return None
 
     conditions = {
-        "per_sgene_ambiguous": lambda x: safe_float(x) is not None and safe_float(x) < 10,
-        "per_sgene_coverage": lambda x: safe_float(x) is not None and safe_float(x) > 98,
+        "per_sgene_ambiguous": lambda x: safe_float(x) is not None
+        and safe_float(x) < 10,
+        "per_sgene_coverage": lambda x: safe_float(x) is not None
+        and safe_float(x) > 98,
         "per_ldmutations": lambda x: (
-            True if isinstance(x, str) and "Not Evaluable" in x
+            True
+            if isinstance(x, str) and "Not Evaluable" in x
             else safe_float(x) is not None and safe_float(x) > 60
         ),
-        "number_of_sgene_frameshifts": lambda x: safe_int(x) is not None and safe_int(x) == 0,
-        "number_of_unambiguous_bases": lambda x: safe_int(x) is not None and safe_int(x) > 24000,
+        "number_of_sgene_frameshifts": lambda x: safe_int(x) is not None
+        and safe_int(x) == 0,
+        "number_of_unambiguous_bases": lambda x: safe_int(x) is not None
+        and safe_int(x) > 24000,
         "number_of_Ns": lambda x: safe_int(x) is not None and safe_int(x) < 5000,
         "qc_filtered": lambda x: safe_int(x) is not None and safe_int(x) > 50000,
         "per_reads_host": lambda x: safe_float(x) is not None and safe_float(x) < 20,
@@ -502,9 +507,15 @@ def quality_control_evaluation(data):
                     qc_status = "fail"
                     break
             sample["qc_test"] = qc_status
-            log_report.update_log_report(method_name, "valid", f"{sample.get('sequencing_sample_id')} evaluated: {qc_status}")
+            log_report.update_log_report(
+                method_name,
+                "valid",
+                f"{sample.get('sequencing_sample_id')} evaluated: {qc_status}",
+            )
         except Exception as e:
             sample["qc_test"] = "fail"
             sample_id = sample.get("sequencing_sample_id", "unknown")
-            log_report.update_log_report(method_name, "warning", f"Error evaluating sample {sample_id}: {e}")
+            log_report.update_log_report(
+                method_name, "warning", f"Error evaluating sample {sample_id}: {e}"
+            )
     return data

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -1027,6 +1027,15 @@ class BioinfoMetadata:
             tag = "bioinfo_lab_metadata_"
             batch_filename = tag + lab_code + "_" + batch_date + ".json"
             batch_filepath = os.path.join(batch_dir, batch_filename)
+            try:
+                qc_func = eval(f"relecov_tools.assets.pipeline_utils.{self.software_name}.quality_control_evaluation")
+                qc_data = qc_func(batch_data)
+                for sample in batch_data:
+                    sample_id = sample.get("sequencing_sample_id")
+                    if sample_id in qc_data:
+                        sample.update(qc_data[sample_id])
+            except Exception as e:
+                log.warning(f"Could not evaluate quality_control_evaluation for batch {batch_dir}: {e}")
             if os.path.exists(batch_filepath):
                 stderr.print(
                     f"[blue]Bioinfo metadata {batch_filepath} file already exists. Merging new data if possible."
@@ -1056,8 +1065,6 @@ class BioinfoMetadata:
         batch_filename = tag + batch_dates + ".json"
         stderr.print("[blue]Writting output json file")
         file_path = os.path.join(out_path, batch_filename)
-        qc_statement = f"relecov_tools.assets.pipeline_utils.{self.software_name}.quality_control_evaluation(self.j_data)"
-        exec(qc_statement)
         if os.path.exists(file_path):
             stderr.print(
                 f"[blue]Bioinfo metadata {file_path} file already exists. Merging new data if possible."

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -1028,14 +1028,18 @@ class BioinfoMetadata:
             batch_filename = tag + lab_code + "_" + batch_date + ".json"
             batch_filepath = os.path.join(batch_dir, batch_filename)
             try:
-                qc_func = eval(f"relecov_tools.assets.pipeline_utils.{self.software_name}.quality_control_evaluation")
+                qc_func = eval(
+                    f"relecov_tools.assets.pipeline_utils.{self.software_name}.quality_control_evaluation"
+                )
                 qc_data = qc_func(batch_data)
                 for sample in batch_data:
                     sample_id = sample.get("sequencing_sample_id")
                     if sample_id in qc_data:
                         sample.update(qc_data[sample_id])
             except Exception as e:
-                log.warning(f"Could not evaluate quality_control_evaluation for batch {batch_dir}: {e}")
+                log.warning(
+                    f"Could not evaluate quality_control_evaluation for batch {batch_dir}: {e}"
+                )
             if os.path.exists(batch_filepath):
                 stderr.print(
                     f"[blue]Bioinfo metadata {batch_filepath} file already exists. Merging new data if possible."


### PR DESCRIPTION
### PR Description:
This PR introduces two key fixes to the `read-bioinfo-metadata` module:

**Changes:**
Evaluate qc_test at Batch Level:
- The evaluation of the `qc_test` flag is now correctly performed for each batch.
- This ensures that the quality control assessment is consistently reflected in both the batch-level bioinfo files and the central update_db output.

Handle Non-Evaluable %LDMutations:
- The function was updated to properly handle cases where `%LDMutations` is set to `"Not Evaluable [NCIT:C186292]"`.