### PR TITLE
Hotfix for non-string fields in json data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ Code contributions to the release:
 - Fix renaming of folders withou any valid sample [#413](https://github.com/BU-ISCIII/relecov-tools/pull/413)
 - Fix download module when deleting corrupted pair-end data [#419](https://github.com/BU-ISCIII/relecov-tools/pull/419)
 - Fixed the upload_results module to handle exceptions properly [#441](https://github.com/BU-ISCIII/relecov-tools/pull/441)
+- Update-db now converts data to string prior to API request to avoid crashing [#455](https://github.com/BU-ISCIII/relecov-tools/pull/455)
+- Fixed recursive generation of build/lib/build/lib from pyproject.toml [#455](https://github.com/BU-ISCIII/relecov-tools/pull/455)
 
 #### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ Homepage = "https://github.com/BU-ISCIII/relecov-tools"
 dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools.packages.find]
-exclude = ["docs"]
+exclude = ["docs", "build*"]
 
 [project.scripts]
 relecov-tools = "relecov_tools.__main__:run_relecov_tools"

--- a/relecov_tools/upload_database.py
+++ b/relecov_tools/upload_database.py
@@ -53,6 +53,10 @@ class UpdateDatabase:
             stderr.print(f"[red] json data file {json_file} does not exist")
             sys.exit(1)
         self.json_data = relecov_tools.utils.read_json_file(json_file)
+        for row in self.json_data:
+            for key, value in row.items():
+                if not isinstance(value, str):
+                    row[key] = str(value)
         self.json_file = json_file
         schema = os.path.join(
             os.path.dirname(os.path.realpath(__file__)),


### PR DESCRIPTION
Right now update-db fails for non-string fields, which is fine since relecov-platform forces most fields to charfields. This PR creates a temporal workaround by converting all fields in json data to strings