### PR TITLE
Now log_summary can merge logs with multiple keys, not for only provided lab-code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Included missing http in server_url from configuration.json [#598](https://github.com/BU-ISCIII/relecov-tools/pull/598)
 - Enhance Sample Presence Validation for read-bioinfo-metadata Processing [#599](https://github.com/BU-ISCIII/relecov-tools/pull/598)
 - Update relecov schema/template to v3.0.9 [#599](https://github.com/BU-ISCIII/relecov-tools/pull/598)
+- Now all keys in log_summary files can be merged. Not only for a given lab-code [#615](https://github.com/BU-ISCIII/relecov-tools/pull/615)
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 #### Added enhancements
 
 - Added zip file removal step in upload_results module [#613](https://github.com/BU-ISCIII/relecov-tools/pull/613)
+- Now all keys in log_summary files can be merged. Not only for a given lab-code [#615](https://github.com/BU-ISCIII/relecov-tools/pull/615)
 
 #### Fixes
 
@@ -50,7 +51,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Included missing http in server_url from configuration.json [#598](https://github.com/BU-ISCIII/relecov-tools/pull/598)
 - Enhance Sample Presence Validation for read-bioinfo-metadata Processing [#599](https://github.com/BU-ISCIII/relecov-tools/pull/598)
 - Update relecov schema/template to v3.0.9 [#599](https://github.com/BU-ISCIII/relecov-tools/pull/598)
-- Now all keys in log_summary files can be merged. Not only for a given lab-code [#615](https://github.com/BU-ISCIII/relecov-tools/pull/615)
 
 #### Changed
 

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -951,8 +951,9 @@ def build_schema(
     "-l",
     "--lab_code",
     type=click.Path(),
-    help="Name for target laboratory in log-summary.json files",
-    required=True,
+    default=None,
+    help="Only merge logs from target laboratory in log-summary.json files",
+    required=False,
 )
 @click.option(
     "-o",
@@ -988,9 +989,10 @@ def logs_to_excel(ctx, lab_code, output_folder, files):
         try:
             with open(file, "r") as f:
                 content = json.load(f)
-                if lab_code not in content:
-                    raise KeyError(f"lab_code '{lab_code}' not found in {file}")
-                all_logs.append(content[lab_code])
+                if lab_code is not None and lab_code not in content:
+                    log.warning(f"lab_code '{lab_code}' not found in {file}")
+                    stderr.print(f"[yellow]lab_code '{lab_code}' not found in {file}")
+                all_logs.append(content)
         except Exception as e:
             stderr.print(f"[red]Couldn't extract data from {file}: {e}")
             log.error(f"Couldn't extract data from {file}: {e}")
@@ -1010,7 +1012,6 @@ def logs_to_excel(ctx, lab_code, output_folder, files):
         logsum.create_logs_excel(logs=final_logs, excel_outpath=excel_outpath)
         json_outpath = output_filepath + ".json"
         relecov_tools.utils.write_json_to_file(final_logs, json_outpath)
-        print(f"[green]Successfully created logs Json in {json_outpath}")
     except Exception as e:
         if debug:
             log.error(f"EXCEPTION FOUND: {e}")

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -150,6 +150,7 @@ class LogSum:
         Returns:
             final_logs (dict): Merged list of logs into a single record
         """
+
         def add_new_logs(current_logs, new_logs):
             """Merge two logs including all its keys"""
             merged_logs = copy.deepcopy(current_logs)


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR Checklist

- [X] This PR includes changes in log_summary so multiple log_summary files can be merged together including all its keys, instead of only the specified one. Making --lab-code no longer mandatory for logs-to-excel module. Closes #612 
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).