### PR TITLE
Improve metadata consistency and error handling across modules

### DIFF
--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -447,10 +447,16 @@ class DownloadManager(BaseModule):
                     stderr.print(f"[red]{str(log_text % s_name)}")
                     self.include_error(entry=str(log_text % s_name), sample=s_name)
                 try:
-                    if "paired" in row[index_layout].lower() and not row[index_fastq_r2]:
+                    if (
+                        "paired" in row[index_layout].lower()
+                        and not row[index_fastq_r2]
+                    ):
                         error_text = "Sample %s is paired-end, but no R2 given"
                         self.include_error(error_text % str(sample_id), s_name)
-                    if "single" in row[index_layout].lower() and not row[index_fastq_r2]:
+                    if (
+                        "single" in row[index_layout].lower()
+                        and not row[index_fastq_r2]
+                    ):
                         error_text = "Sample %s is single-end, but R1 and R2 were given"
                         self.include_error(error_text % str(sample_id), s_name)
                 except AttributeError:

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -446,12 +446,22 @@ class DownloadManager(BaseModule):
                     log_text = "Sequence File R1 not defined in Metadata for sample %s"
                     stderr.print(f"[red]{str(log_text % s_name)}")
                     self.include_error(entry=str(log_text % s_name), sample=s_name)
-                if "paired" in row[index_layout].lower() and not row[index_fastq_r2]:
-                    error_text = "Sample %s is paired-end, but no R2 given"
-                    self.include_error(error_text % str(sample_id), s_name)
-                if "single" in row[index_layout].lower() and not row[index_fastq_r2]:
-                    error_text = "Sample %s is single-end, but R1 and R2 were given"
-                    self.include_error(error_text % str(sample_id), s_name)
+                try:
+                    if "paired" in row[index_layout].lower() and not row[index_fastq_r2]:
+                        error_text = "Sample %s is paired-end, but no R2 given"
+                        self.include_error(error_text % str(sample_id), s_name)
+                    if "single" in row[index_layout].lower() and not row[index_fastq_r2]:
+                        error_text = "Sample %s is single-end, but R1 and R2 were given"
+                        self.include_error(error_text % str(sample_id), s_name)
+                except AttributeError:
+                    error_text = (
+                        f"Missing or invalid 'Library Layout' value for sample {s_name}. "
+                        f"Please check the metadata file and provide a value (single/paired)."
+                    )
+                    self.include_error(error_text, sample=s_name)
+                    stderr.print(f"[red]{error_text}")
+                    raise MetadataError(error_text)
+
                 sample_file_dict[s_name] = {}
                 # TODO: move these keys to configuration.json
                 sample_file_dict[s_name]["sequence_file_R1"] = row[

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -256,7 +256,6 @@ class BioinfoMetadata(BaseModule):
                 for field, value in mapping_fields.items():
                     try:
                         raw_val = map_data[sample_name][value]
-                        # import pdb; pdb.set_trace()
                         raw_val = self.replace_na_value_if_needed(field, raw_val)
                         expected_type = (
                             self.bioinfo_schema["properties"]

--- a/relecov_tools/upload_database.py
+++ b/relecov_tools/upload_database.py
@@ -228,6 +228,16 @@ class UpdateDatabase(BaseModule):
                     s_dict[r_field] = None
             field_values.append(s_dict)
         return field_values
+    
+    def clean_ambiguous_value(self, value):
+        """Replace ambiguous values by default if value is not required."""
+        if isinstance(value, str):
+            if value.strip() in {"", "NA", "None"}:
+                return "Not Provided"
+        elif value is None:
+            return "Not Provided"
+        return value
+
 
     def update_database(self, field_values, post_url):
         """Send the request to update database"""
@@ -333,7 +343,10 @@ class UpdateDatabase(BaseModule):
 
         elif type_of_info == "bioinfodata":
             post_url = "bioinfodata"
-            map_fields = self.json_data
+            map_fields = [
+                {k: self.clean_ambiguous_value(v) for k, v in row.items()}
+                for row in self.json_data
+            ]
 
         elif type_of_info == "variantdata":
             post_url = "variantdata"

--- a/relecov_tools/upload_database.py
+++ b/relecov_tools/upload_database.py
@@ -228,7 +228,7 @@ class UpdateDatabase(BaseModule):
                     s_dict[r_field] = None
             field_values.append(s_dict)
         return field_values
-    
+
     def clean_ambiguous_value(self, value):
         """Replace ambiguous values by default if value is not required."""
         if isinstance(value, str):
@@ -237,7 +237,6 @@ class UpdateDatabase(BaseModule):
         elif value is None:
             return "Not Provided"
         return value
-
 
     def update_database(self, field_values, post_url):
         """Send the request to update database"""


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR Description
This PR addresses three open issues related to metadata handling and error handling:

Closes:
[#625 ](https://github.com/BU-ISCIII/relecov-tools/issues/XXX) – Map "NA" to "Not Provided [SNOMED:434941000124101]" for non-required fields in read-bioinfo-metadata.

[#626 ](https://github.com/BU-ISCIII/relecov-tools/issues/XXX) – Fill None or "NA" values in non-required fields with "Not Provided [SNOMED:434941000124101]" in upload_results module.

[#630 ](https://github.com/BU-ISCIII/relecov-tools/issues/XXX) – Improve error handling when "Library Layout" field is null in the download module.

## PR Checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).