### PR TITLE
fixed parsing of multic software versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed level being set by default to debug instead of level provided in CLI [#584](https://github.com/BU-ISCIII/relecov-tools/pull/584)
 - Fixed wrong output dir when --log-path was set via CLI in BaseModule [#584](https://github.com/BU-ISCIII/relecov-tools/pull/584)
 - Add irma config and fixed read bioinfo metadata [#578](https://github.com/BU-ISCIII/relecov-tools/pull/578)
+- Fixed multiqc software versions with new pattern [#593](https://github.com/BU-ISCIII/relecov-tools/pull/593)
 
 #### Changed
 

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -621,33 +621,35 @@ class BioinfoMetadata(BaseModule):
         div_id = re.compile(
             r"mqc-module-section-(software_versions|multiqc_software_versions)"
         )
-        versions_div = soup.find("div", id=div_id)
+        versions_div = soup.find_all("div", id=div_id)
+        program_versions = {}
         if versions_div:
-            table = versions_div.find("table", class_="table")
-            if table:
-                rows = table.find_all("tr")
-                for row in rows[1:]:  # skipping header
-                    columns = row.find_all("td")
-                    if len(columns) == 3:
-                        program_name = columns[1].text.strip()
-                        version = columns[2].text.strip()
-                        program_versions[program_name] = version
-                    else:
-                        self.update_all_logs(
-                            method_name,
-                            "error",
-                            f"HTML entry error in {columns}. HTML table expected format should be \n<th> Process Name\n</th>\n<th> Software </th>\n.",
-                        )
-                        sys.exit(
-                            self.log_report.print_log_report(method_name, ["error"])
-                        )
-            else:
-                self.update_all_logs(
-                    method_name,
-                    "error",
-                    f"Unable to locate the table containing software versions in file {f_path} under div section {div_id}.",
-                )
-                sys.exit(self.log_report.print_log_report(method_name, ["error"]))
+            for div in versions_div:
+                table = div.find("table", class_="table")
+                if table:
+                    rows = table.find_all("tr")
+                    for row in rows[1:]:  # skipping header
+                        columns = row.find_all("td")
+                        if len(columns) == 3:
+                            program_name = columns[1].text.strip()
+                            version = columns[2].text.strip()
+                            program_versions[program_name] = version
+                        else:
+                            self.update_all_logs(
+                                method_name,
+                                "error",
+                                f"HTML entry error in {columns}. HTML table expected format should be \n<th> Process Name\n</th>\n<th> Software </th>\n.",
+                            )
+                            sys.exit(
+                                self.log_report.print_log_report(method_name, ["error"])
+                            )
+                else:
+                    self.update_all_logs(
+                        method_name,
+                        "error",
+                        f"Unable to locate the table containing software versions in file {f_path} under div section {div_id}.",
+                    )
+                    sys.exit(self.log_report.print_log_report(method_name, ["error"]))
         else:
             self.update_all_logs(
                 self.get_multiqc_software_versions.__name__,


### PR DESCRIPTION
in #578 a new regex for div was added to make it work with taxprofiler. in viralrecon wasn't working propperly depending on the multiqc.html file.

Fixed this by adding a soup.find_all and another iteration

## PR Checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).