### PR TITLE
Updated `create_summary_tables.py` to organize data jointly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Credits
 
 - [Pablo Mata](https://github.com/shettland)
+- [Victor Lopez](https://github.com/victor5lm)
 
 #### Added enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Included a new validation workflow to discard samples that are already in the platform database [#721](https://github.com/BU-ISCIII/relecov-tools/pull/721)
 - New flag 'check_db' was introduced in validate to activate checking of samples in platform [#721](https://github.com/BU-ISCIII/relecov-tools/pull/721)
 - Included docstrings for all methods in rest_api.py [#721](https://github.com/BU-ISCIII/relecov-tools/pull/721)
+- Updated create_summary_tables.py to organize data jointly [#722](https://github.com/BU-ISCIII/relecov-tools/pull/722).
 
 #### Fixes
 

--- a/relecov_tools/assets/pipeline_utils/create_summary_tables.py
+++ b/relecov_tools/assets/pipeline_utils/create_summary_tables.py
@@ -17,6 +17,7 @@ import shutil
 import pandas as pd
 from datetime import datetime
 
+
 # Function to determine the epidemiological week associated to a certain date.
 def get_epi_week(date_str):
     date = datetime.strptime(date_str, "%Y-%m-%d")

--- a/relecov_tools/assets/pipeline_utils/create_summary_tables.py
+++ b/relecov_tools/assets/pipeline_utils/create_summary_tables.py
@@ -3,10 +3,9 @@
 
 # This script is run in order to organise data from the RELECOV analyses according to their corresponding epidemiological weeks.
 # By default, all data will be stored in a folder called surveillance_files.
-# Within this folder, different subfolders will be created, each one referring to a certain epidemiological week.
-# Inside each subfolder, the following items are stored:
-# - epidemiological_data.xlsx: an excel file containing lineage information for all the samples from a given week. This information is also aggregated in another sheet.
-# - variant_data.csv: a .csv file containing information regarding the variants identified for all the samples associated to a given week.
+# Inside, the following items are stored:
+# - epidemiological_data.xlsx: an excel file containing lineage information for all the samples. This information is also aggregated in another sheet.
+# - variant_data.csv: a .csv file containing information regarding the variants identified for all the samples.
 # - consensus_files: a subfolder containing all the consensus.fa files obtained after the analysis of samples.
 
 # =============================================================
@@ -18,13 +17,11 @@ import shutil
 import pandas as pd
 from datetime import datetime
 
-
 # Function to determine the epidemiological week associated to a certain date.
 def get_epi_week(date_str):
     date = datetime.strptime(date_str, "%Y-%m-%d")
     year, week, weekday = date.isocalendar()
     return f"{year}-{week:02d}"
-
 
 # Function to search .json files in the paths indicated in the provided .txt files (specifically, bioinfo_lab_metadata and long_table .json files), read them, extract the relevant information and generate tables.
 def process_json_files(
@@ -38,6 +35,10 @@ def process_json_files(
     copy_fasta=False,
 ):
     os.makedirs(output_dir, exist_ok=True)
+
+    excel_file = os.path.join(output_dir, "epidemiological_data.xlsx")
+    variant_csv = os.path.join(output_dir, "variant_data.csv")
+    consensus_dir = os.path.join(output_dir, "consensus_files")
 
     bioinfo_files = []
     if metadata_list:
@@ -70,7 +71,7 @@ def process_json_files(
     fa_files = []
     sample_variant_data = {}
 
-    # Processing of bioinfo_lab_metadata_*.json.
+    # Processing of bioinfo_lab_metadata_*.json
     for filepath in bioinfo_files:
         if not os.path.exists(filepath):
             print(
@@ -103,21 +104,30 @@ def process_json_files(
                                 "PANGOLIN_DATABASE_VERSION": sample.get(
                                     "lineage_assignment_database_version", "-"
                                 ),
-                                "SAMPLE_ID": str(
+                                "SEQUENCING_SAMPLE_ID": str(
                                     sample.get("sequencing_sample_id", "-")
-                                ),  # str to prevent from having issues between excel and pandas with digital and characters
+                                ),
+                                "COLLECTING_LAB_SAMPLE_ID": sample.get(
+                                    "collecting_lab_sample_id", "-"
+                                ),
+                                "MICROBIOLOGY_LAB_SAMPLE_ID": sample.get(
+                                    "microbiology_lab_sample_id", "-"
+                                ),
                                 "SAMPLE_COLLECTION_DATE": sample.get(
                                     "sample_collection_date", "-"
                                 ),
                                 "LINEAGE": sample.get("lineage_assignment", "-"),
                                 "WEEK": week,
+                                "GISAID_ACCESSION_ID": sample.get(
+                                    "gisaid_accession_id", "-"
+                                ),
                             }
                         )
 
-                        # Search of consensus.fa files.
+                        # Search of consensus.fa files
                         fa_path = sample.get("consensus_sequence_filepath")
                         if copy_fasta and fa_path and os.path.exists(fa_path):
-                            fa_files.append((fa_path, week))
+                            fa_files.append(fa_path)
 
             except json.JSONDecodeError:
                 print(
@@ -128,7 +138,7 @@ def process_json_files(
         print("No bioinfo_lab_metadata_*.json files were found.")
         return
 
-    # Processing of long_table_*.json.
+    # Processing of long_table_*.json
     for filepath in long_table_files:
         if not os.path.exists(filepath):
             print(
@@ -153,151 +163,135 @@ def process_json_files(
         return
 
     df = pd.DataFrame(all_data)
-    weeks = df["WEEK"].unique()
 
-    # Creation of epidemiological-week folders, the .xlsx file with lineage information per week and the .csv file with the variant information per week.
-    for week in weeks:
-        week_dir = os.path.join(output_dir, week)
-        os.makedirs(week_dir, exist_ok=True)
+    # Handle consensus files
+    if copy_fasta and fa_files:
+        os.makedirs(consensus_dir, exist_ok=True)
+        for fa_path in fa_files:
+            dest_path = os.path.join(consensus_dir, os.path.basename(fa_path))
+            shutil.copy(fa_path, dest_path)
+        print("Copy of consensus.fa files completed successfully")
 
-        week_df = df[df["WEEK"] == week]
-        excel_file = os.path.join(week_dir, "epidemiological_data.xlsx")
+    # Handle Excel file (read existing if present)
+    existing_sample_ids = set()
+    existing_df = pd.DataFrame()
+    existing_agg_df = pd.DataFrame()
 
-        existing_sample_ids = set()
-        existing_week_df = pd.DataFrame()
+    if os.path.exists(excel_file):
+        with pd.ExcelFile(excel_file) as reader:
+            existing_df = reader.parse("per_sample_data", dtype=str)
+            existing_sample_ids = set(existing_df["SEQUENCING_SAMPLE_ID"])
+            existing_agg_df = reader.parse("aggregated_data", dtype=str)
 
-        if os.path.exists(excel_file):
-            # Check if xlsx file exists, read data and list the SAMPLE_ID
-            with pd.ExcelFile(excel_file) as reader:
-                existing_week_df = reader.parse(
-                    "per_sample_data", dtype=str
-                )  # str ensures no mofications are done between what excel has and what the dataframe reads
-                existing_sample_ids = set(existing_week_df["SAMPLE_ID"])
+    # Only add new samples
+    new_samples_df = df[~df["SEQUENCING_SAMPLE_ID"].astype(str).isin(existing_sample_ids)]
 
-        # only new samples are added
-        week_df = week_df[~week_df["SAMPLE_ID"].astype(str).isin(existing_sample_ids)]
+    if new_samples_df.empty:
+        print("No new samples found. Skipping.")
+        return
 
-        if week_df.empty:
-            print(f"No new samples for week {week}. Skipping.")
-            continue
+    # Combine data
+    combined_samples = pd.concat([existing_df, new_samples_df], ignore_index=True)
 
-        # concatenate new records to those already in the excel file
-        week_df = pd.concat([existing_week_df, week_df], ignore_index=True)
-        aggregated_df = (
-            week_df.groupby("LINEAGE").size().reset_index(name="NUMBER_SAMPLES")
-        )
+    # Recreate aggregated data from all samples
+    combined_agg = combined_samples.groupby("LINEAGE").size().reset_index(name="NUMBER_SAMPLES")
 
-        with pd.ExcelWriter(excel_file) as writer:
-            week_df.to_excel(writer, sheet_name="per_sample_data", index=False)
-            aggregated_df.to_excel(writer, sheet_name="aggregated_data", index=False)
+    # Write to Excel file
+    with pd.ExcelWriter(excel_file) as writer:
+        combined_samples.to_excel(writer, sheet_name="per_sample_data", index=False)
+        combined_agg.to_excel(writer, sheet_name="aggregated_data", index=False)
 
-        print(f"Tables were stored in {week_dir}")
+    print(f"Excel file updated: {excel_file}")
 
-        # Copy of the consensus.fa files into a subfolder called consensus_files.
-        if copy_fasta:
-            consensus_dir = os.path.join(week_dir, "consensus_files")
-            os.makedirs(consensus_dir, exist_ok=True)
-            for fa_path, week_fa in fa_files:
-                if week_fa == week:
-                    dest_path = os.path.join(consensus_dir, os.path.basename(fa_path))
-                    shutil.copy(fa_path, dest_path)
-            print("Copy of consensus.fa files completed successfully")
+    # Handle variant data
+    variant_data = []
+    for _, row in new_samples_df.iterrows():
+        sample_id = row["SEQUENCING_SAMPLE_ID"]
+        if sample_id in sample_variant_data:
+            variant_entries = sample_variant_data[sample_id].get("variants", [])
+            for variant in variant_entries:
+                variant_data.append(
+                    {
+                        "SAMPLE": variant.get("sample", "-"),
+                        "CHROM": variant.get("chromosome", "-"),
+                        "POS": variant.get("pos", "-"),
+                        "ALT": variant.get("alt", "-"),
+                        "REF": variant.get("ref", "-"),
+                        "FILTER": variant.get("Filter", "-"),
+                        "DP": variant.get("dp", "-"),
+                        "REF_DP": variant.get("ref_dp", "-"),
+                        "ALT_DP": variant.get("alt_dp", "-"),
+                        "AF": variant.get("af", "-"),
+                        "GENE": variant.get("gene", "-"),
+                        "EFFECT": variant.get("effect", "-"),
+                        "HGVS_C": variant.get("hgvs_c", "-"),
+                        "HGVS_P": variant.get("hgvs_p", "-"),
+                        "HGVS_P_1LETTER": variant.get("hgvs_p_1_letter", "-"),
+                        "CALLER": variant.get("caller", "-"),
+                        "LINEAGE": variant.get("lineage", "-"),
+                    }
+                )
 
-        # Generation of the .csv files with variant data.
-        variant_data = []
-        for _, row in week_df.iterrows():
-            sample_id = row["SAMPLE_ID"]
-            if sample_id in sample_variant_data:
-                variant_entries = sample_variant_data[sample_id].get("variants", [])
-                for variant in variant_entries:
-                    variant_data.append(
-                        {
-                            "SAMPLE": variant.get("sample", "-"),
-                            "CHROM": variant.get("chromosome", "-"),
-                            "POS": variant.get("pos", "-"),
-                            "ALT": variant.get("alt", "-"),
-                            "REF": variant.get("ref", "-"),
-                            "FILTER": variant.get("Filter", "-"),
-                            "DP": variant.get("dp", "-"),
-                            "REF_DP": variant.get("ref_dp", "-"),
-                            "ALT_DP": variant.get("alt_dp", "-"),
-                            "AF": variant.get("af", "-"),
-                            "GENE": variant.get("gene", "-"),
-                            "EFFECT": variant.get("effect", "-"),
-                            "HGVS_C": variant.get("hgvs_c", "-"),
-                            "HGVS_P": variant.get("hgvs_p", "-"),
-                            "HGVS_P_1LETTER": variant.get("hgvs_p_1_letter", "-"),
-                            "CALLER": variant.get("caller", "-"),
-                            "LINEAGE": variant.get("lineage", "-"),
-                        }
-                    )
-
-        if variant_data:
-            variant_df = pd.DataFrame(variant_data)
-            variant_csv = os.path.join(week_dir, "variant_data.csv")
+    if variant_data:
+        variant_df = pd.DataFrame(variant_data)
 
         if os.path.exists(variant_csv):
-            existing_df = pd.read_csv(variant_csv, dtype=str)
-            final_df = pd.concat([existing_df, variant_df], ignore_index=True)
-            final_variant_df = final_df.drop_duplicates()
+            existing_variant_df = pd.read_csv(variant_csv, dtype=str)
+            variant_df = pd.concat([existing_variant_df, variant_df], ignore_index=True)
 
-        else:
-            final_variant_df = variant_df
-
-        final_variant_df.to_csv(variant_csv, index=False)
-        print(f"Variant data stored in {variant_csv}")
+        variant_df.to_csv(variant_csv, index=False)
+        print(f"Variant data updated: {variant_csv}")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="JSON files are processed in order to asssign epidemiological weeks to each  analysed sample and to generate tables with lineage and variant information for each sample "
+        description="JSON files are processed to generate consolidated tables with lineage and variant information"
     )
     parser.add_argument(
         "-i",
         "--input",
-        help=" Directoy containing files called bioinfo_lab_metadata_*.json and long_table_*.json (both JSON files must be in the same directory)",
+        help="Directory containing bioinfo_lab_metadata_*.json and long_table_*.json files",
     )
     parser.add_argument(
         "-b",
         "--metadata-list",
-        help="File .txt with paths to those JSON files to be processed for generating the table with information on aggregated and non-aggregated data (bioinfo_lab_metadata_*.json)",
+        help="Text file with paths to bioinfo_lab_metadata_*.json files",
     )
     parser.add_argument(
         "-l",
         "--long-table-list",
-        help="File .txt with paths to those JSON files to be processed for generating the variant report in csv format (long_table_*.json)",
+        help="Text file with paths to long_table_*.json files",
     )
     parser.add_argument(
         "-m",
         "--metadata-file",
-        help="Direct path to a single bioinfo_lab_metadata_*.json file to process and to add to the tables if they already exist",
+        help="Direct path to a single bioinfo_lab_metadata_*.json file",
     )
     parser.add_argument(
         "-t",
         "--long-table-file",
-        help="Direct path to a single long_table_*.json file to process and to add to the tables if they already exist",
+        help="Direct path to a single long_table_*.json file",
     )
     parser.add_argument(
         "-o",
         "--output",
         default="surveillance_files",
-        help="Directory where the generated tables are saved (surveillance_files, by default)",
+        help="Output directory (default: surveillance_files)",
     )
     parser.add_argument(
         "-w",
         "--week",
-        help="Epidemiological week of intestest (format: YYYY-WW)",
+        help="Filter for specific epidemiological week (format: YYYY-WW)",
     )
     parser.add_argument(
         "-c",
         "--copy-fasta",
         action="store_true",
-        help="Copy files consensus.fa in a subdirectory called consensus_files (this argument must be provided to enable the feature)",
+        help="Copy consensus.fa files to consensus_files subdirectory",
     )
 
     args = parser.parse_args()
 
-    # Validate that either input directory or file lists or individual files are provided
     if not (args.input or args.metadata_list or args.metadata_file):
         parser.error(
             "Either --input, --metadata-list, or --metadata-file must be provided"

--- a/relecov_tools/assets/pipeline_utils/create_summary_tables.py
+++ b/relecov_tools/assets/pipeline_utils/create_summary_tables.py
@@ -23,6 +23,7 @@ def get_epi_week(date_str):
     year, week, weekday = date.isocalendar()
     return f"{year}-{week:02d}"
 
+
 # Function to search .json files in the paths indicated in the provided .txt files (specifically, bioinfo_lab_metadata and long_table .json files), read them, extract the relevant information and generate tables.
 def process_json_files(
     input_dir=None,
@@ -184,7 +185,9 @@ def process_json_files(
             existing_agg_df = reader.parse("aggregated_data", dtype=str)
 
     # Only add new samples
-    new_samples_df = df[~df["SEQUENCING_SAMPLE_ID"].astype(str).isin(existing_sample_ids)]
+    new_samples_df = df[
+        ~df["SEQUENCING_SAMPLE_ID"].astype(str).isin(existing_sample_ids)
+    ]
 
     if new_samples_df.empty:
         print("No new samples found. Skipping.")
@@ -194,7 +197,9 @@ def process_json_files(
     combined_samples = pd.concat([existing_df, new_samples_df], ignore_index=True)
 
     # Recreate aggregated data from all samples
-    combined_agg = combined_samples.groupby("LINEAGE").size().reset_index(name="NUMBER_SAMPLES")
+    combined_agg = (
+        combined_samples.groupby("LINEAGE").size().reset_index(name="NUMBER_SAMPLES")
+    )
 
     # Write to Excel file
     with pd.ExcelWriter(excel_file) as writer:

--- a/relecov_tools/assets/pipeline_utils/create_summary_tables.py
+++ b/relecov_tools/assets/pipeline_utils/create_summary_tables.py
@@ -25,7 +25,7 @@ def get_epi_week(date_str):
     return f"{year}-{week:02d}"
 
 
-# Function to search .json files in the paths indicated in the provided .txt files (specifically, bioinfo_lab_metadata and long_table .json files), read them, extract the relevant information and generate tables.
+# Function to search .json files, read them, extract the relevant information and generate tables.
 def process_json_files(
     input_dir=None,
     metadata_list=None,
@@ -177,13 +177,11 @@ def process_json_files(
     # Handle Excel file (read existing if present)
     existing_sample_ids = set()
     existing_df = pd.DataFrame()
-    existing_agg_df = pd.DataFrame()
 
     if os.path.exists(excel_file):
         with pd.ExcelFile(excel_file) as reader:
             existing_df = reader.parse("per_sample_data", dtype=str)
             existing_sample_ids = set(existing_df["SEQUENCING_SAMPLE_ID"])
-            existing_agg_df = reader.parse("aggregated_data", dtype=str)
 
     # Only add new samples
     new_samples_df = df[


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR Checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## PR Description

As per the title, the `create_summary_tables.py` script is updated so that, within the `surveillance_files` folder, an Excel file is created combining information for all analysed samples so far, along with a CSV file with all variant information for all samples and a subfolder called `consensus_files` (if indicated) containing `consensus.fa` files for all samples analysed so far. Therefore, information is generated for all samples together, instead of for each epidemiological week separately.