### PR TITLE
Improve Warning Handling for `.gz` Files and `variants_long_table.csv` in `read-bioinfo-metadata`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Code contributions to the release:
 - Enhance Schema Modularity, Formatting, and Conditional Validation Across Metadata Modules [#448](https://github.com/BU-ISCIII/relecov-tools/pull/448)
 - Add --update Flag to Allow Metadata Update in read-bioinfo-metadata Module [#451](https://github.com/BU-ISCIII/relecov-tools/pull/451)
 - Modified create_summary_tables.py to add new columns in epidemiological_data.xlsh (Pangolin software and database version and analysis date) [#454](https://github.com/BU-ISCIII/relecov-tools/pull/454)
+- Improve Warning Handling for .gz Files and variants_long_table.csv in read-bioinfo-metadata [#457](https://github.com/BU-ISCIII/relecov-tools/pull/457)
 
 #### Fixes
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Within each software block, the keys correspond to different analysis stages or 
 | `function`        | Name of a custom processing function (if applicable). Functions should be located in `assets/pipeline_utils`. | String or `null`   |
 | `multiple_samples`| Specifies if the file contains data for multiple samples.                                                    | Boolean            |
 | `split_by_batch`  | Indicates whether data should be separated by batches.                                                       | Boolean            |
+| `map`  | Indicates whether the file's values should be mapped into the final metadata (`j_data`). If set to `false`, the file is still processed (e.g., to generate the `long_table`), but its content will not be included in `j_data`.                                                       | Boolean            |
 | `extract`         | If `true`, instructs the module to extract data from the file’s content.                                     | Boolean            |
 | `content`         | Dictionary mapping standardized parameter names to the corresponding columns in the source file.             | Object             |
 

--- a/relecov_tools/conf/bioinfo_config.json
+++ b/relecov_tools/conf/bioinfo_config.json
@@ -64,6 +64,7 @@
             "required": true,
             "multiple_samples": true,
             "split_by_batch": true,
+            "map": false,
             "function": "parse_long_table",
             "content": {
                 "sample" : "SAMPLE",

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -431,7 +431,7 @@ class BioinfoMetadata:
             return {}
 
         if conf_tab_name.endswith(".gz"):
-            inner_ext = os.path.splitext(conf_tab_name[:-3])[1]
+            inner_ext = os.path.splitext(conf_tab_name.strip(".gz"))[1]
             if inner_ext in extdict:
                 self.log_report.update_log_report(
                     method_name,
@@ -447,11 +447,11 @@ class BioinfoMetadata:
                     sep=extdict[file_ext],
                     key_position=sample_idx_colpos,
                 )
-            except Exception as e:
+            except FileNotFoundError as e:
                 self.log_report.update_log_report(
                     method_name,
                     "error",
-                    f"Failed to read tabular file '{file_list[0]}': {e}",
+                    f"Tabular file not found: '{file_list[0]}': {e}",
                 )
                 raise
 

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -462,7 +462,6 @@ class BioinfoMetadata:
         )
         raise ValueError(self.log_report.print_log_report(method_name, ["error"]))
 
-
     def handling_files(self, file_list, sufix, output_folder, batch_date):
         """Handles different file formats to extract data regardless of their structure.
         The goal is to extract the data contained in files specified in ${file_list},

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -453,14 +453,16 @@ class BioinfoMetadata:
                     "error",
                     f"Tabular file not found: '{file_list[0]}': {e}",
                 )
-                raise
-
-        self.log_report.update_log_report(
-            method_name,
-            "error",
-            f"Unrecognized defined file name extension '{file_ext}' in '{conf_tab_name}'.",
-        )
-        raise ValueError(self.log_report.print_log_report(method_name, ["error"]))
+                raise FileNotFoundError(
+                    f"Tabular file not found: '{file_list[0]}'"
+                ) from e
+        else:
+            self.log_report.update_log_report(
+                method_name,
+                "error",
+                f"Unrecognized defined file name extension '{file_ext}' in '{conf_tab_name}'.",
+            )
+            raise ValueError(self.log_report.print_log_report(method_name, ["error"]))
 
     def handling_files(self, file_list, sufix, output_folder, batch_date):
         """Handles different file formats to extract data regardless of their structure.

--- a/relecov_tools/schema/ena_schema.json
+++ b/relecov_tools/schema/ena_schema.json
@@ -72,7 +72,7 @@
       "examples": [
         "3/19/2020"
       ],
-      "ontology": "GENEPIO:0001174",
+      "ontology": "SNOMED:399445004",
       "type": "string",
       "description": "The date on which the sample was collected.",
       "format": "date",
@@ -84,7 +84,7 @@
       "examples": [
         "3/21/2020"
       ],
-      "ontology": "NCIT:C93644",
+      "ontology": "SNOMED:281271004",
       "type": "string",
       "description": "The date on which the sample was received.",
       "format": "date",
@@ -931,7 +931,7 @@
       "examples": [
         "3e69af1f875fab020aed82f5edbc1f03"
       ],
-      "ontology": "MS_1000569",
+      "ontology": "NCIT:C171276",
       "type": "string",
       "description": "",
       "clasification": "Bioinformatics and QC metrics",


### PR DESCRIPTION
### PR Description:
This PR addresses issue [#453] by improving how the read-bioinfo-metadata module handles warnings related to:
1. `.gz` Compressed Files
2. variants_long_table.csv mapping