### PR TITLE
Hotfix for level and cli-logpath outdir in BaseModule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Credits
 
 - [Alejandro Bernabeu](https://github.com/aberdur)
+- [Pablo Mata](https://github.com/shettland)
 
 #### Added enhancements
 
 #### Fixes
+
+- Fixed level being set by default to debug instead of level provided in CLI [#584](https://github.com/BU-ISCIII/relecov-tools/pull/584)
+- Fixed wrong output dir when --log-path was set via CLI in BaseModule [#584](https://github.com/BU-ISCIII/relecov-tools/pull/584)
 
 #### Changed
 

--- a/relecov_tools/base_module.py
+++ b/relecov_tools/base_module.py
@@ -69,9 +69,10 @@ class BaseModule:
             self.log.addHandler(handler)
         else:
             # First time this class is initialized, set root handler and move cli-log-file
+            log_level = self.log.root.getEffectiveLevel()
             if not self.log.handlers:
                 handler = BaseModule.set_log_handler(
-                    self.final_log_path, level=logging.DEBUG
+                    self.final_log_path, level=log_level
                 )
                 self.log.addHandler(handler)
             self.redirect_logs(
@@ -138,8 +139,7 @@ class BaseModule:
                 "--log-path activated via CLI. Logs output folder wont change"
             )
             new_log_path = os.path.join(
-                os.path.dirname(BaseModule._cli_log_path_param),
-                os.path.basename(new_log_path),
+                BaseModule._cli_log_path_param, os.path.basename(new_log_path)
             )
         try:
             # Only copy file content, not permissions nor metadata


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR Checklist

- [X] Fixed level being set by default to debug instead of level provided in CLI. Fixed wrong output dir when --log-path was set via CLI in BaseModule. Closes #583 
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).