### PR TITLE
Added error message in download when library layout is not provided in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Corrected some geo_loc_region names  [#674](https://github.com/BU-ISCIII/relecov-tools/pull/674)
 - Fixed error when subfolder was a part of the main_folder name e.g. FOLDER_RELECOV. Fixes #646 [#679](https://github.com/BU-ISCIII/relecov-tools/pull/679)
 - Fixed wrapper crash when there was no invalid samples for a given folder. Fixes #678 [#679](https://github.com/BU-ISCIII/relecov-tools/pull/679)
+- Added a clear error message when library_layout is missing in the metadata. [#680](https://github.com/BU-ISCIII/relecov-tools/pull/680)
 
 #### Changed
 

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -505,9 +505,7 @@ class DownloadManager(BaseModule):
                     self.include_error(entry=str(log_text % s_name), sample=s_name)
                 try:
                     if not row[index_layout]:
-                        error_text = (
-                            "Missing 'Library Layout' value for sample %s."
-                        )
+                        error_text = "Missing 'Library Layout' value for sample %s."
                         self.include_error(error_text % str(sample_id), s_name)
                     if (
                         "paired" in row[index_layout].lower()

--- a/relecov_tools/download_manager.py
+++ b/relecov_tools/download_manager.py
@@ -504,6 +504,11 @@ class DownloadManager(BaseModule):
                     stderr.print(f"[red]{str(log_text % s_name)}")
                     self.include_error(entry=str(log_text % s_name), sample=s_name)
                 try:
+                    if not row[index_layout]:
+                        error_text = (
+                            "Missing 'Library Layout' value for sample %s."
+                        )
+                        self.include_error(error_text % str(sample_id), s_name)
                     if (
                         "paired" in row[index_layout].lower()
                         and not row[index_fastq_r2]


### PR DESCRIPTION
### Summary
This PR closes #642 by improving error reporting during metadata download.

### Changes included:
- Added a clear error message when library_layout is missing in the metadata.
- The underlying issue was already fixed in [PR #619](https://github.com/relecov/relecov-tools/pull/619); this PR only adds explicit feedback to the user to improve traceability and usability.

## PR Checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).