### PR TITLE
Clean up legacy fallback logic in upload_database mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Credits
 
 - [Pablo Mata](https://github.com/shettland)
+- [Sergio Olmos](https://github.com/OPSergio)
 
 #### Added enhancements
 
@@ -21,6 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 #### Changed
 
 #### Removed
+
+- Removed hardcoded `sample_entry_date` and legacy fallback logic from `upload_database` mapping. [#610](https://github.com/BU-ISCIII/relecov-tools/pull/610)
+
 
 ### Requirements
 

--- a/relecov_tools/upload_database.py
+++ b/relecov_tools/upload_database.py
@@ -139,21 +139,7 @@ class UpdateDatabase(BaseModule):
             )
             for prop, val in fixed_value.items():
                 s_dict[prop] = val
-            # Adding tha specimen_source field to set sample_type
-            try:
-                s_dict["sample_type"] = row["specimen_source"]
-            except KeyError as e:
-                logtxt = f"Unable to fetch specimen_source from json file {e}"
-                self.logsum.add_warning(entry=logtxt)
-                s_dict["sample_type"] = "Other"
             sample_list.append(s_dict)
-            # if sample_entry_date is not set then, add the current date
-            if "sample_entry_date" not in row:
-                logtxt = "sample_entry_date is not in the sample fields"
-                self.logsum.add_warning(entry=logtxt)
-                stderr.print(f"[yellow]{logtxt}")
-                s_dict["sample_entry_date"] = time.strftime("%Y-%m-%d")
-
         return sample_list
 
     def get_iskylims_fields_sample(self):


### PR DESCRIPTION
### Description

This PR cleans up legacy logic in the `upload_database` module by removing the hardcoded fallback for `sample_entry_date` and the default assignment of `sample_type` when `specimen_source` is missing. These fields are now handled via proper ontology mapping or fixed configuration values. This improves consistency and prevents incorrect or redundant data from being sent to iSkyLIMS.

<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR Checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).