### PR TITLE
closes #647 by fixing a logging inconsistency and updating versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 #### Fixes
 
 - Fixed output_folder to output_dif in logs_to_excel params [#658](https://github.com/BU-ISCIII/relecov-tools/pull/658)
+- Fixed an issue where no message was printed to stdout/stderr when an exception was raised, making debugging harder [#672](https://github.com/BU-ISCIII/relecov-tools/pull/672)
+- Fixed logic to ensure that example entries are not silently skipped when empty — now they are properly validated or reported [#672](https://github.com/BU-ISCIII/relecov-tools/pull/672)
 
 #### Changed
 

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -323,6 +323,7 @@ def download(
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 
@@ -379,6 +380,7 @@ def read_lab_metadata(ctx, metadata_file, sample_list_file, output_dir, files_fo
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 
@@ -438,6 +440,7 @@ def validate(
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 
@@ -615,6 +618,7 @@ def send_mail(
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 
@@ -659,6 +663,7 @@ def map(ctx, origin_schema, json_file, destination_schema, schema_file, output_d
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 
@@ -718,6 +723,7 @@ def upload_to_ena(
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 
@@ -798,6 +804,7 @@ def upload_to_gisaid(
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 
@@ -859,6 +866,7 @@ def update_db(
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 
@@ -919,6 +927,7 @@ def read_bioinfo_metadata(
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 
@@ -964,6 +973,7 @@ def metadata_homogeneizer(ctx, institution, directory, output_dir):
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 
@@ -1025,6 +1035,7 @@ def pipeline_manager(ctx, input, templates_root, output_dir, config, folder_name
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 
@@ -1107,6 +1118,7 @@ def build_schema(
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 
@@ -1197,6 +1209,7 @@ def logs_to_excel(ctx, lab_code, output_dir, files):
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 
@@ -1237,6 +1250,7 @@ def wrapper(ctx, config_file, output_dir):
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 
@@ -1268,6 +1282,7 @@ def upload_results(ctx, user, password, batch_id, template_path, project):
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 
@@ -1317,6 +1332,7 @@ def add_extra_config(ctx, config_name, config_file, force, clear_config):
             raise
         else:
             log.exception(f"EXCEPTION FOUND: {e}")
+            stderr.print(f"EXCEPTION FOUND: {e}")
             sys.exit(1)
 
 

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -354,9 +354,7 @@ class SchemaBuilder(BaseModule):
         )
         return draft_template
 
-    def standard_jsonschema_object(
-        self, data_dict, target_key, remove_ontology=False
-    ):
+    def standard_jsonschema_object(self, data_dict, target_key, remove_ontology=False):
         """
         Create a standard JSON Schema object for a given key in the data dictionary.
 

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -355,7 +355,7 @@ class SchemaBuilder(BaseModule):
         return draft_template
 
     def standard_jsonschema_object(
-        seschemalf, data_dict, target_key, remove_ontology=False
+        self, data_dict, target_key, remove_ontology=False
     ):
         """
         Create a standard JSON Schema object for a given key in the data dictionary.
@@ -379,7 +379,7 @@ class SchemaBuilder(BaseModule):
         if target_key in ["enum", "examples"]:
             value = handle_nan(data_dict.get(target_key, ""))
             # if no value, json key won't be necessary, then avoid adding it
-            if len(value) > 0:
+            if len(value) > 0 or target_key == "examples":
                 items = value.split("; ")
                 if remove_ontology and target_key == "enum":
                     items = [re.sub(r"\s*\[.*?\]", "", item).strip() for item in items]


### PR DESCRIPTION
### Summary
This PR closes #647 by improving error handling and execution flow in the metadata module.

### Changes included:
- Fixed an issue where no message was printed to stdout/stderr when an exception was raised, making debugging harder.
- Fixed logic to ensure that example entries are not silently skipped when empty — now they are properly validated or reported.

## PR Checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).