### PR TITLE
Hotfix for folder specific download log_summary filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ Code contributions to the release:
 - Fix *fastq properties in pipeline_manager.py [#509](https://github.com/BU-ISCIII/relecov-tools/pull/509)
 - Fixed overriding and wrong configuration in read-lab-metadata for submitting institution [#521](https://github.com/BU-ISCIII/relecov-tools/pull/521)
 - Fixed unused keys in initial_config.yaml [#522](https://github.com/BU-ISCIII/relecov-tools/pull/522)
+- Hotfix for folder specific download log_summary filename [#571](https://github.com/BU-ISCIII/relecov-tools/pull/571)
 
 #### Changed
 

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -1301,12 +1301,9 @@ class DownloadManager(BaseModule):
             if self.logsum.logs.get(self.current_folder):
                 self.logsum.logs[self.current_folder].update({"path": local_folder})
                 try:
-                    log_name = "_".join(
-                        [
-                            "download",
-                            self.current_folder,
-                            self.tag_filename("log_summary.json"),
-                        ]
+                    log_name = (
+                        self.tag_filename("download_" + self.current_folder)
+                        + "_log_summary.json"
                     )
                     self.parent_create_error_summary(
                         filepath=os.path.join(local_folder, log_name),


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR checklist

- [X] Folder-specific Log summary for download `download_FOLDERNAME_log_summary.json` was generated with a wrong name as the "log_summary" tag was not at the end of the filename. This PR fixes it
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).