### PR TITLE
Truncated Sample-Level error messages in global report and terminal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Made --template_path optional in send-email and upload-results commands, using fallback to config key delivery_template_path_file [#548](https://github.com/BU-ISCIII/relecov-tools/pull/548)
 - The configuration necessary to use the mail module is incorporated as an extra-config. [#548](https://github.com/BU-ISCIII/relecov-tools/pull/548)- Add support for qc_failed logic in viralrecon.py and update PR template [#559](https://github.com/BU-ISCIII/relecov-tools/pull/559)
 - Better handling if new_key already exists in log_summary.py-rename_log_key(). [#561](https://github.com/BU-ISCIII/relecov-tools/pull/561)
+- Truncated excessively long error and warning messages in the validation summary output. This affects only the summary section; full messages are still stored in individual sample logs. ([#568](https://github.com/BU-ISCIII/relecov-tools/pull/568))
 
 #### Removed
 

--- a/relecov_tools/json_validation.py
+++ b/relecov_tools/json_validation.py
@@ -267,6 +267,7 @@ class SchemaValidation(BaseModule):
         stderr.print("[blue] VALIDATION SUMMARY")
         stderr.print("[blue] --------------------")
         self.log.info("Validation summary:")
+        max_length = 250
         for error_type, count in errors.items():
             field_with_error = error_keys[error_type]
             if (
@@ -275,8 +276,9 @@ class SchemaValidation(BaseModule):
                 error_text = f"{count} samples failed validation for {field_with_error}:\n{error_type.split()[0]} is not a valid date format. Valid format 'YYYY-MM-DD"
             else:
                 error_text = f"{count} samples failed validation for {field_with_error}:\n{error_type}"
-            self.logsum.add_warning(entry=error_text)
-            stderr.print(f"[red]{error_text}")
+            truncated_msg = error_text[:max_length] + "..." if len(error_text) > max_length else error_text
+            self.logsum.add_warning(entry=truncated_msg)
+            stderr.print(f"[red]{truncated_msg}")
             stderr.print("[red] --------------------")
 
         return validated_json_data, invalid_json

--- a/relecov_tools/json_validation.py
+++ b/relecov_tools/json_validation.py
@@ -276,7 +276,11 @@ class SchemaValidation(BaseModule):
                 error_text = f"{count} samples failed validation for {field_with_error}:\n{error_type.split()[0]} is not a valid date format. Valid format 'YYYY-MM-DD"
             else:
                 error_text = f"{count} samples failed validation for {field_with_error}:\n{error_type}"
-            truncated_msg = error_text[:max_length] + "..." if len(error_text) > max_length else error_text
+            truncated_msg = (
+                error_text[:max_length] + "..."
+                if len(error_text) > max_length
+                else error_text
+            )
             self.logsum.add_warning(entry=truncated_msg)
             stderr.print(f"[red]{truncated_msg}")
             stderr.print("[red] --------------------")

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -276,9 +276,9 @@ class LogSum:
                 regex = (
                     r"\[.*?\]"  # Regex to remove ontology annotations between brackets
                 )
-                
+
                 for sample, slog in samples_logs.items():
-                    clean_errors= []
+                    clean_errors = []
                     for x in slog["errors"]:
                         err_str = reg_remover(str(x), regex)
                         if len(err_str) > max_lenght:
@@ -291,21 +291,20 @@ class LogSum:
                         "\n".join(clean_errors),
                     ]
                     workbook["Samples Report"].append(error_row)
-                    
-                    clean_warngs= []
+
+                    clean_warngs = []
                     for x in slog["warnings"]:
                         war_str = reg_remover(str(x), regex)
                         if len(war_str) > max_lenght:
-                            war_str= war_str[:max_lenght] + "..."
+                            war_str = war_str[:max_lenght] + "..."
                         clean_warngs.append(war_str)
                     warning_row = [
                         str(key),
                         sample,
                         str(slog["valid"]),
-                        "\n ".join(clean_warngs)
+                        "\n ".join(clean_warngs),
                     ]
                     workbook["Other warnings"].append(warning_row)
-                        
 
             # Adjusting the size of the columns in the excel file
             for name in sheet_names_and_headers.keys():

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -276,23 +276,36 @@ class LogSum:
                 regex = (
                     r"\[.*?\]"  # Regex to remove ontology annotations between brackets
                 )
+                
                 for sample, slog in samples_logs.items():
-                    clean_errors = [reg_remover(x, regex) for x in slog["errors"]]
+                    clean_errors= []
+                    for x in slog["errors"]:
+                        err_str = reg_remover(str(x), regex)
+                        if len(err_str) > max_lenght:
+                            err_str = err_str[:max_lenght] + "..."
+                        clean_errors.append(err_str)
                     error_row = [
                         str(key),
                         sample,
                         str(slog["valid"]),
-                        "\n ".join(clean_errors),
+                        "\n".join(clean_errors),
                     ]
                     workbook["Samples Report"].append(error_row)
-                    clean_warngs = [reg_remover(x, regex) for x in slog["warnings"]]
+                    
+                    clean_warngs= []
+                    for x in slog["warnings"]:
+                        war_str = reg_remover(str(x), regex)
+                        if len(war_str) > max_lenght:
+                            war_str= war_str[:max_lenght] + "..."
+                        clean_warngs.append(war_str)
                     warning_row = [
                         str(key),
                         sample,
                         str(slog["valid"]),
-                        "\n ".join(clean_warngs),
+                        "\n ".join(clean_warngs)
                     ]
                     workbook["Other warnings"].append(warning_row)
+                        
 
             # Adjusting the size of the columns in the excel file
             for name in sheet_names_and_headers.keys():

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -71,6 +71,8 @@ class LogSum:
         if self.unique_key:
             key = self.unique_key
         log.error(entry)
+        truncated_entry = (entry[:250] + "...") if len(entry) > 250 else entry
+        stderr.print(f"[bold red]ERROR:[/] {truncated_entry}")
         self.update_summary(
             log_type="errors", key=key, entry=entry, sample=sample, path=path
         )
@@ -81,6 +83,8 @@ class LogSum:
         if self.unique_key:
             key = self.unique_key
         log.warning(entry)
+        truncated_entry = (entry[:250] + "...") if len(entry) > 250 else entry
+        stderr.print(f"[bold yellow]WARNING:[/] {truncated_entry}")
         self.update_summary(
             log_type="warnings", key=key, entry=entry, sample=sample, path=path
         )

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -71,8 +71,6 @@ class LogSum:
         if self.unique_key:
             key = self.unique_key
         log.error(entry)
-        truncated_entry = (entry[:250] + "...") if len(entry) > 250 else entry
-        stderr.print(f"[bold red]ERROR:[/] {truncated_entry}")
         self.update_summary(
             log_type="errors", key=key, entry=entry, sample=sample, path=path
         )
@@ -83,8 +81,6 @@ class LogSum:
         if self.unique_key:
             key = self.unique_key
         log.warning(entry)
-        truncated_entry = (entry[:250] + "...") if len(entry) > 250 else entry
-        stderr.print(f"[bold yellow]WARNING:[/] {truncated_entry}")
         self.update_summary(
             log_type="warnings", key=key, entry=entry, sample=sample, path=path
         )


### PR DESCRIPTION
### Changes: 

- Applied truncation to error and warning messages longer than 250 characters in the `validate_instances` method.
- Ensured both `stderr.print` output and entries added via `logsum.add_warning` are properly truncated to prevent overflow in terminal reports and emails.
- Preserved full error context in individual sample logs (i.e., `logsum.add_error`) while keeping the summary concise
----
Closes(https://github.com/BU-ISCIII/relecov-tools/issues/517)
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).