### PR TITLE
Add support for `qc_failed` logic in `viralrecon.py` and update `PR template`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-# bu-isciii tools pull request
+# relecov-isciii tools pull request
 
 Based on nf-core/viralrecon pull request template
 
@@ -8,7 +8,7 @@ Fill in the appropriate checklist below and delete whatever is not relevant.
 PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
 -->
 
-## PR checklist
+## PR Checklist
 
 - [ ] This comment contains a description of changes (with reason).
 - [ ] Make sure your code lints (`black and flake8`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Update relecov_schema.json [#550](https://github.com/BU-ISCIII/relecov-tools/pull/550)
 - Improve json to excel generation to admit excels with more than one lab [#552](https://github.com/BU-ISCIII/relecov-tools/pull/552)
 - Made --template_path optional in send-email and upload-results commands, using fallback to config key delivery_template_path_file [#548](https://github.com/BU-ISCIII/relecov-tools/pull/548)
-- The configuration necessary to use the mail module is incorporated as an extra-config. [#548](https://github.com/BU-ISCIII/relecov-tools/pull/548)
+- The configuration necessary to use the mail module is incorporated as an extra-config. [#548](https://github.com/BU-ISCIII/relecov-tools/pull/548)- Add support for qc_failed logic in viralrecon.py and update PR template [#559](https://github.com/BU-ISCIII/relecov-tools/pull/559)
+
 #### Removed
 
 ### Requirements

--- a/relecov_tools/assets/pipeline_utils/viralrecon.py
+++ b/relecov_tools/assets/pipeline_utils/viralrecon.py
@@ -513,6 +513,12 @@ def quality_control_evaluation(data):
                 try:
                     if value is None or not condition(value):
                         if is_not_evaluable(value):
+                            log.info(
+                                "%s is not evaluable for %s in sample %s",
+                                value,
+                                param,
+                                sample["sequencing_sample_id"],
+                            )
                             continue
                         qc_status = "fail"
                         op, th = thresholds[param]


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR Description
This PR introduces the following updates:

- Support for qc_failed logic in viralrecon.py:

The module now parses and evaluates the qc_failed expression defined in the schema to determine whether a sample fails quality control.

Example supported expression:
`"qc_failed": "(per_sgene_coverage < 98.0) -- (per_ldmutations < 60.0)"
`
The expression supports logical grouping using -- as a separator for multiple conditions, evaluated as logical OR.

- PR Template Updated

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).