### PR TITLE
Truncate long warnings individually in Global Report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Code contributions to the release:
 - [Victor Lopez](https://github.com/victor5lm)
 - [Jaime Ozáez](https://github.com/jaimeozaez)
 - [Juan Ledesma](https://github.com/juanledesma78)
+- [Sergio Olmos](https://github.com/OPSergio)
 
 ### Modules
 
@@ -60,6 +61,7 @@ Code contributions to the release:
 - Modified create_summary_tables.py to add new columns in epidemiological_data.xlsh (Pangolin software and database version and analysis date) [#454](https://github.com/BU-ISCIII/relecov-tools/pull/454)
 - Improve Warning Handling for .gz Files and variants_long_table.csv in read-bioinfo-metadata [#457](https://github.com/BU-ISCIII/relecov-tools/pull/457)
 - Add Tracking Summary of Samples per COD and Destination Folder in pipeline-manager [#463](https://github.com/BU-ISCIII/relecov-tools/pull/463)
+- Improves the formatting of the Global Report sheet in the summary Excel by truncating overly long warnings individually [#474](https://github.com/BU-ISCIII/relecov-tools/pull/474)
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Code contributions to the release:
 - Modified create_summary_tables.py to add new columns in epidemiological_data.xlsh (Pangolin software and database version and analysis date) [#454](https://github.com/BU-ISCIII/relecov-tools/pull/454)
 - Improve Warning Handling for .gz Files and variants_long_table.csv in read-bioinfo-metadata [#457](https://github.com/BU-ISCIII/relecov-tools/pull/457)
 - Add Tracking Summary of Samples per COD and Destination Folder in pipeline-manager [#463](https://github.com/BU-ISCIII/relecov-tools/pull/463)
-- Improves the formatting of the Global Report sheet in the summary Excel by truncating overly long warnings individually [#474](https://github.com/BU-ISCIII/relecov-tools/pull/474)
+- Improves the formatting of the Global Report sheet in the summary Excel by truncating overly long warnings and errors individually [#474](https://github.com/BU-ISCIII/relecov-tools/pull/474)
 
 #### Fixes
 

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -226,9 +226,28 @@ class LogSum:
                 new_sheet = workbook.create_sheet(name)
                 new_sheet.append(header)
             regex = r"[\[\]]"  # Regex to remove lists brackets
+            
+            valid = logs.get("Valid", True)
+            errors = logs.get("Errors", [])
+            warnings = logs.get("Warnings", [])
+            
+            errors = reg_remover(errors, regex)
+            
+            warnings_list = warnings if isinstance(warnings, list) else [warnings]
+            truncated_warnings = []
+            max_warning_lenght = 150
+            
+            for warning in warnings_list:
+                warnings_str = str(warning)
+                if len(warnings_str) > max_warning_lenght:
+                    warnings_str = warnings_str[:max_warning_lenght] + "..."
+                truncated_warnings.append(warnings_str)
+            warnings_cleaned = "; ".join(truncated_warnings)
+            
             workbook["Global Report"].append(
-                [reg_remover(x, regex) for k, x in logs.items() if k != "samples"]
+                [str(valid), errors, warnings_cleaned]
             )
+            
             regex = r"\[.*?\]"  # Regex to remove ontology annotations between brackets
             for sample, slog in samples_logs.items():
                 clean_errors = [reg_remover(x, regex) for x in slog["errors"]]

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -228,23 +228,37 @@ class LogSum:
             regex = r"[\[\]]"  # Regex to remove lists brackets
 
             valid = logs.get("valid", True)
-            errors = logs.get("errors", [])
             warnings = logs.get("warnings", [])
-
-            errors = reg_remover(errors, regex)
 
             warnings_list = warnings if isinstance(warnings, list) else [warnings]
             truncated_warnings = []
-            max_warning_lenght = 150
+            max_lenght = 150
 
             for warning in warnings_list:
                 warnings_str = str(warning)
-                if len(warnings_str) > max_warning_lenght:
-                    warnings_str = warnings_str[:max_warning_lenght] + "..."
+                if len(warnings_str) > max_lenght:
+                    warnings_str = warnings_str[:max_lenght] + "..."
                 truncated_warnings.append(warnings_str)
             warnings_cleaned = "; ".join(truncated_warnings)
 
-            workbook["Global Report"].append([str(valid), errors, warnings_cleaned])
+            errors_list = logs.get("errors", [])
+            errors_list = (
+                errors_list if isinstance(errors_list, list) else [errors_list]
+            )
+
+            truncated_errors = []
+
+            for err in errors_list:
+                err_str = reg_remover(str(err), regex)
+                if len(err_str) > max_lenght:
+                    err_str = err_str[:max_lenght] + "..."
+                truncated_errors.append(err_str)
+
+            errors_cleaned = "; ".join(truncated_errors)
+
+            workbook["Global Report"].append(
+                [str(valid), errors_cleaned, warnings_cleaned]
+            )
 
             regex = r"\[.*?\]"  # Regex to remove ontology annotations between brackets
             for sample, slog in samples_logs.items():

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -227,9 +227,9 @@ class LogSum:
                 new_sheet.append(header)
             regex = r"[\[\]]"  # Regex to remove lists brackets
 
-            valid = logs.get("Valid", True)
-            errors = logs.get("Errors", [])
-            warnings = logs.get("Warnings", [])
+            valid = logs.get("valid", True)
+            errors = logs.get("errors", [])
+            warnings = logs.get("warnings", [])
 
             errors = reg_remover(errors, regex)
 

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -226,28 +226,26 @@ class LogSum:
                 new_sheet = workbook.create_sheet(name)
                 new_sheet.append(header)
             regex = r"[\[\]]"  # Regex to remove lists brackets
-            
+
             valid = logs.get("Valid", True)
             errors = logs.get("Errors", [])
             warnings = logs.get("Warnings", [])
-            
+
             errors = reg_remover(errors, regex)
-            
+
             warnings_list = warnings if isinstance(warnings, list) else [warnings]
             truncated_warnings = []
             max_warning_lenght = 150
-            
+
             for warning in warnings_list:
                 warnings_str = str(warning)
                 if len(warnings_str) > max_warning_lenght:
                     warnings_str = warnings_str[:max_warning_lenght] + "..."
                 truncated_warnings.append(warnings_str)
             warnings_cleaned = "; ".join(truncated_warnings)
-            
-            workbook["Global Report"].append(
-                [str(valid), errors, warnings_cleaned]
-            )
-            
+
+            workbook["Global Report"].append([str(valid), errors, warnings_cleaned])
+
             regex = r"\[.*?\]"  # Regex to remove ontology annotations between brackets
             for sample, slog in samples_logs.items():
                 clean_errors = [reg_remover(x, regex) for x in slog["errors"]]


### PR DESCRIPTION
### Truncate long warnings and errors individually in Global Report

This PR improves the formatting of the Global Report sheet in the summary Excel by truncating overly long warnings and errors individually, preventing excessively large or unreadable cells (e.g., enum lists with thousands of items).

Before: 
![image](https://github.com/user-attachments/assets/30975e8e-25fc-4455-a7b9-c44d5dd596a6)

After: 
![image](https://github.com/user-attachments/assets/84320c8b-bec1-4028-9d6d-4cbf88f8f801)
![image](https://github.com/user-attachments/assets/a3ce2469-a495-45a6-bdb6-7eb58ff72326)

---
Closes(#469)