### PR TITLE
Modified warning message when validating invalid date format

### DIFF
--- a/relecov_tools/json_validation.py
+++ b/relecov_tools/json_validation.py
@@ -185,10 +185,11 @@ class SchemaValidation(BaseModule):
                     except KeyError:
                         self.log.error(f"Could not extract label for {error_field}")
                         err_field_label = error_field
-
                     # Format the error message
-                    error.message = error.message.replace(error_field, err_field_label)
-                    error_text = f"Error in column {err_field_label}: {error.message}"
+                    if error.validator == "format" and error.validator_value == "date":
+                        error_text = f"Error in column {err_field_label}: '{error.instance}' is not a valid date format. Valid format 'YYYY-MM-DD'"
+                    else:
+                        error_text = f"Error in column {err_field_label}: {error.message}"
 
                     # Log errors for summary
                     error_keys[error.message] = error_field
@@ -205,7 +206,10 @@ class SchemaValidation(BaseModule):
         self.log.info("Validation summary:")
         for error_type, count in errors.items():
             field_with_error = error_keys[error_type]
-            error_text = f"{count} samples failed validation for {field_with_error}:\n{error_type}"
+            if "is not a 'date'" in error_type:
+                error_text = f"{count} samples failed validation for {field_with_error}:\n{error_type.split()[0]} is not a valid date format. Valid format 'YYYY-MM-DD"
+            else:
+                error_text = f"{count} samples failed validation for {field_with_error}:\n{error_type}"
             self.logsum.add_warning(entry=error_text)
             stderr.print(f"[red]{error_text}")
             stderr.print("[red] --------------------")


### PR DESCRIPTION
The current error message for invalid dates in the "Sample Collection Date" column reads:

`Error in column Sample Collection Date: '2023/06/21' is not a 'date'`

This message has been substituted by

`Error in column Sample Collection Date: '2023/06/21' is not a valid date format. Valid format 'YYYY-MM-DD.`

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).