### PR TITLE
Add `--update` Flag to Allow Metadata Update in `read-bioinfo-metadata` Module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Code contributions to the release:
 - Now logs-to-excel also creates a Json file with merged logs [#445](https://github.com/BU-ISCIII/relecov-tools/pull/445)
 - Fix read-bioinfo-metadata: Evaluate qc_test at Batch Level and Handle Non-Evaluable %LDMutations [#447](https://github.com/BU-ISCIII/relecov-tools/pull/447)
 - Enhance Schema Modularity, Formatting, and Conditional Validation Across Metadata Modules [#448](https://github.com/BU-ISCIII/relecov-tools/pull/448)
+- Add --update Flag to Allow Metadata Update in read-bioinfo-metadata Module [#451](https://github.com/BU-ISCIII/relecov-tools/pull/451)
 
 #### Fixes
 

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -659,8 +659,14 @@ def update_db(ctx, user, password, json, type, platform, server_url, full_update
 @click.option("-i", "--input_folder", type=click.Path(), help="Path to input files")
 @click.option("-o", "--out_dir", type=click.Path(), help="Path to save output file")
 @click.option("-s", "--software_name", help="Name of the software/pipeline used.")
+@click.option(
+    "--update",
+    is_flag=True,
+    default=False,
+    help="If the output file already exists, ask if you want to update it.",
+)
 @click.pass_context
-def read_bioinfo_metadata(ctx, json_file, input_folder, out_dir, software_name):
+def read_bioinfo_metadata(ctx, json_file, input_folder, out_dir, software_name, update):
     """
     Create the json compliant  from the Bioinfo Metadata.
     """
@@ -670,6 +676,7 @@ def read_bioinfo_metadata(ctx, json_file, input_folder, out_dir, software_name):
         input_folder,
         out_dir,
         software_name,
+        update,
     )
     try:
         new_bioinfo_metadata.create_bioinfo_file()


### PR DESCRIPTION
### PR Description:
This PR introduces a new `--update` flag in the `read-bioinfo-metadata` module to support conditional updates of existing metadata files. When enabled, the module will compare the new metadata being generated with the already existing file and allow the user to interactively confirm updates where discrepancies are found.