### PR TITLE
Fixed paired and single-end files validation #535

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Credits
 
+- [Pablo Mata](https://github.com/shettland)
+
+
 #### Added enhancements
 
 #### Fixes
+
+- Fixed paired and single-end files validation [#537](https://github.com/BU-ISCIII/relecov-tools/pull/537)
 
 #### Changed
 
@@ -37,6 +42,7 @@ Code contributions to the release:
 
 - Introduced BaseModule as parent class for all other classes. Used to to handle logs. [#466](https://github.com/BU-ISCIII/relecov-tools/pull/466)
 - New module add-extra-config for additional custom config [#464](https://github.com/BU-ISCIII/relecov-tools/pull/464)
+- Created new `upload-results` module for uploading analysis_results folder back to every COD folder in sftp. [#433](https://github.com/BU-ISCIII/relecov-tools/pull/433)
 
 #### Added enhancements
 
@@ -65,7 +71,6 @@ Code contributions to the release:
 - Test SFTP Login by Updating Port Assignment in wrapper_manager [#426](https://github.com/BU-ISCIII/relecov-tools/pull/426)
 - Update Test Data for new Schema & Modify JSON Filepaths in read-bioinfo-metadata [#427](https://github.com/BU-ISCIII/relecov-tools/pull/427)
 - Update download Module to Process Data by Laboratory COD and Project Subfolder [#431](https://github.com/BU-ISCIII/relecov-tools/pull/431)
-- Created new `upload-results` for uploading analysis_results folder back to every COD folder in sftp. [#433](https://github.com/BU-ISCIII/relecov-tools/pull/433)
 - Update relecov_schema.json to 3.0.0dev version [#435](https://github.com/BU-ISCIII/relecov-tools/pull/435)
 - Fix viralrecon_filepaths Path in read-bioinfo-metadata Module [#438](https://github.com/BU-ISCIII/relecov-tools/pull/438)
 - Fix adding_ontology_to_enum when enum has no ontology [#439](https://github.com/BU-ISCIII/relecov-tools/pull/439)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Code contributions to the release:
 
 ### Modules
 
+- Introduced BaseModule as parent class for all other classes. Used to to handle logs. [#466](https://github.com/BU-ISCIII/relecov-tools/pull/466)
 - New module add-extra-config for additional custom config [#464](https://github.com/BU-ISCIII/relecov-tools/pull/464)
 
 #### Added enhancements

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -20,7 +20,6 @@ from relecov_tools.base_module import BaseModule
 
 # from relecov_tools.rest_api import RestApi
 
-"""log = logging.getLogger(__name__)"""
 stderr = rich.console.Console(
     stderr=True,
     style="dim",
@@ -427,11 +426,11 @@ class DownloadManager(BaseModule):
                         stderr.print(log_text)
                         self.include_warning(log_text, sample=s_name)
                         continue
-                if row[index_layout] == "Paired" and row[index_fastq_r2] is None:
+                if "paired" in row[index_layout].lower() and row[index_fastq_r2] is None:
                     error_text = "Sample %s is paired-end, but no R2 given"
                     self.include_error(error_text % str(row[index_sampleID]), s_name)
                     row_complete = False
-                if row[index_layout] == "Single" and row[index_fastq_r2] is not None:
+                if "single" in row[index_layout].lower() and row[index_fastq_r2] is not None:
                     error_text = "Sample %s is single-end, but R1 and R2 were given"
                     self.include_error(error_text % str(row[index_sampleID]), s_name)
                     row_complete = False

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -426,11 +426,17 @@ class DownloadManager(BaseModule):
                         stderr.print(log_text)
                         self.include_warning(log_text, sample=s_name)
                         continue
-                if "paired" in row[index_layout].lower() and row[index_fastq_r2] is None:
+                if (
+                    "paired" in row[index_layout].lower()
+                    and row[index_fastq_r2] is None
+                ):
                     error_text = "Sample %s is paired-end, but no R2 given"
                     self.include_error(error_text % str(row[index_sampleID]), s_name)
                     row_complete = False
-                if "single" in row[index_layout].lower() and row[index_fastq_r2] is not None:
+                if (
+                    "single" in row[index_layout].lower()
+                    and row[index_fastq_r2] is not None
+                ):
                     error_text = "Sample %s is single-end, but R1 and R2 were given"
                     self.include_error(error_text % str(row[index_sampleID]), s_name)
                     row_complete = False


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This PR fixes validation of single-end files when more than 1 file is provided, and the same for paired-end when R2 file is missing. This was caused because the field value for paired-end and single-end changed in the schema and was not correctly recognized. Closes #535
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).