### PR TITLE
Fixed permissions error between different machines #477

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Code contributions to the release:
 - Temporal hotfix for invalid folders in remote sftp [#482](https://github.com/BU-ISCIII/relecov-tools/pull/482)
 - Fix subfolder handling in wrapper module [#484](https://github.com/BU-ISCIII/relecov-tools/pull/484)
 - Reverted temporal hotfix changes for invalid sftp folders [#486](https://github.com/BU-ISCIII/relecov-tools/pull/486)
+- Fixed permissions error when redirecting logs between different machines [#489](https://github.com/BU-ISCIII/relecov-tools/pull/489)
 
 #### Changed
 

--- a/relecov_tools/base_module.py
+++ b/relecov_tools/base_module.py
@@ -133,16 +133,13 @@ class BaseModule:
                 os.path.basename(new_log_path),
             )
         try:
-            os.rename(log_file, new_log_path)
-        except OSError:
-            self.log.debug(f"Could not rename {log_file}, trying to copy and delete...")
-            try:
-                shutil.copy(log_file, new_log_path)
-                os.remove(log_file)
-                self.log.debug("Successful copy and delete")
-            except OSError as e:
-                self.log.error(f"Could not redirect {log_file} to {new_log_path}: {e}")
-                return
+            # Only copy file content, not permissions nor metadata
+            shutil.copyfile(log_file, new_log_path)
+            os.remove(log_file)
+            self.log.debug(f"Successful copy and delete of old log-file {log_file}")
+        except OSError as e:
+            self.log.error(f"Could not redirect {log_file} to {new_log_path}: {e}")
+            return
         for handler in self.log.handlers:
             if isinstance(handler, logging.FileHandler):
                 if self.called_module in handler.baseFilename:


### PR DESCRIPTION
This PR addresses an error in BaseModule that arose when redirecting logs to a different machine, as the copied files retained their original permissions, leading to a somewhat confusing OSError

Closes #477 