### PR TITLE
Included new module add-extra-config

### DIFF
--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -206,16 +206,16 @@ def download(
 ):
     """Download files located in sftp server."""
     debug = ctx.obj.get("debug", False)
-    download_manager = relecov_tools.download_manager.DownloadManager(
-        user,
-        password,
-        conf_file,
-        download_option,
-        output_location,
-        target_folders,
-        subfolder,
-    )
     try:
+        download_manager = relecov_tools.download_manager.DownloadManager(
+            user,
+            password,
+            conf_file,
+            download_option,
+            output_location,
+            target_folders,
+            subfolder,
+        )
         download_manager.execute_process()
     except Exception as e:
         if debug:
@@ -962,6 +962,54 @@ def upload_results(ctx, user, password, batch_id, template_path, project):
             raise
         else:
             sys.exit(f"EXCEPTION FOUND: {e}")
+
+
+@relecov_tools_cli.command(help_priority=1)
+@click.option(
+    "-n",
+    "--config_name",
+    default=None,
+    help="Name of the config key that will be added"
+)
+@click.option(
+    "-f",
+    "--config_file",
+    default=None,
+    help="Path to the input file: Json or Yaml format"
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Force replacement of existing configuration if needed"
+)
+@click.option(
+    "--clear_config",
+    is_flag=True,
+    default=False,
+    help="Remove given config_name from extra config: Use with empty --config_name to remove all"
+)
+@click.pass_context
+def add_extra_config(ctx, config_name, config_file, force, clear_config):
+    """Save given file content as additional configuration"""
+    debug = ctx.obj.get("debug", False)
+    try:
+        config_json = relecov_tools.config_json.ConfigJson(extra_config=True)
+        if clear_config:
+            config_json.remove_extra_config(config_name)
+        else:
+            config_json.include_extra_config(
+                config_file,
+                config_name=config_name,
+                force=force
+            )
+    except Exception as e:
+        if debug:
+            log.error(f"EXCEPTION FOUND: {e}")
+            raise
+        else:
+            sys.exit(f"EXCEPTION FOUND: {e}")
+
 
 
 if __name__ == "__main__":

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -13,8 +13,8 @@ import rich.console
 import rich.logging
 import rich.traceback
 
+import relecov_tools.config_json
 import relecov_tools.utils
-import relecov_tools.assets.pipeline_utils.viralrecon
 import relecov_tools.read_lab_metadata
 import relecov_tools.download_manager
 import relecov_tools.json_validation

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -969,25 +969,25 @@ def upload_results(ctx, user, password, batch_id, template_path, project):
     "-n",
     "--config_name",
     default=None,
-    help="Name of the config key that will be added"
+    help="Name of the config key that will be added",
 )
 @click.option(
     "-f",
     "--config_file",
     default=None,
-    help="Path to the input file: Json or Yaml format"
+    help="Path to the input file: Json or Yaml format",
 )
 @click.option(
     "--force",
     is_flag=True,
     default=False,
-    help="Force replacement of existing configuration if needed"
+    help="Force replacement of existing configuration if needed",
 )
 @click.option(
     "--clear_config",
     is_flag=True,
     default=False,
-    help="Remove given config_name from extra config: Use with empty --config_name to remove all"
+    help="Remove given config_name from extra config: Use with empty --config_name to remove all",
 )
 @click.pass_context
 def add_extra_config(ctx, config_name, config_file, force, clear_config):
@@ -999,9 +999,7 @@ def add_extra_config(ctx, config_name, config_file, force, clear_config):
             config_json.remove_extra_config(config_name)
         else:
             config_json.include_extra_config(
-                config_file,
-                config_name=config_name,
-                force=force
+                config_file, config_name=config_name, force=force
             )
     except Exception as e:
         if debug:
@@ -1009,7 +1007,6 @@ def add_extra_config(ctx, config_name, config_file, force, clear_config):
             raise
         else:
             sys.exit(f"EXCEPTION FOUND: {e}")
-
 
 
 if __name__ == "__main__":

--- a/relecov_tools/config_json.py
+++ b/relecov_tools/config_json.py
@@ -12,12 +12,13 @@ log = logging.getLogger(__name__)
 # TODO: Make this path configurable too
 EXTRA_CONFIG_PATH = os.path.expanduser("~/.relecov_tools/extra_config.json")
 
