### PR TITLE
Unify CLI Option Name for JSON Schema Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ Code contributions to the release:
 - Changed utils.write_json_fo_file() name to write_json_to_file() [#412](https://github.com/BU-ISCIII/relecov-tools/pull/412)
 - Changed pipeline-manager --template param to --templates_root, now points to root folder [#412](https://github.com/BU-ISCIII/relecov-tools/pull/412)
 - Changed property name for consistency with the rest of the properties. [#480](https://github.com/BU-ISCIII/relecov-tools/pull/480)
+- Renamed CLI argument --json_schema to --json_schema_file in validate command for consistency with internal function arguments and YAML configuration. [#503](https://github.com/BU-ISCIII/relecov-tools/pull/503)
 
 #### Removed
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Usage: relecov-tools validate [OPTIONS]
 
   Options:
     -j, --json_file TEXT    Json file to validate
-    -s, --json_schema TEXT  Json schema (default: relecov-schema)
+    -s, --json_schema_file TEXT Path to the JSON Schema file used for validation (default: relecov-schema)
     -m, --metadata PATH     Origin file containing metadata
     -o, --out_folder TEXT   Path to save validate json file
     --help                  Show this message and exit.

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -316,7 +316,7 @@ def read_lab_metadata(ctx, metadata_file, sample_list_file, metadata_out, files_
 # validation
 @relecov_tools_cli.command(help_priority=4)
 @click.option("-j", "--json_file", help="Json file to validate")
-@click.option("-s", "--json_schema_file", help="Json schema")
+@click.option("-s", "--json_schema_file", help="Path to the JSON Schema file used for validation")
 @click.option(
     "-m",
     "--metadata",

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -316,7 +316,9 @@ def read_lab_metadata(ctx, metadata_file, sample_list_file, metadata_out, files_
 # validation
 @relecov_tools_cli.command(help_priority=4)
 @click.option("-j", "--json_file", help="Json file to validate")
-@click.option("-s", "--json_schema_file", help="Path to the JSON Schema file used for validation")
+@click.option(
+    "-s", "--json_schema_file", help="Path to the JSON Schema file used for validation"
+)
 @click.option(
     "-m",
     "--metadata",

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -316,7 +316,7 @@ def read_lab_metadata(ctx, metadata_file, sample_list_file, metadata_out, files_
 # validation
 @relecov_tools_cli.command(help_priority=4)
 @click.option("-j", "--json_file", help="Json file to validate")
-@click.option("-s", "--json_schema", help="Json schema")
+@click.option("-s", "--json_schema_file", help="Json schema")
 @click.option(
     "-m",
     "--metadata",
@@ -332,11 +332,11 @@ def read_lab_metadata(ctx, metadata_file, sample_list_file, metadata_out, files_
     help="Optional: Name of the sheet in excel file to validate.",
 )
 @click.pass_context
-def validate(ctx, json_file, json_schema, metadata, out_folder, excel_sheet):
+def validate(ctx, json_file, json_schema_file, metadata, out_folder, excel_sheet):
     """Validate json file against schema."""
     debug = ctx.obj.get("debug", False)
     validation = relecov_tools.json_validation.SchemaValidation(
-        json_file, json_schema, metadata, out_folder, excel_sheet
+        json_file, json_schema_file, metadata, out_folder, excel_sheet
     )
     try:
         validation.validate()


### PR DESCRIPTION
## Summary

This PR standardizes the name of the CLI option used to specify the JSON Schema in the `validate` command.

Closes (#499) Inconsistent option name between CLI help and wrapper config for json_schema