### PR TITLE
Enhanced new log handling in read-bioinfo-metadata. Fixed deprecated r1_path field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Added enhancements
 
+- Correctly implemented new log handling in read-bioinfo-metadata [#546](https://github.com/BU-ISCIII/relecov-tools/pull/546)
+
 #### Fixes
 
 - Fixed paired and single-end files validation [#537](https://github.com/BU-ISCIII/relecov-tools/pull/537)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed paired and single-end files validation [#537](https://github.com/BU-ISCIII/relecov-tools/pull/537)
 - Suppressed unrelated warning when extra-config is not set [#543](https://github.com/BU-ISCIII/relecov-tools/pull/543)
 - Add identifier fields to relecov_schema.json [#544](https://github.com/BU-ISCIII/relecov-tools/pull/544)
+- Fixed deprecated sequence_file_path_R1 field in read-bioinfo-metadata [#546](https://github.com/BU-ISCIII/relecov-tools/pull/546)
 
 #### Changed
 

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -21,7 +21,7 @@ stderr = rich.console.Console(
 )
 
 
-class BioinfoReportLog():
+class BioinfoReportLog:
     def __init__(self, log_report=None, output_folder="/tmp/"):
         if not log_report:
             self.report = {"error": {}, "valid": {}, "warning": {}}
@@ -685,9 +685,7 @@ class BioinfoMetadata(BaseModule):
                 row["bioinfo_metadata_file"] = self.out_filename
                 for field, value in f_values.items():
                     row[field] = value
-            self.update_all_logs(
-                method_name, "valid", "Fields added successfully."
-            )
+            self.update_all_logs(method_name, "valid", "Fields added successfully.")
         except KeyError as e:
             self.update_all_logs(
                 method_name, "warning", f"Error found while adding fixed values: {e}"
@@ -760,9 +758,7 @@ class BioinfoMetadata(BaseModule):
                     )
         self.log_report.print_log_report(method_name, ["warning"])
         if sample_name_error == 0:
-            self.update_all_logs(
-                method_name, "valid", "File paths added successfully."
-            )
+            self.update_all_logs(method_name, "valid", "File paths added successfully.")
         self.log_report.print_log_report(method_name, ["valid", "warning"])
         return j_data
 


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This PR addresses two issues: 
- New log functionality is now correctly handled in read-bioinfo-metadata, as it was generating two logfiles due to a repeated init of BaseModule class in BioinfoLogReport(). Closes #533 
- Fixed deprecated `sequence_file_path_R1_fastq` for the newer version `sequence_file_path_R1`. Closes #545 
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).