+
 # pass test
 class ConfigJson:
     def __init__(
         self,
         json_file=os.path.join(os.path.dirname(__file__), "conf", "configuration.json"),
-        extra_config=False
+        extra_config=False,
     ):
         """Load config content in configuration.json and additional config if required
 
@@ -37,10 +38,13 @@ class ConfigJson:
                 except (OSError, json.JSONDecodeError) as e:
                     log.warning(f"Could not load extra config: {e}")
             else:
-                log.warning(f"Could not load extra config: {EXTRA_CONFIG_PATH} does not exist")
-                log.warning("Run ``relecov-tools add_extra_config`` to include additional configuration")
+                log.warning(
+                    f"Could not load extra config: {EXTRA_CONFIG_PATH} does not exist"
+                )
+                log.warning(
+                    "Run ``relecov-tools add_extra_config`` to include additional configuration"
+                )
         self.topic_config = list(self.json_data.keys())
-
 
     def get_configuration(self, topic):
         """Obtain the topic configuration from json data"""
@@ -48,9 +52,9 @@ class ConfigJson:
             return self.json_data[topic]
         return None
 
-
     def get_topic_data(self, topic, found):
         """Obtain from topic any forward items from json data"""
+
         def get_recursive(subtopic, found):
             if isinstance(subtopic, dict):
                 for key, val in subtopic.items():
@@ -62,14 +66,13 @@ class ConfigJson:
                             return result
             else:
                 return None
-        
+
         if topic not in self.json_data.keys():
             return None
         if found in self.json_data[topic]:
             return self.json_data[topic][found]
         else:
             return get_recursive(self.json_data[topic], found)
-
 
     def include_extra_config(self, config_file, config_name=None, force=False):
         """Include given file content as additional configuration for later usage.
@@ -82,11 +85,14 @@ class ConfigJson:
         Raises:
             ValueError: If provided config_file does not have a supported extension.
         """
+
         def validate_new_config(config_name, current_conf, force=False):
             """Check if config_name is already in configuration"""
             if config_name in current_conf.keys():
                 if force:
-                    log.info(f"`{config_name}` already in config. Replacing its content...")
+                    log.info(
+                        f"`{config_name}` already in config. Replacing its content..."
+                    )
                     return True
                 else:
                     err_txt = f"Cannot add `{config_name}`: already in config. Set `force` to force replacement"
@@ -125,7 +131,9 @@ class ConfigJson:
             elif config_file.endswith((".yaml", ".yml")):
                 file_content = yaml.load(fh, Loader=yaml.FullLoader)
             else:
-                raise ValueError(f"config_file {config_file} extension is not supported. Use: {valid_exts}")
+                raise ValueError(
+                    f"config_file {config_file} extension is not supported. Use: {valid_exts}"
+                )
         if additional_config is not None:
             if config_name is None:
                 rec_merge_config(additional_config, file_content, force=force)
@@ -146,7 +154,6 @@ class ConfigJson:
         for state, changes in summary.items():
             print(state, ":\n", "\n".join([str(msg) for msg in changes]))
         return
-
 
     def remove_extra_config(self, config_name):
         """Remove key from extra_config configuration file

--- a/relecov_tools/config_json.py
+++ b/relecov_tools/config_json.py
@@ -1,18 +1,46 @@
 #!/usr/bin/env python
 import json
 import os
+import yaml
+import logging
+import rich
 
+import relecov_tools.utils
+
+log = logging.getLogger(__name__)
+
+# TODO: Make this path configurable too
+EXTRA_CONFIG_PATH = os.path.expanduser("~/.relecov_tools/extra_config.json")
 
 # pass test
 class ConfigJson:
     def __init__(
         self,
         json_file=os.path.join(os.path.dirname(__file__), "conf", "configuration.json"),
+        extra_config=False
     ):
-        fh = open(json_file)
-        self.json_data = json.load(fh)
-        fh.close()
+        """Load config content in configuration.json and additional config if required
+
+        Args:
+            json_file (str, optional): config filepath.
+            extra_config (bool, optional): Include content from ~/.relecov_tools/extra_config.json.
+        """
+        with open(json_file, "r", encoding="utf-8") as fh:
+            self.json_data = json.load(fh)
+
+        if extra_config:
+            if os.path.isfile(EXTRA_CONFIG_PATH):
+                try:
+                    with open(EXTRA_CONFIG_PATH, "r", encoding="utf-8") as add_fh:
+                        additional_conf = json.load(add_fh)
+                    self.json_data.update(additional_conf)
+                except (OSError, json.JSONDecodeError) as e:
+                    log.warning(f"Could not load extra config: {e}")
+            else:
+                log.warning(f"Could not load extra config: {EXTRA_CONFIG_PATH} does not exist")
+                log.warning("Run ``relecov-tools add_extra_config`` to include additional configuration")
         self.topic_config = list(self.json_data.keys())
+
 
     def get_configuration(self, topic):
         """Obtain the topic configuration from json data"""
@@ -20,13 +48,147 @@ class ConfigJson:
             return self.json_data[topic]
         return None
 
+
     def get_topic_data(self, topic, found):
         """Obtain from topic any forward items from json data"""
+        def get_recursive(subtopic, found):
+            if isinstance(subtopic, dict):
+                for key, val in subtopic.items():
+                    if key == found:
+                        return val
+                    elif isinstance(val, dict):
+                        result = get_recursive(val, found)
+                        if result is not None:
+                            return result
+            else:
+                return None
+        
+        if topic not in self.json_data.keys():
+            return None
         if found in self.json_data[topic]:
             return self.json_data[topic][found]
         else:
