### PR TITLE
Fixed errors during sftp handling in wrapper and download

### DIFF
--- a/relecov_tools/conf/configuration.json
+++ b/relecov_tools/conf/configuration.json
@@ -152,7 +152,8 @@
             "sequence_file_R1",
             "sequence_file_R2",
             "sequence_file_path_R1",
-            "sequence_file_path_R2"
+            "sequence_file_path_R2",
+            "batch_id"
         ]
     },
     "long_table_heading": [

--- a/relecov_tools/dataprocess_wrapper.py
+++ b/relecov_tools/dataprocess_wrapper.py
@@ -195,44 +195,24 @@ class ProcessWrapper(BaseModule):
         )
         stderr.print(f"[green]Merged logs from all processes in {local_folder}")
         self.log.info(f"Merged logs from all processes in {local_folder}")
-        sftp_dirs = self.download_manager.relecov_sftp.list_remote_folders(key)
-        sftp_dirs_paths = [os.path.join(key, d) for d in sftp_dirs]
+        subfolder = getattr(self.download_manager, "subfolder", None)
+        if subfolder and subfolder not in key:
+            main_folder = os.path.join(key, subfolder)
+        else:
+            main_folder = key
+        sftp_dirs = self.download_manager.relecov_sftp.list_remote_folders(main_folder)
+        sftp_dirs_paths = [os.path.join(main_folder, d) for d in sftp_dirs]
         valid_dirs = [d for d in sftp_dirs_paths if d in finished_folders.keys()]
-
-        if not valid_dirs:
-            subfolder = getattr(self.download_manager, "subfolder", None)
-            if subfolder:
-                key_subfolder = os.path.join(key, subfolder)
-                try:
-                    sftp_dirs = self.download_manager.relecov_sftp.list_remote_folders(
-                        key_subfolder
-                    )
-                    sftp_dirs_paths = [
-                        os.path.join(key_subfolder, d) for d in sftp_dirs
-                    ]
-                    valid_dirs = [
-                        d for d in sftp_dirs_paths if d in finished_folders.keys()
-                    ]
-                except FileNotFoundError as e:
-                    warn_msg = (
-                        f"Subfolder {key_subfolder} not found in remote SFTP: {e}"
-                    )
-                    self.log.warning(warn_msg)
-                    stderr.print(f"[yellow]{warn_msg}")
 
         # As all folders are merged into one during download, there should only be 1 folder
         if not valid_dirs or len(valid_dirs) >= 2:
             # If all samples were valid during download and download_clean is used, the original folder might have been deleted
             self.log.warning(
-                "Couldnt find %s folder in remote sftp. Creating new one", key
+                "Couldnt find %s folder in remote sftp. Creating new one", main_folder
             )
-            subfolder = getattr(self.download_manager, "subfolder", None)
-            if subfolder:
-                remote_dir = os.path.join(
-                    key, subfolder, self.batch_id + "_invalid_samples"
-                )
-            else:
-                remote_dir = os.path.join(key, self.batch_id + "_invalid_samples")
+            remote_dir = os.path.join(
+                main_folder, self.batch_id + "_invalid_samples"
+            )
             self.download_manager.relecov_sftp.make_dir(remote_dir)
         else:
             remote_dir = valid_dirs[0]
@@ -244,17 +224,15 @@ class ProcessWrapper(BaseModule):
             )
             file_fields = ("sequence_file_R1", "sequence_file_R2")
             valid_sampfiles = [
-                f.get(key) for key in file_fields for f in valid_json_data
+                f.get(v) for v in file_fields for f in valid_json_data
             ]
+            remote_files = self.download_manager.relecov_sftp.get_file_list(remote_dir)
             valid_files = [
-                f for f in finished_folders[remote_dir] if f in valid_sampfiles
+                f for f in remote_files if f in valid_sampfiles
             ]
             self.download_manager.delete_remote_files(remote_dir, files=valid_files)
             self.download_manager.delete_remote_files(remote_dir, skip_seqs=True)
             self.download_manager.clean_remote_folder(remote_dir)
-        subfolder = getattr(self.download_manager, "subfolder", None)
-        if subfolder and subfolder not in remote_dir:
-            remote_dir = os.path.join(key, subfolder)
         if invalid_json:
             logtxt = f"Found {len(invalid_json)} invalid samples in {key}"
             self.wrapper_logsum.add_warning(key=key, entry=logtxt)
@@ -294,6 +272,7 @@ class ProcessWrapper(BaseModule):
         else:
             self.log.info("No invalid samples in %s", key)
             stderr.print(f"[green]No invalid samples were found for {key} !!!")
