### PR TITLE
Fix return values and configuration handling in `upload-results` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed anatomical material collection config file to match new enums in json_Schema [#567](https://github.com/BU-ISCIII/relecov-tools/pull/567)
 - Fix handling of "Not Provided" in configuration.json [#570](https://github.com/BU-ISCIII/relecov-tools/pull/570)
 - Hotfix for folder specific download log_summary filename [#571](https://github.com/BU-ISCIII/relecov-tools/pull/571)
+- Fix return values and configuration handling in upload-results module [#573](https://github.com/BU-ISCIII/relecov-tools/pull/573)
 
 #### Changed
 

--- a/relecov_tools/upload_results.py
+++ b/relecov_tools/upload_results.py
@@ -35,7 +35,7 @@ class UploadSftp(BaseModule):
         if not batch_id:
             raise ValueError("Error: You must provide a batch_id as an argument.")
         self.set_batch_id(batch_id)
-        config_json = ConfigJson()
+        config_json = ConfigJson(extra_config=True)
         config = config_json.get_configuration("mail_sender")
         sftp_config = config_json.get_configuration("sftp_handle")
         self.allowed_file_ext = config_json.get_topic_data(
@@ -97,6 +97,8 @@ class UploadSftp(BaseModule):
             raise FileNotFoundError(
                 f"Batch {self.batch_id} was not found in any COD* folder."
             )
+
+        return matching_cod
 
     def compress_results(self, batch_data, cod):
         """Compress the analysis_results folder with a random password"""


### PR DESCRIPTION
<!--
# bu-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
##  PR Description
This PR fixes the return behavior of the upload-results module and updates the configuration loading mechanism to ensure proper handling of mail and SFTP configurations.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).