### PR TITLE
Reverted temporal hotfix for corrupted sftp folders 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Code contributions to the release:
 - Fixed datetime generation, avoiding the omission of number zero in case of hours of a single digit [#472](https://github.com/BU-ISCIII/relecov-tools/pull/472)
 - Temporal hotfix for invalid folders in remote sftp [#482](https://github.com/BU-ISCIII/relecov-tools/pull/482)
 - Fix subfolder handling in wrapper module [#484](https://github.com/BU-ISCIII/relecov-tools/pull/484)
+- Reverted temporal hotfix changes for invalid sftp folders [#486](https://github.com/BU-ISCIII/relecov-tools/pull/486)
 
 #### Changed
 

--- a/relecov_tools/sftp_client.py
+++ b/relecov_tools/sftp_client.py
@@ -125,9 +125,6 @@ class SftpRelecov:
             return [folder_name]
 
         def recursive_list(folder_name):
-            invalid_folders = ["D-2435-", "D-2403-"]
-            if any(f in folder_name for f in invalid_folders):
-                return directory_list
             try:
                 attribute_list = self.sftp.listdir_attr(folder_name)
             except (FileNotFoundError, OSError) as e:


### PR DESCRIPTION
This PR reverts the changes applied in #483 
This error was correctly addressed in the remote sftp and the hotfix is no longer necessary