### PR TITLE
Restructured SchemaValidation so validate_instances can be a staticmethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed error when subfolder was a part of the main_folder name e.g. FOLDER_RELECOV. Fixes #646 [#679](https://github.com/BU-ISCIII/relecov-tools/pull/679)
 - Fixed wrapper crash when there was no invalid samples for a given folder. Fixes #678 [#679](https://github.com/BU-ISCIII/relecov-tools/pull/679)
 - Added a clear error message when library_layout is missing in the metadata. [#680](https://github.com/BU-ISCIII/relecov-tools/pull/680)
+- AnyOf error messages are now correctly managed in validation process [#684](https://github.com/BU-ISCIII/relecov-tools/pull/684)
+- Fixed incorrect sample count in validate summary message for date fields [#684](https://github.com/BU-ISCIII/relecov-tools/pull/684)
 
 #### Changed
 
 - Forced log-summary and report.xlsx files to be saved in --log-path if given [#681](https://github.com/BU-ISCIII/relecov-tools/pull/681)
+- Validate_instances method is now an static method and does not require SchemaValidation initialization [#684](https://github.com/BU-ISCIII/relecov-tools/pull/684)
+- Summarize_errors is now an independent function instead of being part of validate_instances method [#684](https://github.com/BU-ISCIII/relecov-tools/pull/684)
+- Unique_id generation is now an independent function instead of being part of validate_instances method [#684](https://github.com/BU-ISCIII/relecov-tools/pull/684)
+- Param validation to update unique_id_registry has been moved out of class _\_init__ [#684](https://github.com/BU-ISCIII/relecov-tools/pull/684)
+- Param validation to generate invalid_samples.xlsx file has been moved out of class _\_init__ [#684](https://github.com/BU-ISCIII/relecov-tools/pull/684)
+- Method get_sample_id_field is now SchemaValidation static method to get a field from a given schema by its ontology [#684](https://github.com/BU-ISCIII/relecov-tools/pull/684)
+- Method validate_schema now checks if each property has label and gives warning if not present [#684](https://github.com/BU-ISCIII/relecov-tools/pull/684)
 
 #### Removed
 

--- a/relecov_tools/json_validation.py
+++ b/relecov_tools/json_validation.py
@@ -174,7 +174,6 @@ class SchemaValidation(BaseModule):
         schema_props = json_schema["properties"]
 
         validated_json_data = []
-        invalid_json = []
         errors = defaultdict(dict)
 
         stderr.print("[blue] Start processing the JSON file")
@@ -272,7 +271,6 @@ class SchemaValidation(BaseModule):
                     errors["samples"].setdefault(error_text, []).append(sample_id_value)
 
                 # Add the invalid row to the list
-                invalid_json.append(item_row)
         return validated_json_data, errors
 
     def summarize_errors(self, errors):
@@ -533,7 +531,8 @@ class SchemaValidation(BaseModule):
         for sample in valid_json_data:
             sample_id_value = sample.get(self.sample_id_field)
             self.logsum.feed_key(sample=sample_id_value)
-        self.summarize_errors(errors)
+        if errors:
+            self.summarize_errors(errors)
 
         # Add all valid samples to the unique_id registry file
         self.validate_registry_file()


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR Checklist

- [ ] This PR addresses one main issue regarding validate_instances() as it could not be easily imported and used because it was dependent on a lot of not-really-needed class arguments that were required in `SchemaValidation.__init__()`. Therefore the solution was to make it a staticmethod by extracting every `self` call which Closes #683. Apart from that I implemented several changes to the module: First by rearranging unique_id_registry update process into a different function, second by extracting argument validation for this latter and for invalid_samples.xlsx file creation into two separate functions. I also implemented custom message management for multi-errors arisen in `AnyOf` clauses that Closes #676 and implemented custom message for date errors which also Closes #662
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).