-            for key, value in self.json_data[topic].items():
-                if isinstance(value, dict):
-                    if found in self.json_data[topic][key]:
-                        return self.json_data[topic][key][found]
-            return None
+            return get_recursive(self.json_data[topic], found)
+
+
+    def include_extra_config(self, config_file, config_name=None, force=False):
+        """Include given file content as additional configuration for later usage.
+
+        Args:
+            config_name (str): Name of the config key that will be added.
+            config_file (str): Path to the input file, either Json or Yaml format.
+            force (bool, optional): Force replacement of existing configuration if needed.
+
+        Raises:
+            ValueError: If provided config_file does not have a supported extension.
+        """
+        def validate_new_config(config_name, current_conf, force=False):
+            """Check if config_name is already in configuration"""
+            if config_name in current_conf.keys():
+                if force:
+                    log.info(f"`{config_name}` already in config. Replacing its content...")
+                    return True
+                else:
+                    err_txt = f"Cannot add `{config_name}`: already in config. Set `force` to force replacement"
+                    log.error(err_txt)
+                    return False
+            else:
+                return True
+
+        def rec_merge_config(current_conf, new_conf, force=False):
+            """Recursively add new configuration without deleting the existing keys"""
+            for k, v in new_conf.items():
+                if isinstance(v, dict) and k in current_conf:
+                    rec_merge_config(current_conf[k], v, force=force)
+                else:
+                    change_msg = f"{k}: {current_conf.get(k, '')} -> {v}"
+                    if not validate_new_config(k, current_conf, force=force):
+                        summary["Canceled"].append(change_msg)
+                        continue
+                    summary["Included"].append(change_msg)
+                    current_conf[k] = v
+
+        if not os.path.isfile(str(config_file)):
+            raise FileNotFoundError(f"Extra config file {config_file} does not exist")
+        if os.path.isfile(EXTRA_CONFIG_PATH):
+            with open(EXTRA_CONFIG_PATH, "r", encoding="utf-8") as f:
+                additional_config = json.load(f)
+        else:
+            additional_config = None
+
+        summary = {"Included": [], "Canceled": []}
+        valid_exts = (".json", ".yaml", ".yml")
+        os.makedirs(os.path.dirname(EXTRA_CONFIG_PATH), exist_ok=True)
+        with open(config_file, "r") as fh:
+            if config_file.endswith(".json"):
+                file_content = json.load(fh)
+            elif config_file.endswith((".yaml", ".yml")):
+                file_content = yaml.load(fh, Loader=yaml.FullLoader)
+            else:
+                raise ValueError(f"config_file {config_file} extension is not supported. Use: {valid_exts}")
+        if additional_config is not None:
+            if config_name is None:
+                rec_merge_config(additional_config, file_content, force=force)
+            else:
+                if validate_new_config(config_name, self.json_data, force=force):
+                    msg = f"{config_name}: {file_content}"
+                    summary["Included"].append(msg)
+                    additional_config.update({config_name: file_content})
+        else:
+            if config_name is None:
+                additional_config = file_content
+            else:
+                additional_config = {config_name: file_content}
+            summary["Included"].extend([k for k in additional_config.keys()])
+        relecov_tools.utils.write_json_to_file(additional_config, EXTRA_CONFIG_PATH)
+        log.info(f"Finished including extra configuration")
+        print("Update summary:")
+        for state, changes in summary.items():
+            print(state, ":\n", "\n".join([str(msg) for msg in changes]))
+        return
+
+
+    def remove_extra_config(self, config_name):
+        """Remove key from extra_config configuration file
+
+        Args:
+            config_name (str): _description_
+        """
+        if config_name is None:
+            try:
+                os.remove(EXTRA_CONFIG_PATH)
+                log.info("Removed extra config file.")
+            except OSError as e:
+                log.error(f"Could not remove extra config file: {e}")
+                return
+        else:
+            with open(EXTRA_CONFIG_PATH, "r") as fh:
+                additional_config = json.load(fh)
+            try:
+                additional_config.pop(config_name)
+            except KeyError:
+                log.error(f"{config_name} not found in extra_config for removal")
+                return
+            except OSError as e:
+                log.error(f"Could not remove {config_name} key: {e}")
+                return
+            relecov_tools.utils.write_json_to_file(additional_config, EXTRA_CONFIG_PATH)
+            log.info(f"Successfully removed {config_name} from extra config")
+        print(f"Finished clearing extra config: {config_name}")
+        return
+
+    def get_lab_code(self, submitting_institution):
+        """Get the corresponding code for the given submitting institution"""
+        if submitting_institution is None:
+            log.warning("No submitting institution could be found to update lab_code")
+            return
+        institutions_config = self.get_configuration("institutions_config")
+        if not institutions_config:
+            log.warning("No institutions_config found. Could not extract lab_code")
+            return
+        for code, conf in institutions_config.items():
+            if submitting_institution in conf.get("institution_name"):
+                return code
+        else:
+            log.warning(f"{submitting_institution} not found in institutions_config")
+        return


### PR DESCRIPTION
This PR addresses a new module that will create an auxiliar config file in /home/user/.relecov_tools/extra_config.json using a CLI command. You can give a certain name to the key or just include the plain input file into the config, which can be either YAML or JSON format. You can delete extra_config or update already defined keys with --force and --clear_config