### PR TITLE
Set default folder as RELECOV when running wrapper module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Included installation with bioconda in README.md [#549](https://github.com/BU-ISCIII/relecov-tools/pull/549)
 - Added support for additional notes via .txt file or manual input in `send-email` CLI [#548](https://github.com/BU-ISCIII/relecov-tools/pull/548)
 - Restructured and cleaned Jinja templates and ENA templates; moved to assets/mail_templates/ | assets/ena_templates and renamed for clarity [#548](https://github.com/BU-ISCIII/relecov-tools/pull/548)
+- Set default folder as RELECOV when running wrapper module [#562](https://github.com/BU-ISCIII/relecov-tools/pull/562)
 
 #### Fixes
 

--- a/relecov_tools/dataprocess_wrapper.py
+++ b/relecov_tools/dataprocess_wrapper.py
@@ -348,7 +348,7 @@ class ProcessWrapper(BaseModule):
             called_module="wrapper",
             to_excel=True,
         )
-        
+
         # Logging wrapper stats
         labs = {folder.split("/")[0] for folder in finished_folders}
         num_labs = len(labs)

--- a/relecov_tools/dataprocess_wrapper.py
+++ b/relecov_tools/dataprocess_wrapper.py
@@ -50,8 +50,8 @@ class ProcessWrapper(BaseModule):
         self.config_data["download"].update({"output_location": output_folder})
         if self.config_data["download"].get("subfolder") is None:
             self.config_data["download"].update({"subfolder": "RELECOV"}) # If subfolder is not defined or None, it is set automatically as RELECOV
-            self.log.warning("Subfolder is not defined. Setting subfolder as RELECOV by default")
-            stderr.print("[yellow]Subfolder is not defined. Setting subfolder as RELECOV by default")  
+            self.log.warning("Subfolder not provided. Set to as RELECOV by default")
+            stderr.print("[yellow]Subfolder not provided. Set to RELECOV by default")  
         self.download_params = self.clean_module_params(
             "DownloadManager", self.config_data["download"]
         )

--- a/relecov_tools/dataprocess_wrapper.py
+++ b/relecov_tools/dataprocess_wrapper.py
@@ -348,14 +348,15 @@ class ProcessWrapper(BaseModule):
             called_module="wrapper",
             to_excel=True,
         )
-
+        
         # Logging wrapper stats
         labs = {folder.split("/")[0] for folder in finished_folders}
         num_labs = len(labs)
         samples_per_lab = defaultdict(int)
         for folder, files in finished_folders.items():
             lab = folder.split("/")[0]
-            samples_per_lab[lab] += len(files)
+            seq_files = [f for f in files if not f.endswith(".xlsx")]
+            samples_per_lab[lab] += len(seq_files)
         total_count = sum(samples_per_lab.values())
 
         stderr.print("[blue] --------------------")

--- a/relecov_tools/dataprocess_wrapper.py
+++ b/relecov_tools/dataprocess_wrapper.py
@@ -48,6 +48,7 @@ class ProcessWrapper(BaseModule):
             output_location=os.path.join(self.output_folder)
         )
         self.config_data["download"].update({"output_location": output_folder})
+        self.config_data["download"].setdefault("subfolder", "RELECOV") # Set default subfolder as RELECOV. If neccesary, it can be overwritten with 'subfolder' parameter in config_file.yaml
         self.download_params = self.clean_module_params(
             "DownloadManager", self.config_data["download"]
         )

--- a/relecov_tools/dataprocess_wrapper.py
+++ b/relecov_tools/dataprocess_wrapper.py
@@ -48,7 +48,9 @@ class ProcessWrapper(BaseModule):
             output_location=os.path.join(self.output_folder)
         )
         self.config_data["download"].update({"output_location": output_folder})
-        self.config_data["download"].setdefault("subfolder", "RELECOV") # Set default subfolder as RELECOV. If neccesary, it can be overwritten with 'subfolder' parameter in config_file.yaml
+        self.config_data["download"].setdefault(
+            "subfolder", "RELECOV"
+        )  # Set default subfolder as RELECOV. If neccesary, it can be overwritten with 'subfolder' parameter in config_file.yaml
         self.download_params = self.clean_module_params(
             "DownloadManager", self.config_data["download"]
         )

--- a/relecov_tools/dataprocess_wrapper.py
+++ b/relecov_tools/dataprocess_wrapper.py
@@ -48,7 +48,7 @@ class ProcessWrapper(BaseModule):
             output_location=os.path.join(self.output_folder)
         )
         self.config_data["download"].update({"output_location": output_folder})
-        if self.config_data["download"].get("subfolder") is None:
+        if "subfolder" not in self.config_data["download"]:
             self.config_data["download"].update(
                 {"subfolder": "RELECOV"}
             )  # If subfolder is not defined or None, it is set automatically as RELECOV

--- a/relecov_tools/dataprocess_wrapper.py
+++ b/relecov_tools/dataprocess_wrapper.py
@@ -48,9 +48,10 @@ class ProcessWrapper(BaseModule):
             output_location=os.path.join(self.output_folder)
         )
         self.config_data["download"].update({"output_location": output_folder})
-        self.config_data["download"].setdefault(
-            "subfolder", "RELECOV"
-        )  # Set default subfolder as RELECOV. If neccesary, it can be overwritten with 'subfolder' parameter in config_file.yaml
+        if self.config_data["download"].get("subfolder") is None:
+            self.config_data["download"].update({"subfolder": "RELECOV"}) # If subfolder is not defined or None, it is set automatically as RELECOV
+            self.log.warning("Subfolder is not defined. Setting subfolder as RELECOV by default")
+            stderr.print("[yellow]Subfolder is not defined. Setting subfolder as RELECOV by default")  
         self.download_params = self.clean_module_params(
             "DownloadManager", self.config_data["download"]
         )

--- a/relecov_tools/dataprocess_wrapper.py
+++ b/relecov_tools/dataprocess_wrapper.py
@@ -49,9 +49,11 @@ class ProcessWrapper(BaseModule):
         )
         self.config_data["download"].update({"output_location": output_folder})
         if self.config_data["download"].get("subfolder") is None:
-            self.config_data["download"].update({"subfolder": "RELECOV"}) # If subfolder is not defined or None, it is set automatically as RELECOV
+            self.config_data["download"].update(
+                {"subfolder": "RELECOV"}
+            )  # If subfolder is not defined or None, it is set automatically as RELECOV
             self.log.warning("Subfolder not provided. Set to as RELECOV by default")
-            stderr.print("[yellow]Subfolder not provided. Set to RELECOV by default")  
+            stderr.print("[yellow]Subfolder not provided. Set to RELECOV by default")
         self.download_params = self.clean_module_params(
             "DownloadManager", self.config_data["download"]
         )

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -934,7 +934,10 @@ class DownloadManager(BaseModule):
             # Taking the main folder for each lab as reference for merge and logs
             main_folder = folder.split("/")[0]
             self.current_folder = main_folder
-            tmp_folder_parent = os.path.join(main_folder, self.subfolder)
+            if self.subfolder is not None:
+                tmp_folder_parent = os.path.join(main_folder, self.subfolder)
+            else:
+                tmp_folder_parent = main_folder
             temporal_foldername = f"{date_and_time}_tmp_processing"
             temp_folder = os.path.join(tmp_folder_parent, temporal_foldername)
             # Get every file except the excel ones as they are going to be merged


### PR DESCRIPTION
RELECOV has been set as the default subfolder. In this way we avoid that this variable could be left empty and, therefore, we avoid associated troubles during the download.

Closes #508 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).