### PR TITLE
Added summary stats logging to wrapper module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Code contributions to the release:
 - Improves the formatting of the Global Report sheet in the summary Excel by truncating overly long warnings and errors individually [#474](https://github.com/BU-ISCIII/relecov-tools/pull/474)
 - Updated bioinfo_config.json to add the analysis date to the lineage_analysis_date in the bioinfo-lab-metadata json file. This analysis date is also added as the last column of the pangolin .csv files [#504](https://github.com/BU-ISCIII/relecov-tools/pull/504).
 - Improve error handling and messages in logs-to-excel module [507#](https://github.com/BU-ISCIII/relecov-tools/pull/507)
+- Added summary stats logging to wrapper module [514#](https://github.com/BU-ISCIII/relecov-tools/pull/514)
 
 #### Fixes
 

--- a/relecov_tools/dataprocess_wrapper.py
+++ b/relecov_tools/dataprocess_wrapper.py
@@ -4,6 +4,7 @@ import yaml
 import os
 import inspect
 import rich.console
+from collections import defaultdict
 from relecov_tools.download_manager import DownloadManager
 from relecov_tools.read_lab_metadata import RelecovMetadata
 from relecov_tools.json_validation import SchemaValidation
@@ -367,5 +368,26 @@ class ProcessWrapper(BaseModule):
             called_module="wrapper",
             to_excel=True,
         )
+
+        # Logging wrapper stats
+        labs = {folder.split("/")[0] for folder in finished_folders}
+        num_labs = len(labs)
+        samples_per_lab = defaultdict(int)
+        for folder, files in finished_folders.items():
+            lab = folder.split("/")[0]
+            samples_per_lab[lab] += len(files)
+        total_count = sum(samples_per_lab.values())
+
+        stderr.print("[blue] --------------------")
+        stderr.print("[blue] WRAPPER SUMMARY")
+        stderr.print("[blue] --------------------")
+        self.log.info(f"Number of processed laboratories: {num_labs}")
+        stderr.print(f"[blue]Number of processed laboratories: {num_labs}")
+        self.log.info(f"Total number of processed files: {total_count}")
+        stderr.print(f"[blue]Total number of processed files: {total_count}")
+        stderr.print("[blue]Processed files for each laboratory")
+        for lab, count in samples_per_lab.items():
+            self.log.info(f"    {lab}: {count} files")
+            stderr.print(f"[blue]    {lab}: {count} files")
 
         return


### PR DESCRIPTION
As per title, statistics about the number of laboratories analysed, the total number of files processed, and the number of files processed by each laboratory have been collected and logged. This information is visible through on-screen text, as well as collected in the wrapper log file.

Closes #468 