+            self.download_manager.clean_remote_folder(remote_dir)
         log_filepath = os.path.join(local_folder, str(key) + "_metadata_report.json")
         self.wrapper_logsum.create_error_summary(
             called_module="metadata",

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -647,6 +647,7 @@ class DownloadManager(BaseModule):
                 self.log.info(
                     "Successfully renamed %s to %s" % (remote_folder, new_name)
                 )
+                self.logsum.rename_log_key(remote_folder, new_name)
             except (OSError, PermissionError) as e:
                 log_text = f"Could not rename remote {remote_folder}. Error: {e}"
                 self.log.error(log_text)
@@ -918,7 +919,6 @@ class DownloadManager(BaseModule):
                 continue
             self.current_folder = folder
             # Include the folder in the final process log summary
-            self.include_new_key()
             downloaded_metadata = pre_validate_folder(folder, target_folders[folder])
             if not downloaded_metadata:
                 continue
@@ -1314,6 +1314,7 @@ class DownloadManager(BaseModule):
             self.log.info(f"Finished processing {folder}")
             stderr.print(f"[green]Finished processing {folder}")
             self.finished_folders[folder] = list(files_md5_dict.keys())
+            self.finished_folders[folder].append(meta_file)
         return
 
     def include_new_key(self, sample=None):

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -252,9 +252,8 @@ class DownloadManager(BaseModule):
         samples_to_delete = []
         lab_code = local_folder.split("/")[-2]
         # TODO: Move these prefixes to configuration.json
-        file_tag = self.batch_id + "_" + self.hex
-        new_meta_file = "lab_metadata_" + lab_code + "_" + file_tag + ".xlsx"
-        sample_data_file = "samples_data_" + lab_code + "_" + file_tag + ".json"
+        new_meta_file = self.tag_filename("lab_metadata_" + lab_code + ".xlsx")
+        sample_data_file = self.tag_filename("samples_data_" + lab_code + ".json")
         sample_data_path = os.path.join(local_folder, sample_data_file)
         os.rename(metadata_file, os.path.join(local_folder, new_meta_file))
         error_text = "Sample %s incomplete. Not added to final Json"
@@ -268,12 +267,12 @@ class DownloadManager(BaseModule):
             # TODO: Move these keys to configuration.json
             values["sequence_file_path_R1"] = local_folder
             values["sequence_file_R1_md5"] = md5_dict.get(values["sequence_file_R1"])
-            values["batch_id"] = self.batch_id
             if values.get("sequence_file_R2"):
                 values["sequence_file_path_R2"] = local_folder
                 values["sequence_file_R2_md5"] = md5_dict.get(
                     values["sequence_file_R2"]
                 )
+            values["batch_id"] = self.batch_id
         if samples_to_delete:
             data = {k: v for k, v in data.items() if k not in samples_to_delete}
         with open(sample_data_path, "w", encoding="utf-8") as fh:
@@ -1295,8 +1294,13 @@ class DownloadManager(BaseModule):
             if self.logsum.logs.get(self.current_folder):
                 self.logsum.logs[self.current_folder].update({"path": local_folder})
                 try:
-                    folder_basename = os.path.basename(local_folder.rstrip("/"))
-                    log_name = folder_basename + "_download_log_summary.json"
+                    log_name = "_".join(
+                        [
+                            "download",
+                            self.current_folder,
+                            self.tag_filename("log_summary.json"),
+                        ]
+                    )
                     self.parent_create_error_summary(
                         filepath=os.path.join(local_folder, log_name),
                         logs={

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -380,8 +380,11 @@ class LogSum:
             old_key (str): Current key name
             new_key (str): New key name
         """
-        if old_key in self.base_logsum.logs.keys():
-            self.logs[new_key] = self.logs.pop(old_key)
+        if old_key in self.logs.keys():
+            if new_key not in self.logs.keys():
+                self.logs[new_key] = self.logs.pop(old_key)
+            else:
+                log.warning(f"Could not rename logsum key {old_key}: {new_key} already in logs")
         else:
             log.warning(f"Could not rename logsum key {old_key}: key not in logs")
         return

--- a/relecov_tools/sftp_client.py
+++ b/relecov_tools/sftp_client.py
@@ -156,11 +156,12 @@ class SftpRelecov:
         return directory_list
 
     @reconnect_if_fail(n_times=3, sleep_time=30)
-    def get_file_list(self, folder_name):
+    def get_file_list(self, folder_name, recursive=False):
         """Return a tuple with file name and directory path from remote
 
         Args:
             folder_name (str): name of folder in remote repository
+            recursive (bool): either to list files recursively through subfolders
 
         Returns:
             file_list (list(str)): list of files in remote folder
@@ -172,7 +173,8 @@ class SftpRelecov:
             for content in content_list:
                 full_path = os.path.join(folder_name, content.filename)
                 if stat.S_ISDIR(content.st_mode):
-                    file_list.extend(self.get_file_list(full_path))
+                    if recursive is True:
+                        file_list.extend(self.get_file_list(full_path))
                 elif stat.S_ISREG(content.st_mode):
                     file_list.append(full_path)
         except FileNotFoundError as e:


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] This PR fixes some errors related to subfolder handling in both wrapper and download modules, specifically related with `download_clean` option, that were causing some files to be left in the remote folder. Closes #556 and Closes #515
- Also fixed the presence of temporal folders due to renaming in `download_log_summary.json`. Closes #495 
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).