### PR TITLE
Fix wrapper errors with no-invalid-samples and _RELECOV folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Sara Monzon](https://github.com/saramonzon)
 - [Jaime Ozáez](https://github.com/jaimeozaez)
+- [Pablo Mata](https://github.com/shettland)
 
 #### Added enhancements
 
@@ -19,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed an issue where no message was printed to stdout/stderr when an exception was raised, making debugging harder [#672](https://github.com/BU-ISCIII/relecov-tools/pull/672)
 - Fixed logic to ensure that example entries are not silently skipped when empty — now they are properly validated or reported [#672](https://github.com/BU-ISCIII/relecov-tools/pull/672)
 - Corrected some geo_loc_region names  [#674](https://github.com/BU-ISCIII/relecov-tools/pull/674)
+- Fixed error when subfolder was a part of the main_folder name e.g. FOLDER_RELECOV. Fixes #646 [#679](https://github.com/BU-ISCIII/relecov-tools/pull/679)
+- Fixed wrapper crash when there was no invalid samples for a given folder. Fixes #678 [#679](https://github.com/BU-ISCIII/relecov-tools/pull/679)
 
 #### Changed
 

--- a/relecov_tools/dataprocess_wrapper.py
+++ b/relecov_tools/dataprocess_wrapper.py
@@ -202,7 +202,8 @@ class ProcessWrapper(BaseModule):
         stderr.print(f"[green]Merged logs from all processes in {local_folder}")
         self.log.info(f"Merged logs from all processes in {local_folder}")
         subfolder = getattr(self.download_manager, "subfolder", None)
-        if subfolder and subfolder not in key:
+
+        if subfolder and subfolder not in os.path.split(key):
             main_folder = os.path.join(key, subfolder)
         else:
             main_folder = key


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR Checklist

- [X] This PR Closes #646 by fixing an unexpected error when subfolder was a part of the name of the main remote folder (e.g. `MAIN_FOLDER_RELECOV` when `RELECOV` is the subfolder) and Closes #678 by only checking to update files when there are invalid samples
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).