### PR TITLE
Fixing subprocess logs going in wrapper output_location instead of its own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Code contributions to the release:
 - Reverted temporal hotfix changes for invalid sftp folders [#486](https://github.com/BU-ISCIII/relecov-tools/pull/486)
 - Fix metadata upload in dataprocess_wrapper and update schema assets to v3.0.0 [#488](https://github.com/BU-ISCIII/relecov-tools/pull/488)
 - Fixed permissions error when redirecting logs between different machines [#489](https://github.com/BU-ISCIII/relecov-tools/pull/489)
+- Included correct handling of CLI --log-path arg fixing #490 [#497](https://github.com/BU-ISCIII/relecov-tools/pull/497)
 
 #### Changed
 

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -11,7 +11,6 @@ import relecov_tools.config_json
 import relecov_tools.download_manager
 import relecov_tools.log_summary
 import rich.console
-import rich.logging
 import rich.traceback
 
 import relecov_tools.config_json
@@ -167,6 +166,8 @@ def relecov_tools_cli(ctx, verbose, log_path, debug, hex_code):
         log_path = logs_config.get("modules_outpath", {}).get(called_module)
         if not log_path:
             log_path = os.path.join(default_outpath, called_module)
+    else:
+        relecov_tools.base_module.BaseModule._cli_log_path_param = log_path
     current_datetime = datetime.today().strftime("%Y%m%d%-H%M%S")
     log_filepath = os.path.join(
         log_path, "_".join([called_module, current_datetime]) + ".log"

--- a/relecov_tools/base_module.py
+++ b/relecov_tools/base_module.py
@@ -13,6 +13,7 @@ class BaseModule:
     # These variables should only be activated via CLI using --hex-code
     _global_hex_code = None
     _cli_log_file = None
+    _cli_log_path_param = None
     # This indicates that there is already a process functioning,
     # therefore you should create new log handlers instead of redirecting
     _active_process = False
@@ -26,7 +27,10 @@ class BaseModule:
             output_directory (str, optional): Output folder to save called module logs. Defaults to None.
             called_module (str, optional): Name of the module being executed. Defaults to None.
         """
-        self.log = logging.getLogger(f"{__class__.__module__}.{called_module}")
+        if BaseModule._active_process:
+            self.log = logging.getLogger(f"{__class__.__module__}.{called_module}")
+        else:
+            self.log = logging.getLogger()
         self.log.propagate = True
         self.log.info(f"RELECOV-tools version {BaseModule._current_version}")
         self.log.info(f"CLI command executed: {BaseModule._cli_command}")
@@ -124,12 +128,12 @@ class BaseModule:
                 "log_file and new_log_path are the same, no redirection needed"
             )
             return
-        if BaseModule._cli_log_file:
+        if BaseModule._cli_log_path_param:
             self.log.warning(
                 "--log-path activated via CLI. Logs output folder wont change"
             )
             new_log_path = os.path.join(
-                os.path.dirname(BaseModule._cli_log_file),
+                os.path.dirname(BaseModule._cli_log_path_param),
                 os.path.basename(new_log_path),
             )
         try:

--- a/relecov_tools/dataprocess_wrapper.py
+++ b/relecov_tools/dataprocess_wrapper.py
@@ -44,7 +44,7 @@ class ProcessWrapper(BaseModule):
                 if val == arg:
                     self.config_data[key] = self.output_folder
         self.wrapper_logsum = self.parent_log_summary(
-            output_location=os.path.join(self.output_folder, "logs")
+            output_location=os.path.join(self.output_folder)
         )
         self.config_data["download"].update({"output_location": output_folder})
         self.download_params = self.clean_module_params(


### PR DESCRIPTION
This PR fixes an small error that was leading to logs from subprocesses to go in wrapper's output_location instead of its own defined output_locations (either via config or by default).

Closes #490