### PR TITLE
Fixed unexpected warning message when `organism` field is empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Pablo Mata](https://github.com/shettland)
 - [Alejandro Bernabeu](https://github.com/aberdur)
+- [Jaime Ozáez](https://github.com/jaimeozaez)
 
 
 #### Added enhancements
@@ -24,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Suppressed unrelated warning when extra-config is not set [#543](https://github.com/BU-ISCIII/relecov-tools/pull/543)
 - Add identifier fields to relecov_schema.json [#544](https://github.com/BU-ISCIII/relecov-tools/pull/544)
 - Fixed deprecated sequence_file_path_R1 field in read-bioinfo-metadata [#546](https://github.com/BU-ISCIII/relecov-tools/pull/546)
+- Fixed unexpected warning message when organism field is empty [#553](https://github.com/BU-ISCIII/relecov-tools/pull/553)
 
 #### Changed
 

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -257,8 +257,8 @@ class RelecovMetadata(BaseModule):
                 m_data[idx]["tax_id"] = organism_mapping[organism]["tax_id"]
                 m_data[idx]["host_disease"] = organism_mapping[organism]["host_disease"]
             else:
-                m_data[idx]["tax_id"] = "Unknown [SNOMED:261665006]"
-                m_data[idx]["host_disease"] = "Unknown [SNOMED:261665006]"
+                m_data[idx]["tax_id"] = "Missing [LOINC:LA14698-7]"
+                m_data[idx]["host_disease"] = "Missing [LOINC:LA14698-7]"
             for key, value in p_data.items():
                 m_data[idx][key] = value
             m_data[idx]["schema_name"] = self.schema_name


### PR DESCRIPTION
Prior to this PR, when the organism field was left empty, a warning was raised informing that an `Unknown` metadata did not belong to a group of enums.
The metadata "Unknown" has been replaced for "Missing" in host_disease field when organism is empty. "Missing" is one of de available enums.
Now, the only warning printed is Organism: `XX samples failed validation for organism:\n'Organism' is a required property`.

Closes #519 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).