### PR TITLE
Hotfix for update-db module in config urls and json_file call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.X.X] - 2025-XX-XX : https://github.com/BU-ISCIII/relecov-tools/releases/tag/v.X.X.X
+## [1.5.4dev] - 2025-XX-XX : https://github.com/BU-ISCIII/relecov-tools/releases/tag/v.X.X.X
 
 ### Credits
+
+- [Pablo Mata](https://github.com/shettland)
 
 #### Added enhancements
 
 #### Fixes
+
+- Fixed self.json_file call before it was set in update-db [#598](https://github.com/BU-ISCIII/relecov-tools/pull/598)
+- Included missing http in server_url from configuration.json [#598](https://github.com/BU-ISCIII/relecov-tools/pull/598)
 
 #### Changed
 

--- a/relecov_tools/conf/configuration.json
+++ b/relecov_tools/conf/configuration.json
@@ -281,7 +281,7 @@
     "upload_database": {
         "platform":{
             "iskylims": {
-                "server_url": "relecov-iskylims.isciiides.es",
+                "server_url": "http://relecov-iskylims.isciiides.es",
                 "api_url": "/wetlab/api/",
                 "store_samples": "create-sample",
                 "url_project_fields": "projects-fields",
@@ -291,7 +291,7 @@
                 "token": ""
             },
             "relecov": {
-            "server_url": "relecov-platform.isciiides.es",
+            "server_url": "http://relecov-platform.isciiides.es",
             "api_url": "/api/",
             "store_samples": "createSampleData",
             "bioinfodata": "createBioinfoData",

--- a/relecov_tools/upload_database.py
+++ b/relecov_tools/upload_database.py
@@ -35,7 +35,7 @@ class UpdateDatabase(BaseModule):
             json_file = relecov_tools.utils.prompt_path(
                 msg="Select the json file which have the data to map"
             )
-        json_dir = os.path.dirname(os.path.realpath(self.json_file))
+        json_dir = os.path.dirname(os.path.realpath(json_file))
         super().__init__(output_directory=json_dir, called_module="update-db")
         # Get the user and password for the database
         if user is None:


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR Checklist

- [X] This PR fixes two small bugs related with update-db. First, `self.json_file` was called before it was set, leading to a crash, and second, the urls in configuration.json were lacking `http://` prefix
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).