### PR TITLE
Improve error handling and messages in `logs-to-excel` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Code contributions to the release:
 - Add Tracking Summary of Samples per COD and Destination Folder in pipeline-manager [#463](https://github.com/BU-ISCIII/relecov-tools/pull/463)
 - Improves the formatting of the Global Report sheet in the summary Excel by truncating overly long warnings and errors individually [#474](https://github.com/BU-ISCIII/relecov-tools/pull/474)
 - Updated bioinfo_config.json to add the analysis date to the lineage_analysis_date in the bioinfo-lab-metadata json file. This analysis date is also added as the last column of the pangolin .csv files [#504](https://github.com/BU-ISCIII/relecov-tools/pull/504).
+- Improve error handling and messages in logs-to-excel module [507#](https://github.com/BU-ISCIII/relecov-tools/pull/507)
 
 #### Fixes
 

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -946,7 +946,9 @@ def logs_to_excel(ctx, lab_code, output_folder, files):
             log.error(f"Couldn't extract data from {file}: {e}")
 
     if not all_logs:
-        stderr.print(f"[red]No logs extracted. Make sure the --lab_code '{lab_code}' exists in the provided files.")
+        stderr.print(
+            f"[red]No logs extracted. Make sure the --lab_code '{lab_code}' exists in the provided files."
+        )
         log.error(f"No logs extracted for lab_code '{lab_code}'.")
         exit(1)
 

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -946,11 +946,10 @@ def logs_to_excel(ctx, lab_code, output_folder, files):
             log.error(f"Couldn't extract data from {file}: {e}")
 
     if not all_logs:
-        stderr.print(
-            f"[red]No logs extracted. Make sure the --lab_code '{lab_code}' exists in the provided files."
-        )
-        log.error(f"No logs extracted for lab_code '{lab_code}'.")
-        exit(1)
+        msg = f"No logs extracted. Make sure the --lab_code '{lab_code}' exists in the provided files."
+        stderr.print(f"[red]{msg}")
+        log.error(msg)
+        raise ValueError(msg)
 
     logsum = relecov_tools.log_summary.LogSum(output_location=output_folder)
     try:


### PR DESCRIPTION
# PR description

- Clarified misleading "All provided files were empty" message when lab_code is not found.

- Added check for empty input files with a proper error message.

Closes #506 