### PR TITLE
Added zip file removal step in upload_results module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Added enhancements
 
+- Added zip file removal step in upload_results module [#613](https://github.com/BU-ISCIII/relecov-tools/pull/613)
+
 #### Fixes
 
 - Restricting filehandler search to basemodule outdir to fix logfiles with temp_id in its name [#607](https://github.com/BU-ISCIII/relecov-tools/pull/607)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Pablo Mata](https://github.com/shettland)
 - [Sergio Olmos](https://github.com/OPSergio)
+- [Jaime Ozáez](https://github.com/jaimeozaez)
 
 #### Added enhancements
 

--- a/relecov_tools/upload_results.py
+++ b/relecov_tools/upload_results.py
@@ -188,11 +188,19 @@ class UploadSftp(BaseModule):
                 self.log.warning(f"Tried to delete {zip_path}, but it does not exist")
                 stderr.print(f"[red]Tried to delete {zip_path}, but it does not exist")
             except PermissionError as e:
-                self.log.error(f"Permission denied when trying to delete {zip_path}: {e}")
-                stderr.print(f"[red]Permission denied when trying to delete {zip_path}: {e}")
+                self.log.error(
+                    f"Permission denied when trying to delete {zip_path}: {e}"
+                )
+                stderr.print(
+                    f"[red]Permission denied when trying to delete {zip_path}: {e}"
+                )
             except Exception as e:
-                self.log.error(f"Unexpected error when trying to delete {zip_path}: {e}")
-                stderr.print(f"[red]Unexpected error when trying to delete {zip_path}: {e}")
+                self.log.error(
+                    f"Unexpected error when trying to delete {zip_path}: {e}"
+                )
+                stderr.print(
+                    f"[red]Unexpected error when trying to delete {zip_path}: {e}"
+                )
             self.relecov_sftp.close_connection()
 
     def notify_lab(

--- a/relecov_tools/upload_results.py
+++ b/relecov_tools/upload_results.py
@@ -97,7 +97,6 @@ class UploadSftp(BaseModule):
             raise FileNotFoundError(
                 f"Batch {self.batch_id} was not found in any COD* folder."
             )
-
         return matching_cod
 
     def compress_results(self, batch_data, cod):
@@ -182,6 +181,7 @@ class UploadSftp(BaseModule):
             return False
 
         finally:
+            os.remove(zip_path)
             self.relecov_sftp.close_connection()
 
     def notify_lab(

--- a/relecov_tools/upload_results.py
+++ b/relecov_tools/upload_results.py
@@ -181,7 +181,18 @@ class UploadSftp(BaseModule):
             return False
 
         finally:
-            os.remove(zip_path)
+            try:
+                os.remove(zip_path)
+                self.log.info(f"Deleted local file {zip_path}")
+            except FileNotFoundError:
+                self.log.warning(f"Tried to delete {zip_path}, but it does not exist")
+                stderr.print(f"[red]Tried to delete {zip_path}, but it does not exist")
+            except PermissionError as e:
+                self.log.error(f"Permission denied when trying to delete {zip_path}: {e}")
+                stderr.print(f"[red]Permission denied when trying to delete {zip_path}: {e}")
+            except Exception as e:
+                self.log.error(f"Unexpected error when trying to delete {zip_path}: {e}")
+                stderr.print(f"[red]Unexpected error when trying to delete {zip_path}: {e}")
             self.relecov_sftp.close_connection()
 
     def notify_lab(


### PR DESCRIPTION
After compressing the analysis_results folder and uploading it back to the sftp, the compressed file located in the local folder is now removed.

Closes #608 

## PR Checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).