### PR TITLE
Included hex code in output filenames from bioinfo pipeline_utils scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Added enhancements
 
+- Included hex code in output filenames pipeline-utils scripts [#591](https://github.com/BU-ISCIII/relecov-tools/pull/591)
+- Included hex code in pipeline-manager merged json filename [#591](https://github.com/BU-ISCIII/relecov-tools/pull/591)
+
 #### Fixes
 
 - Fixed level being set by default to debug instead of level provided in CLI [#584](https://github.com/BU-ISCIII/relecov-tools/pull/584)

--- a/relecov_tools/assets/pipeline_utils/irma.py
+++ b/relecov_tools/assets/pipeline_utils/irma.py
@@ -154,9 +154,9 @@ class LongTableParse:
             j_list.append(j_dict)
         return j_list
 
-    def save_to_file(self, j_list, batch_date):
+    def save_to_file(self, j_list, file_tag):
         """Transform the parsed data into a json file"""
-        file_name = "long_table_" + batch_date + ".json"
+        file_name = "long_table_" + file_tag + ".json"
         file_path = os.path.join(self.output_directory, file_name)
         if os.path.exists(file_path):
             stderr.print(
@@ -218,7 +218,7 @@ class LongTableParse:
 # START util functions
 
 
-def parse_long_table(files_list, batch_date, output_folder=None):
+def parse_long_table(files_list, file_tag, output_folder=None):
     """File handler to retrieve data from long table files and convert it into a JSON structured format.
     This function utilizes the LongTableParse class to parse the long table data.
     Since this utility handles and maps data using a custom way, it returns None to be avoid being  transferred to method read_bioinfo_metadata.BioinfoMetadata.mapping_over_table().
@@ -247,7 +247,7 @@ def parse_long_table(files_list, batch_date, output_folder=None):
         # Parsing long table data and saving it
         long_table_data = long_table.parsing_csv()
         # Saving long table data into a file
-        long_table.save_to_file(long_table_data, batch_date)
+        long_table.save_to_file(long_table_data, file_tag)
         stderr.print("[green]\tProcess completed")
     elif len(files_list) > 1:
         method_log_report.update_log_report(
@@ -259,7 +259,7 @@ def parse_long_table(files_list, batch_date, output_folder=None):
     return None
 
 
-def handle_consensus_fasta(files_list, batch_date, output_folder=None):
+def handle_consensus_fasta(files_list, file_tag, output_folder=None):
     """File handler to parse consensus data (fasta) into JSON structured format.
 
     Args:
@@ -330,7 +330,7 @@ def quality_control_evaluation(data):
     return data
 
 
-def get_software_versions(files_list, batch_date, output_folder=None):
+def get_software_versions(files_list, file_tag, output_folder=None):
     """File handler to parse software versions from csv.
 
     Args:

--- a/relecov_tools/assets/pipeline_utils/viralrecon.py
+++ b/relecov_tools/assets/pipeline_utils/viralrecon.py
@@ -153,9 +153,9 @@ class LongTableParse:
             j_list.append(j_dict)
         return j_list
 
-    def save_to_file(self, j_list, batch_date):
+    def save_to_file(self, j_list, file_tag):
         """Transform the parsed data into a json file"""
-        file_name = "long_table_" + batch_date + ".json"
+        file_name = "long_table_" + file_tag + ".json"
         file_path = os.path.join(self.output_directory, file_name)
         if os.path.exists(file_path):
             stderr.print(
@@ -217,7 +217,7 @@ class LongTableParse:
 
 
 # START util functions
-def handle_pangolin_data(files_list, batch_date, output_folder=None):
+def handle_pangolin_data(files_list, file_tag, output_folder=None):
     """File handler to parse pangolin data (csv) into JSON structured format.
 
     Args:
@@ -267,7 +267,7 @@ def handle_pangolin_data(files_list, batch_date, output_folder=None):
     return pango_data_processed
 
 
-def parse_long_table(files_list, batch_date, output_folder=None):
+def parse_long_table(files_list, file_tag, output_folder=None):
     """File handler to retrieve data from long table files and convert it into a JSON structured format.
     This function utilizes the LongTableParse class to parse the long table data.
     Since this utility handles and maps data using a custom way, it returns None to be avoid being  transferred to method read_bioinfo_metadata.BioinfoMetadata.mapping_over_table().
@@ -296,7 +296,7 @@ def parse_long_table(files_list, batch_date, output_folder=None):
         # Parsing long table data and saving it
         long_table_data = long_table.parsing_csv()
         # Saving long table data into a file
-        long_table.save_to_file(long_table_data, batch_date)
+        long_table.save_to_file(long_table_data, file_tag)
         stderr.print("[green]\tProcess completed")
         log.info("Long table process completed")
     elif len(files_list) > 1:
@@ -309,7 +309,7 @@ def parse_long_table(files_list, batch_date, output_folder=None):
     return None
 
 
-def handle_consensus_fasta(files_list, batch_date, output_folder=None):
+def handle_consensus_fasta(files_list, file_tag, output_folder=None):
     """File handler to parse consensus data (fasta) into JSON structured format.
 
     Args:

--- a/relecov_tools/pipeline_manager.py
+++ b/relecov_tools/pipeline_manager.py
@@ -535,8 +535,9 @@ class PipelineManager(BaseModule):
             relecov_tools.utils.write_json_to_file(fields, group_info)
             self.log.info(f"Group fields info saved in {group_info}")
 
+            output_filename = self.tag_filename(f"{group_tag}_validate_batch.json")
             json_filename = os.path.join(
-                group_doc_folder, f"{group_tag}_validate_batch.json"
+                group_doc_folder, output_filename
             )
             relecov_tools.utils.write_json_to_file(final_valid_samples, json_filename)
             self.log.info("Successfully created pipeline folder. Ready to launch")

--- a/relecov_tools/pipeline_manager.py
+++ b/relecov_tools/pipeline_manager.py
@@ -536,9 +536,7 @@ class PipelineManager(BaseModule):
             self.log.info(f"Group fields info saved in {group_info}")
 
             output_filename = self.tag_filename(f"{group_tag}_validate_batch.json")
-            json_filename = os.path.join(
-                group_doc_folder, output_filename
-            )
+            json_filename = os.path.join(group_doc_folder, output_filename)
             relecov_tools.utils.write_json_to_file(final_valid_samples, json_filename)
             self.log.info("Successfully created pipeline folder. Ready to launch")
             stderr.print(f"[blue]Folder {group_outfolder} finished. Ready to launch")

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -528,7 +528,7 @@ class BioinfoMetadata(BaseModule):
         Args:
             file_list (list): A list of file path/s to be processed.
             output_folder (str): Path to save output files from imported method if necessary
-            file_tag(str): Number of the batch which corresponds with the data download date.
+            file_tag(str): Tag that will be used for output filenames includes batch date (same as download date) and hex.
 
         Returns:
             data: A dictionary containing bioinfo metadata handled for each sample.
@@ -1021,7 +1021,7 @@ class BioinfoMetadata(BaseModule):
 
         Args:
             files_dict (dict): A dictionary containing file paths identified for each configuration item.
-            file_tag (str): Tag to be used in the output file name, should include batch date and hex.
+            file_tag (str): Tag that will be used for output filenames includes batch date (same as download date) and hex.
             output_folder (str): Path to save output files generated during processing.
 
         Returns:

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -1098,7 +1098,9 @@ class BioinfoMetadata(BaseModule):
         for batch_dir, batch_dict in data_by_batch.items():
             batch_data = batch_dict["j_data"]
             if not batch_data:
-                self.log.warning(f"Data from batch {batch_dir} was completely empty. Skipped.")
+                self.log.warning(
+                    f"Data from batch {batch_dir} was completely empty. Skipped."
+                )
                 self.update_all_logs(
                     self.create_bioinfo_file.__name__,
                     "warning",


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR Checklist

- [X] As per the title, this PR includes the hexcode in the filenames generated by the auxiliar scripts for each pipeline in read-bioinfo-metadata and also in pipeline-manager. Closes #589 and Closes #590 
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).