### PR TITLE
Refactor `configuration.json` structure by grouping fields by `module usage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Pablo Mata](https://github.com/shettland)
 - [Victor Lopez](https://github.com/victor5lm)
+- [Alejandro Bernabeu](https://github.com/aberdur)
 
 #### Added enhancements
 
@@ -18,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - New flag 'check_db' was introduced in validate to activate checking of samples in platform [#721](https://github.com/BU-ISCIII/relecov-tools/pull/721)
 - Included docstrings for all methods in rest_api.py [#721](https://github.com/BU-ISCIII/relecov-tools/pull/721)
 - Updated create_summary_tables.py to organize data jointly [#722](https://github.com/BU-ISCIII/relecov-tools/pull/722).
+- Refactor configuration.json structure by grouping fields by module usage[#725](https://github.com/BU-ISCIII/relecov-tools/pull/725)
 
 #### Fixes
 

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -212,7 +212,7 @@ def relecov_tools_cli(ctx, verbose, log_path, debug, hex_code):
         config = relecov_tools.config_json.ConfigJson(extra_config=True)
     else:
         config = relecov_tools.config_json.ConfigJson()
-    logs_config = config.get_topic_data("general", "logs_config")
+    logs_config = config.get_topic_data("generic", "logs_config")
     default_outpath = logs_config.get("default_outpath", "/tmp/relecov_tools")
     if log_path is None:
         log_path = logs_config.get("modules_outpath", {}).get(called_module)

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -212,7 +212,7 @@ def relecov_tools_cli(ctx, verbose, log_path, debug, hex_code):
         config = relecov_tools.config_json.ConfigJson(extra_config=True)
     else:
         config = relecov_tools.config_json.ConfigJson()
-    logs_config = config.get_configuration("logs_config")
+    logs_config = config.get_topic_data("general", "logs_config")
     default_outpath = logs_config.get("default_outpath", "/tmp/relecov_tools")
     if log_path is None:
         log_path = logs_config.get("modules_outpath", {}).get(called_module)

--- a/relecov_tools/base_module.py
+++ b/relecov_tools/base_module.py
@@ -43,7 +43,7 @@ class BaseModule:
         self.batch_id = "temp_id"
         self.basemod_date = datetime.today().strftime("%Y%m%d%H%M%S")
         config = ConfigJson(extra_config=True)
-        logs_config = config.get_configuration("logs_config")
+        logs_config = config.get_topic_data("general", "logs_config")
         if self.called_module in logs_config.get("modules_outpath", {}):
             output_dir = logs_config["modules_outpath"][self.called_module]
         else:

--- a/relecov_tools/base_module.py
+++ b/relecov_tools/base_module.py
@@ -43,7 +43,7 @@ class BaseModule:
         self.batch_id = "temp_id"
         self.basemod_date = datetime.today().strftime("%Y%m%d%H%M%S")
         config = ConfigJson(extra_config=True)
-        logs_config = config.get_topic_data("general", "logs_config")
+        logs_config = config.get_topic_data("generic", "logs_config")
         if self.called_module in logs_config.get("modules_outpath", {}):
             output_dir = logs_config["modules_outpath"][self.called_module]
         else:

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -141,9 +141,9 @@ class BuildSchema(BaseModule):
                 )
         else:
             try:
-                relecov_schema = config_json.get_topic_data(
-                    "json_schemas", "relecov_schema"
-                )
+                relecov_schema = config_json.get_topic_data("general", "json_schemas")[
+                    "relecov_schema"
+                ]
             except KeyError as key_error:
                 self.log.error(f"Configuration key error: {key_error}")
                 stderr.print(f"[orange]Configuration key error: {key_error}")

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -141,7 +141,7 @@ class BuildSchema(BaseModule):
                 )
         else:
             try:
-                relecov_schema = config_json.get_topic_data("general", "json_schemas")[
+                relecov_schema = config_json.get_topic_data("generic", "json_schemas")[
                     "relecov_schema"
                 ]
             except KeyError as key_error:

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -141,9 +141,7 @@ class BuildSchema(BaseModule):
                 )
         else:
             try:
-                relecov_schema = config_json.get_topic_data("generic", "json_schemas")[
-                    "relecov_schema"
-                ]
+                relecov_schema = config_json.get_topic_data("generic", "relecov_schema")
             except KeyError as key_error:
                 self.log.error(f"Configuration key error: {key_error}")
                 stderr.print(f"[orange]Configuration key error: {key_error}")

--- a/relecov_tools/conf/configuration.json
+++ b/relecov_tools/conf/configuration.json
@@ -1,12 +1,96 @@
-{
-    "logs_config": {
-        "default_outpath": "/tmp/"
+{   
+    "general": {
+        "logs_config": {
+            "default_outpath": "/tmp/"
+        },
+        "validate_config": {
+            "default_sample_id_registry": "/tmp/unique_sampleid_registry.json",
+            "starting_date": "2020-01-01"
+        },
+        "json_schemas": {
+            "relecov_schema": "relecov_schema.json",
+            "ena_schema": "ena_schema.json",
+            "gisaid_schema": "gisaid_schema.json"
+        },
+        "institution_mapping_file": {
+            "ISCIII": "ISCIII.json",
+            "HUGTiP": "HUGTiP.json"
+        }
     },
-    "validate_config": {
-        "default_sample_id_registry": "/tmp/unique_sampleid_registry.json",
-        "starting_date": "2020-01-01"
+    "pipeline_manager": {
+        "analysis_group": "RLV",
+        "analysis_user": "icasas_C",
+        "doc_folder": "DOC",
+        "analysis_folder": "ANALYSIS",
+        "sample_stored_folder": "RAW",
+        "sample_link_folder": "00-reads",
+        "organism_config": {
+            "Severe acute respiratory syndrome coronavirus 2 [LOINC:LA31065-8]": {
+                "pipeline_template": "viralrecon",
+                "service_tag": "SARSCOV2",
+                "group_by_fields": [
+                    "sequencing_instrument_platform",
+                    "enrichment_panel",
+                    "enrichment_panel_version"
+                ]
+            },
+            "Respiratory syncytial virus [SNOMED:6415009]": {
+                "pipeline_template": "IRMA",
+                "service_tag": "GENOMERSV",
+                "group_by_fields": [
+                    "sequencing_instrument_platform",
+                    "enrichment_panel",
+                    "enrichment_panel_version"
+                ]
+            },
+            "Influenza virus [SNOMED:725894000]": {
+                "pipeline_templates": ["IRMA", "taxprofiler"],
+                "service_tag": "GENOMEFLU",
+                "group_by_fields": [
+                    "sequencing_instrument_platform"
+                ]
+            }
+        }
     },
-    "lab_metadata": {
+    "sftp_handle": {
+        "sftp_connection": {
+            "sftp_server": "sftpgenvigies.isciii.es",
+            "sftp_port": "22"
+        },
+        "metadata_processing": {
+            "sample_id_col": "Sample ID given for sequencing",
+            "header_flag": "CAMPO",
+            "excel_sheet": "METADATA_LAB",
+            "alternative_sheet": "5.Viral Characterisation and Se",
+            "alternative_flag": "CAMPO",
+            "alternative_sample_id_col": "Sample ID given for sequencing"
+        },
+        "abort_if_md5_mismatch": "False",
+        "analysis_results_folder": "ANALYSIS_RESULTS",
+        "platform_storage_folder": "/tmp/relecov",
+        "allowed_file_extensions": [
+            ".fastq.gz",
+            ".fastq",
+            ".fq",
+            ".fq.gz",
+            ".fasta",
+            ".fasta.gz",
+            ".fa",
+            ".fa.gz",
+            "bam"
+        ],
+        "allowed_download_options": [
+            "download_only",
+            "download_clean",
+            "delete_only"
+        ],
+        "skip_when_found": [
+            "#",
+            "Hash",
+            "Path"
+        ]
+    },
+    "read_lab_metadata": {
         "fixed_fields": {
             "study_type": "Whole Genome Sequencing",
             "collector_name": "Not Provided [SNOMED:434941000124101]"
@@ -161,178 +245,41 @@
             "batch_id"
         ]
     },
-    "long_table_heading": [
-        "SAMPLE",
-        "CHROM",
-        "POS",
-        "REF",
-        "ALT",
-        "FILTER",
-        "DP",
-        "REF_DP",
-        "ALT_DP",
-        "AF",
-        "GENE",
-        "EFFECT",
-        "HGVS_C",
-        "HGVS_P",
-        "HGVS_P_1LETTER",
-        "CALLER",
-        "LINEAGE"
-    ],
-    "long_table_parse_aux": {
-        "Chromosome": "CHROM",
-        "Variant": {
-            "pos": "POS", 
-            "alt": "ALT", 
-            "ref": "REF"
-        },
-        "Filter": "FILTER",
-        "VariantInSample": {
-            "dp": "DP",
-            "ref_dp": "REF_DP",
-            "alt_dp": "ALT_DP",
-            "af": "AF"
-        },
-        "Effect": "EFFECT",
-        "VariantAnnotation": {
-            "hgvs_c": "HGVS_C",
-            "hgvs_p": "HGVS_P",
-            "hgvs_p_1_letter": "HGVS_P_1LETTER"
+    "upload_to_gisaid": {
+        "gisaid_csv_headers": [
+            "submitter",
+            "covv_virus_name",
+            "covv_type",
+            "covv_passage",
+            "covv_collection_date",
+            "covv_location",
+            "covv_add_location",
+            "covv_host",
+            "covv_add_host_info",
+            "covv_sampling_strategy",
+            "covv_gender",
+            "covv_patient_age",
+            "covv_patient_status",
+            "covv_specimen",
+            "covv_outbreak",
+            "covv_last_vaccinated",
+            "covv_treatment",
+            "covv_seq_technology",
+            "covv_assembly_method",
+            "covv_coverage",
+            "covv_orig_lab",
+            "covv_orig_lab_addr",
+            "covv_provider_sample_id",
+            "covv_subm_lab",
+            "covv_subm_lab_addr",
+            "covv_subm_sample_id",
+            "covv_authors"
+        ],
+        "GISAID_configuration": {
+            "submitter": "GISAID_ID"
         }
     },
-    "gisaid_csv_headers": [
-        "submitter",
-        "covv_virus_name",
-        "covv_type",
-        "covv_passage",
-        "covv_collection_date",
-        "covv_location",
-        "covv_add_location",
-        "covv_host",
-        "covv_add_host_info",
-        "covv_sampling_strategy",
-        "covv_gender",
-        "covv_patient_age",
-        "covv_patient_status",
-        "covv_specimen",
-        "covv_outbreak",
-        "covv_last_vaccinated",
-        "covv_treatment",
-        "covv_seq_technology",
-        "covv_assembly_method",
-        "covv_coverage",
-        "covv_orig_lab",
-        "covv_orig_lab_addr",
-        "covv_provider_sample_id",
-        "covv_subm_lab",
-        "covv_subm_lab_addr",
-        "covv_subm_sample_id",
-        "covv_authors"
-    ],
-    "json_schemas": {
-        "relecov_schema": "relecov_schema.json",
-        "ena_schema": "ena_schema.json",
-        "gisaid_schema": "gisaid_schema.json"
-    },
-    "institution_mapping_file": {
-        "ISCIII": "ISCIII.json",
-        "HUGTiP": "HUGTiP.json"
-    },
-    "sftp_handle": {
-        "sftp_connection": {
-            "sftp_server": "sftpgenvigies.isciii.es",
-            "sftp_port": "22"
-        },
-        "metadata_processing": {
-            "sample_id_col": "Sample ID given for sequencing",
-            "header_flag": "CAMPO",
-            "excel_sheet": "METADATA_LAB",
-            "alternative_sheet": "5.Viral Characterisation and Se",
-            "alternative_flag": "CAMPO",
-            "alternative_sample_id_col": "Sample ID given for sequencing"
-        },
-        "abort_if_md5_mismatch": "False",
-        "analysis_results_folder": "ANALYSIS_RESULTS",
-        "platform_storage_folder": "/tmp/relecov",
-        "allowed_file_extensions": [
-            ".fastq.gz",
-            ".fastq",
-            ".fq",
-            ".fq.gz",
-            ".fasta",
-            ".fasta.gz",
-            ".fa",
-            ".fa.gz",
-            "bam"
-        ],
-        "allowed_download_options": [
-            "download_only",
-            "download_clean",
-            "delete_only"
-        ],
-        "skip_when_found": [
-            "#",
-            "Hash",
-            "Path"
-        ]
-    },
-    "GISAID_configuration": {
-        "submitter": "GISAID_ID"
-    },
-    "upload_database": {
-        "platform":{
-            "iskylims": {
-                "server_url": "http://relecov-iskylims.isciiides.es",
-                "api_url": "/wetlab/api/",
-                "store_samples": "create-sample",
-                "url_project_fields": "projects-fields",
-                "url_sample_fields": "sample-fields",
-                "param_sample_project": "project",
-                "project_name": "relecov",
-                "token": ""
-            },
-            "relecov": {
-            "server_url": "http://relecov-platform.isciiides.es",
-            "api_url": "/api/",
-            "store_samples": "createSampleData",
-            "bioinfodata": "createBioinfoData",
-            "variantdata": "createVariantData",
-            "check_sample": "getSampleData",
-            "sftp_info": "sftpInfo",
-            "token": ""
-            }
-        },
-        "iskylims_fixed_values": {
-            "patient_core": "",
-            "sample_project": "Relecov",
-            "only_recorded": "Yes",
-            "sample_location": "Not defined"
-        },
-        "relecov_sample_metadata": [
-            "authors",
-            "collecting_institution",
-            "collecting_lab_sample_id",
-            "ena_broker_name",
-            "ena_sample_accession",
-            "gisaid_accession_id",
-            "gisaid_virus_name",
-            "microbiology_lab_sample_id",
-            "sequence_file_path_R1",
-            "sequence_file_path_R2",
-            "schema_name",
-            "schema_version",
-            "sequencing_date",
-            "sequence_file_R1_md5",
-            "sequence_file_R2_md5",
-            "sequence_file_R1",
-            "sequence_file_R2",
-            "sequencing_sample_id",
-            "submitting_institution",
-            "submitting_lab_sample_id"
-        ]
-    },
-    "ENA_fields": {
+    "upload_to_ena": {
         "ENA_configuration": {
             "study_alias": "RELECOV",
             "design_description": "Design Description",
@@ -454,39 +401,56 @@
             ]
         }
     },
-    "pipeline_manager": {
-        "analysis_group": "RLV",
-        "analysis_user": "icasas_C",
-        "doc_folder": "DOC",
-        "analysis_folder": "ANALYSIS",
-        "sample_stored_folder": "RAW",
-        "sample_link_folder": "00-reads",
-        "organism_config": {
-            "Severe acute respiratory syndrome coronavirus 2 [LOINC:LA31065-8]": {
-                "pipeline_template": "viralrecon",
-                "service_tag": "SARSCOV2",
-                "group_by_fields": [
-                    "sequencing_instrument_platform",
-                    "enrichment_panel",
-                    "enrichment_panel_version"
-                ]
+    "upload_database": {
+        "platform":{
+            "iskylims": {
+                "server_url": "http://relecov-iskylims.isciiides.es",
+                "api_url": "/wetlab/api/",
+                "store_samples": "create-sample",
+                "url_project_fields": "projects-fields",
+                "url_sample_fields": "sample-fields",
+                "param_sample_project": "project",
+                "project_name": "relecov",
+                "token": ""
             },
-            "Respiratory syncytial virus [SNOMED:6415009]": {
-                "pipeline_template": "IRMA",
-                "service_tag": "GENOMERSV",
-                "group_by_fields": [
-                    "sequencing_instrument_platform",
-                    "enrichment_panel",
-                    "enrichment_panel_version"
-                ]
-            },
-            "Influenza virus [SNOMED:725894000]": {
-                "pipeline_templates": ["IRMA", "taxprofiler"],
-                "service_tag": "GENOMEFLU",
-                "group_by_fields": [
-                    "sequencing_instrument_platform"
-                ]
+            "relecov": {
+            "server_url": "http://relecov-platform.isciiides.es",
+            "api_url": "/api/",
+            "store_samples": "createSampleData",
+            "bioinfodata": "createBioinfoData",
+            "variantdata": "createVariantData",
+            "check_sample": "getSampleData",
+            "sftp_info": "sftpInfo",
+            "token": ""
             }
-        }
+        },
+        "iskylims_fixed_values": {
+            "patient_core": "",
+            "sample_project": "Relecov",
+            "only_recorded": "Yes",
+            "sample_location": "Not defined"
+        },
+        "relecov_sample_metadata": [
+            "authors",
+            "collecting_institution",
+            "collecting_lab_sample_id",
+            "ena_broker_name",
+            "ena_sample_accession",
+            "gisaid_accession_id",
+            "gisaid_virus_name",
+            "microbiology_lab_sample_id",
+            "sequence_file_path_R1",
+            "sequence_file_path_R2",
+            "schema_name",
+            "schema_version",
+            "sequencing_date",
+            "sequence_file_R1_md5",
+            "sequence_file_R2_md5",
+            "sequence_file_R1",
+            "sequence_file_R2",
+            "sequencing_sample_id",
+            "submitting_institution",
+            "submitting_lab_sample_id"
+        ]
     }
 }

--- a/relecov_tools/conf/configuration.json
+++ b/relecov_tools/conf/configuration.json
@@ -1,5 +1,5 @@
 {   
-    "general": {
+    "generic": {
         "logs_config": {
             "default_outpath": "/tmp/"
         },

--- a/relecov_tools/download.py
+++ b/relecov_tools/download.py
@@ -118,7 +118,7 @@ class Download(BaseModule):
         if sftp_passwd is None:
             sftp_passwd = relecov_tools.utils.prompt_password(msg="Enter your password")
         self.metadata_lab_heading = config_json.get_topic_data(
-            "lab_metadata", "metadata_lab_heading"
+            "read_lab_metadata", "metadata_lab_heading"
         )
         self.metadata_processing = config_json.get_topic_data(
             "sftp_handle", "metadata_processing"
@@ -127,7 +127,7 @@ class Download(BaseModule):
             "sftp_handle", "skip_when_found"
         )
         self.samples_json_fields = config_json.get_topic_data(
-            "lab_metadata", "samples_json_fields"
+            "read_lab_metadata", "samples_json_fields"
         )
         # initialize the sftp client
         self.relecov_sftp = relecov_tools.sftp_client.SftpClient(

--- a/relecov_tools/ena_upload.py
+++ b/relecov_tools/ena_upload.py
@@ -121,7 +121,9 @@ class EnaUpload(BaseModule):
 
         config_json = ConfigJson()
         self.config_json = config_json
-        self.checklist = self.config_json.get_configuration("ENA_fields")["checklist"]
+        self.checklist = self.config_json.get_configuration("upload_to_ena")[
+            "checklist"
+        ]
         with open(self.source_json_file, "r") as fh:
             json_data = json.loads(fh.read())
             self.json_data = json_data
@@ -171,7 +173,9 @@ class EnaUpload(BaseModule):
         source_options = self.metadata_types
         schemas_dataframe = {}
         schemas_dataframe_raw = {}
-        acces_fields = self.config_json.get_topic_data("ENA_fields", "accession_fields")
+        acces_fields = self.config_json.get_topic_data(
+            "upload_to_ena", "accession_fields"
+        )
         filtered_access_fields = [
             fd for fd in acces_fields if any(source in fd for source in source_options)
         ]
@@ -195,7 +199,9 @@ class EnaUpload(BaseModule):
 
         for source in source_options:
             source_topic = "_".join(["df", source, "fields"])
-            source_fields = self.config_json.get_topic_data("ENA_fields", source_topic)
+            source_fields = self.config_json.get_topic_data(
+                "upload_to_ena", source_topic
+            )
             if self.action in ["CANCEL", "MODIFY", "RELEASE"]:
                 source_fields.append(str("ena_" + source + "_accession"))
             source_dict = {
@@ -238,7 +244,7 @@ class EnaUpload(BaseModule):
         """The metadata is submitted in an xml format"""
         schema_targets = extract_targets(self.action, schemas_dataframe)
 
-        tool = self.config_json.get_configuration("ENA_fields")["tool"]
+        tool = self.config_json.get_configuration("upload_to_ena")["tool"]
 
         if self.action in ["ADD", "MODIFY"]:
             schema_xmls = run_construct(

--- a/relecov_tools/gisaid_upload.py
+++ b/relecov_tools/gisaid_upload.py
@@ -130,7 +130,9 @@ class GisaidUpload:
         dataframe.loc[dataframe["covv_passage"] == "", "covv_passage"] = "Original"
 
         config_json = ConfigJson()
-        gisaid_config = config_json.get_configuration("GISAID_configuration")
+        gisaid_config = config_json.get_configuration("upload_to_gisaid")[
+            "GISAID_configuration"
+        ]
         submitter_id = gisaid_config["submitter"]
         dataframe.loc[dataframe["submitter"] == "", "submitter"] = submitter_id
 
@@ -150,7 +152,8 @@ class GisaidUpload:
         df_data = pd.DataFrame(data)
 
         config_json = ConfigJson()
-        fields = config_json.get_configuration("gisaid_csv_headers")
+        fields = config_json.get_configuration("upload_to_gisaid")["gisaid_csv_headers"]
+
         col_df = list(df_data.columns)
         for field in fields:
             if field not in col_df:
@@ -158,7 +161,7 @@ class GisaidUpload:
 
         config_lab_json = ConfigJson()
         lab_json_conf = config_lab_json.get_topic_data(
-            "lab_metadata", "laboratory_data"
+            "read_lab_metadata", "laboratory_data"
         )
         lab_json_file = os.path.join(
             os.path.dirname(os.path.realpath(__file__)), "conf", lab_json_conf["file"]

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -40,7 +40,7 @@ class LogSum:
         else:
             log.info("No output_dir provided, selecting it from config...")
             config_json = ConfigJson(extra_config=True)
-            logs_config = config_json.get_topic_data("general", "logs_config")
+            logs_config = config_json.get_topic_data("generic", "logs_config")
             output_dir = logs_config.get("default_outpath", "/tmp")
 
         log.info(f"Log summary outpath set to {output_dir}")

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -40,7 +40,7 @@ class LogSum:
         else:
             log.info("No output_dir provided, selecting it from config...")
             config_json = ConfigJson(extra_config=True)
-            logs_config = config_json.get_configuration("logs_config")
+            logs_config = config_json.get_topic_data("general", "logs_config")
             output_dir = logs_config.get("default_outpath", "/tmp")
 
         log.info(f"Log summary outpath set to {output_dir}")

--- a/relecov_tools/map.py
+++ b/relecov_tools/map.py
@@ -37,7 +37,7 @@ class Map(BaseModule):
             origin_schema = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
                 "schema",
-                config_json.get_topic_data("json_schemas", "relecov_schema"),
+                config_json.get_topic_data("general", "json_schemas")["relecov_schema"],
             )
         else:
             if not os.path.isfile(origin_schema):
@@ -103,7 +103,7 @@ class Map(BaseModule):
             self.schema_file = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
                 "schema",
-                config_json.get_topic_data("json_schemas", "ena_schema"),
+                config_json.get_topic_data("general", "json_schemas")["ena_schema"],
             )
         elif self.destination_schema == "GISAID":
             self.schema_file = os.path.join(
@@ -178,9 +178,11 @@ class Map(BaseModule):
         word splitting and include fields with fixed values.
         """
         additional_data = self.config_json.get_topic_data(
-            "ENA_fields", "additional_formating"
+            "upload_to_ena", "additional_formating"
         )
-        fixed_fields = self.config_json.get_topic_data("ENA_fields", "ena_fixed_fields")
+        fixed_fields = self.config_json.get_topic_data(
+            "upload_to_ena", "ena_fixed_fields"
+        )
 
         if self.destination_schema == "ENA":
             for idx in range(len(self.json_data)):

--- a/relecov_tools/map.py
+++ b/relecov_tools/map.py
@@ -109,7 +109,7 @@ class Map(BaseModule):
             self.schema_file = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
                 "schema",
-                config_json.get_topic_data("json_schemas", "gisaid_schema"),
+                config_json.get_topic_data("general", "json_schemas")["gisaid_schema"],
             )
         else:
             stderr.print("[red] Invalid option for mapping to schena")

--- a/relecov_tools/map.py
+++ b/relecov_tools/map.py
@@ -37,7 +37,7 @@ class Map(BaseModule):
             origin_schema = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
                 "schema",
-                config_json.get_topic_data("generic", "json_schemas")["relecov_schema"],
+                config_json.get_topic_data("generic", "relecov_schema"),
             )
         else:
             if not os.path.isfile(origin_schema):
@@ -103,13 +103,13 @@ class Map(BaseModule):
             self.schema_file = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
                 "schema",
-                config_json.get_topic_data("generic", "json_schemas")["ena_schema"],
+                config_json.get_topic_data("generic", "ena_schema"),
             )
         elif self.destination_schema == "GISAID":
             self.schema_file = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
                 "schema",
-                config_json.get_topic_data("generic", "json_schemas")["gisaid_schema"],
+                config_json.get_topic_data("generic", "gisaid_schema"),
             )
         else:
             stderr.print("[red] Invalid option for mapping to schena")

--- a/relecov_tools/map.py
+++ b/relecov_tools/map.py
@@ -37,7 +37,7 @@ class Map(BaseModule):
             origin_schema = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
                 "schema",
-                config_json.get_topic_data("general", "json_schemas")["relecov_schema"],
+                config_json.get_topic_data("generic", "json_schemas")["relecov_schema"],
             )
         else:
             if not os.path.isfile(origin_schema):
@@ -103,13 +103,13 @@ class Map(BaseModule):
             self.schema_file = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
                 "schema",
-                config_json.get_topic_data("general", "json_schemas")["ena_schema"],
+                config_json.get_topic_data("generic", "json_schemas")["ena_schema"],
             )
         elif self.destination_schema == "GISAID":
             self.schema_file = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
                 "schema",
-                config_json.get_topic_data("general", "json_schemas")["gisaid_schema"],
+                config_json.get_topic_data("generic", "json_schemas")["gisaid_schema"],
             )
         else:
             stderr.print("[red] Invalid option for mapping to schena")

--- a/relecov_tools/metadata_homogeneizer.py
+++ b/relecov_tools/metadata_homogeneizer.py
@@ -40,9 +40,7 @@ class MetadataHomogeneizer:
             os.path.dirname(__file__),
             "schema",
             "institution_schemas",
-            self.config_json.get_topic_data("generic", "institution_mapping_file")[
-                self.institution
-            ],
+            self.config_json.get_topic_data("generic", "self.institution"),
         )
 
         self.mapping_json_data = relecov_tools.utils.read_json_file(mapping_json_file)

--- a/relecov_tools/metadata_homogeneizer.py
+++ b/relecov_tools/metadata_homogeneizer.py
@@ -24,7 +24,7 @@ class MetadataHomogeneizer:
         self.config_json = ConfigJson()
         # read heading from config
         self.heading = self.config_json.get_topic_data(
-            "lab_metadata", "metadata_lab_heading"
+            "read_lab_metadata", "metadata_lab_heading"
         )
 
         # handle institution
@@ -40,9 +40,9 @@ class MetadataHomogeneizer:
             os.path.dirname(__file__),
             "schema",
             "institution_schemas",
-            self.config_json.get_topic_data(
-                "institution_mapping_file", self.institution
-            ),
+            self.config_json.get_topic_data("general", "institution_mapping_file")[
+                self.institution
+            ],
         )
 
         self.mapping_json_data = relecov_tools.utils.read_json_file(mapping_json_file)

--- a/relecov_tools/metadata_homogeneizer.py
+++ b/relecov_tools/metadata_homogeneizer.py
@@ -40,7 +40,7 @@ class MetadataHomogeneizer:
             os.path.dirname(__file__),
             "schema",
             "institution_schemas",
-            self.config_json.get_topic_data("general", "institution_mapping_file")[
+            self.config_json.get_topic_data("generic", "institution_mapping_file")[
                 self.institution
             ],
         )

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -86,9 +86,7 @@ class BioinfoMetadata(BaseModule):
         # Init process log
 
         if json_schema_file is None:
-            schema_name = config_json.get_topic_data("generic", "json_schemas")[
-                "relecov_schema"
-            ]
+            schema_name = config_json.get_topic_data("generic", "relecov_schema")
             json_schema_file = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)), "schema", schema_name
             )

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -86,7 +86,7 @@ class BioinfoMetadata(BaseModule):
         # Init process log
 
         if json_schema_file is None:
-            schema_name = config_json.get_topic_data("general", "json_schemas")[
+            schema_name = config_json.get_topic_data("generic", "json_schemas")[
                 "relecov_schema"
             ]
             json_schema_file = os.path.join(

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -86,7 +86,9 @@ class BioinfoMetadata(BaseModule):
         # Init process log
 
         if json_schema_file is None:
-            schema_name = config_json.get_topic_data("json_schemas", "relecov_schema")
+            schema_name = config_json.get_topic_data("general", "json_schemas")[
+                "relecov_schema"
+            ]
             json_schema_file = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)), "schema", schema_name
             )

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -76,7 +76,9 @@ class LabMetadata(BaseModule):
         config_json = ConfigJson(extra_config=True)
 
         # TODO: remove hardcoded schema selection
-        relecov_schema = config_json.get_topic_data("json_schemas", "relecov_schema")
+        relecov_schema = config_json.get_topic_data("general", "json_schemas")[
+            "relecov_schema"
+        ]
         relecov_sch_path = os.path.join(
             os.path.dirname(os.path.realpath(__file__)), "schema", relecov_schema
         )
@@ -114,7 +116,7 @@ class LabMetadata(BaseModule):
                 continue
         self.date = dtime.now().strftime("%Y%m%d%H%M%S")
         self.json_req_files = config_json.get_topic_data(
-            "lab_metadata", "lab_metadata_req_json"
+            "read_lab_metadata", "lab_metadata_req_json"
         )
         self.schema_name = self.relecov_sch_json["title"]
         self.schema_version = self.relecov_sch_json["version"]
@@ -122,7 +124,7 @@ class LabMetadata(BaseModule):
             "sftp_handle", "metadata_processing"
         )
         self.samples_json_fields = config_json.get_topic_data(
-            "lab_metadata", "samples_json_fields"
+            "read_lab_metadata", "samples_json_fields"
         )
         self.unique_sample_id = "sequencing_sample_id"
 
@@ -266,9 +268,9 @@ class LabMetadata(BaseModule):
 
     def adding_fixed_fields(self, m_data):
         """Include fixed data that are always the same for every sample"""
-        p_data = self.configuration.get_topic_data("lab_metadata", "fixed_fields")
+        p_data = self.configuration.get_topic_data("read_lab_metadata", "fixed_fields")
         organism_mapping = self.configuration.get_topic_data(
-            "lab_metadata", "organism_mapping"
+            "read_lab_metadata", "organism_mapping"
         )
 
         for idx in range(len(m_data)):
@@ -289,7 +291,7 @@ class LabMetadata(BaseModule):
     def adding_copy_from_other_field(self, m_data):
         """Add a new field with information based in another field."""
         p_data = self.configuration.get_topic_data(
-            "lab_metadata", "required_copy_from_other_field"
+            "read_lab_metadata", "required_copy_from_other_field"
         )
         for idx in range(len(m_data)):
             for key, value in p_data.items():
@@ -299,7 +301,7 @@ class LabMetadata(BaseModule):
     def adding_post_processing(self, m_data):
         """Add fields which values require post processing"""
         p_data = self.configuration.get_topic_data(
-            "lab_metadata", "required_post_processing"
+            "read_lab_metadata", "required_post_processing"
         )
         for idx in range(len(m_data)):
             for key, p_values in p_data.items():
@@ -644,7 +646,7 @@ class LabMetadata(BaseModule):
             self.log.warning("Metadata was completely empty. No output file generated")
             stderr.print("Metadata was completely empty. No output file generated")
             return
-        file_code = "_".join(["lab_metadata", self.lab_code]) + ".json"
+        file_code = "_".join(["read_lab_metadata", self.lab_code]) + ".json"
         file_name = self.tag_filename(filename=file_code)
         stderr.print("[blue]Writting output json file")
         os.makedirs(self.output_dir, exist_ok=True)

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -76,7 +76,7 @@ class LabMetadata(BaseModule):
         config_json = ConfigJson(extra_config=True)
 
         # TODO: remove hardcoded schema selection
-        relecov_schema = config_json.get_topic_data("general", "json_schemas")[
+        relecov_schema = config_json.get_topic_data("generic", "json_schemas")[
             "relecov_schema"
         ]
         relecov_sch_path = os.path.join(

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -76,9 +76,7 @@ class LabMetadata(BaseModule):
         config_json = ConfigJson(extra_config=True)
 
         # TODO: remove hardcoded schema selection
-        relecov_schema = config_json.get_topic_data("generic", "json_schemas")[
-            "relecov_schema"
-        ]
+        relecov_schema = config_json.get_topic_data("generic", "relecov_schema")
         relecov_sch_path = os.path.join(
             os.path.dirname(os.path.realpath(__file__)), "schema", relecov_schema
         )

--- a/relecov_tools/upload_database.py
+++ b/relecov_tools/upload_database.py
@@ -64,9 +64,7 @@ class UploadDatabase(BaseModule):
         schema = os.path.join(
             os.path.dirname(os.path.realpath(__file__)),
             "schema",
-            self.config_json.get_topic_data("generic", "json_schemas")[
-                "relecov_schema"
-            ],
+            self.config_json.get_topic_data("generic", "relecov_schema"),
         )
         self.schema = relecov_tools.utils.read_json_file(schema)
         if full_update is True:

--- a/relecov_tools/upload_database.py
+++ b/relecov_tools/upload_database.py
@@ -64,7 +64,9 @@ class UploadDatabase(BaseModule):
         schema = os.path.join(
             os.path.dirname(os.path.realpath(__file__)),
             "schema",
-            self.config_json.get_topic_data("json_schemas", "relecov_schema"),
+            self.config_json.get_topic_data("general", "json_schemas")[
+                "relecov_schema"
+            ],
         )
         self.schema = relecov_tools.utils.read_json_file(schema)
         if full_update is True:

--- a/relecov_tools/upload_database.py
+++ b/relecov_tools/upload_database.py
@@ -64,7 +64,7 @@ class UploadDatabase(BaseModule):
         schema = os.path.join(
             os.path.dirname(os.path.realpath(__file__)),
             "schema",
-            self.config_json.get_topic_data("general", "json_schemas")[
+            self.config_json.get_topic_data("generic", "json_schemas")[
                 "relecov_schema"
             ],
         )

--- a/relecov_tools/validate.py
+++ b/relecov_tools/validate.py
@@ -868,7 +868,9 @@ class Validate(BaseModule):
         self.log.info("Validate the given schema")
         self.validate_schema()
         self.log.info("Preparing validator based on config")
-        starting_date = self.config.get_topic_data("validate_config", "starting_date")
+        starting_date = self.config.get_topic_data("general", "validate_config")[
+            "starting_date"
+        ]
         date_checker = (
             relecov_tools.assets.schema_utils.custom_validators.make_date_checker(
                 datetime.strptime(starting_date, "%Y-%m-%d").date(),

--- a/relecov_tools/validate.py
+++ b/relecov_tools/validate.py
@@ -66,7 +66,9 @@ class Validate(BaseModule):
                 f"Config file is missing required sections: {', '.join(missing)}"
             )
         if json_schema_file is None:
-            schema_name = self.config.get_topic_data("json_schemas", "relecov_schema")
+            schema_name = self.config.get_topic_data("general", "json_schemas")[
+                "relecov_schema"
+            ]
             json_schema_file = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)), "schema", schema_name
             )
@@ -478,9 +480,9 @@ class Validate(BaseModule):
         else:
             config_json = ConfigJson(extra_config=True)
             try:
-                default_path = config_json.get_topic_data(
-                    "validate_config", "default_sample_id_registry"
-                )
+                default_path = config_json.get_topic_data("general", "validate_config")[
+                    "default_sample_id_registry"
+                ]
             except KeyError:
                 default_path = None
 

--- a/relecov_tools/validate.py
+++ b/relecov_tools/validate.py
@@ -66,9 +66,7 @@ class Validate(BaseModule):
                 f"Config file is missing required sections: {', '.join(missing)}"
             )
         if json_schema_file is None:
-            schema_name = self.config.get_topic_data("generic", "json_schemas")[
-                "relecov_schema"
-            ]
+            schema_name = self.config.get_topic_data("generic", "relecov_schema")
             json_schema_file = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)), "schema", schema_name
             )
@@ -480,9 +478,9 @@ class Validate(BaseModule):
         else:
             config_json = ConfigJson(extra_config=True)
             try:
-                default_path = config_json.get_topic_data("generic", "validate_config")[
-                    "default_sample_id_registry"
-                ]
+                default_path = config_json.get_topic_data(
+                    "generic", "default_sample_id_registry"
+                )
             except KeyError:
                 default_path = None
 
@@ -868,9 +866,7 @@ class Validate(BaseModule):
         self.log.info("Validate the given schema")
         self.validate_schema()
         self.log.info("Preparing validator based on config")
-        starting_date = self.config.get_topic_data("generic", "validate_config")[
-            "starting_date"
-        ]
+        starting_date = self.config.get_topic_data("generic", "starting_date")
         date_checker = (
             relecov_tools.assets.schema_utils.custom_validators.make_date_checker(
                 datetime.strptime(starting_date, "%Y-%m-%d").date(),

--- a/relecov_tools/validate.py
+++ b/relecov_tools/validate.py
@@ -66,7 +66,7 @@ class Validate(BaseModule):
                 f"Config file is missing required sections: {', '.join(missing)}"
             )
         if json_schema_file is None:
-            schema_name = self.config.get_topic_data("general", "json_schemas")[
+            schema_name = self.config.get_topic_data("generic", "json_schemas")[
                 "relecov_schema"
             ]
             json_schema_file = os.path.join(
@@ -480,7 +480,7 @@ class Validate(BaseModule):
         else:
             config_json = ConfigJson(extra_config=True)
             try:
-                default_path = config_json.get_topic_data("general", "validate_config")[
+                default_path = config_json.get_topic_data("generic", "validate_config")[
                     "default_sample_id_registry"
                 ]
             except KeyError:
@@ -868,7 +868,7 @@ class Validate(BaseModule):
         self.log.info("Validate the given schema")
         self.validate_schema()
         self.log.info("Preparing validator based on config")
-        starting_date = self.config.get_topic_data("general", "validate_config")[
+        starting_date = self.config.get_topic_data("generic", "validate_config")[
             "starting_date"
         ]
         date_checker = (

--- a/tests/data/sftp_handle/configuration.json
+++ b/tests/data/sftp_handle/configuration.json
@@ -1,8 +1,99 @@
-{
-    "lab_metadata": {
+{   
+    "general": {
+        "logs_config": {
+            "default_outpath": "/tmp/"
+        },
+        "validate_config": {
+            "default_sample_id_registry": "/tmp/unique_sampleid_registry.json",
+            "starting_date": "2020-01-01"
+        },
+        "json_schemas": {
+            "relecov_schema": "relecov_schema.json",
+            "ena_schema": "ena_schema.json",
+            "gisaid_schema": "gisaid_schema.json"
+        },
+        "institution_mapping_file": {
+            "ISCIII": "ISCIII.json",
+            "HUGTiP": "HUGTiP.json"
+        }
+    },
+    "pipeline_manager": {
+        "analysis_group": "RLV",
+        "analysis_user": "icasas_C",
+        "doc_folder": "DOC",
+        "analysis_folder": "ANALYSIS",
+        "sample_stored_folder": "RAW",
+        "sample_link_folder": "00-reads",
+        "organism_config": {
+            "Severe acute respiratory syndrome coronavirus 2 [LOINC:LA31065-8]": {
+                "pipeline_template": "viralrecon",
+                "service_tag": "SARSCOV2",
+                "group_by_fields": [
+                    "sequencing_instrument_platform",
+                    "enrichment_panel",
+                    "enrichment_panel_version"
+                ]
+            },
+            "Respiratory syncytial virus [SNOMED:6415009]": {
+                "pipeline_template": "IRMA",
+                "service_tag": "GENOMERSV",
+                "group_by_fields": [
+                    "sequencing_instrument_platform",
+                    "enrichment_panel",
+                    "enrichment_panel_version"
+                ]
+            },
+            "Influenza virus [SNOMED:725894000]": {
+                "pipeline_templates": ["IRMA", "taxprofiler"],
+                "service_tag": "GENOMEFLU",
+                "group_by_fields": [
+                    "sequencing_instrument_platform"
+                ]
+            }
+        }
+    },
+    "sftp_handle": {
+        "sftp_connection": {
+            "sftp_server": "sftpgenvigies.isciii.es",
+            "sftp_port": "22"
+        },
+        "metadata_processing": {
+            "sample_id_col": "Sample ID given for sequencing",
+            "header_flag": "CAMPO",
+            "excel_sheet": "METADATA_LAB",
+            "alternative_sheet": "5.Viral Characterisation and Se",
+            "alternative_flag": "CAMPO",
+            "alternative_sample_id_col": "Sample ID given for sequencing"
+        },
+        "abort_if_md5_mismatch": "False",
+        "analysis_results_folder": "ANALYSIS_RESULTS",
+        "platform_storage_folder": "/tmp/relecov",
+        "allowed_file_extensions": [
+            ".fastq.gz",
+            ".fastq",
+            ".fq",
+            ".fq.gz",
+            ".fasta",
+            ".fasta.gz",
+            ".fa",
+            ".fa.gz",
+            "bam"
+        ],
+        "allowed_download_options": [
+            "download_only",
+            "download_clean",
+            "delete_only"
+        ],
+        "skip_when_found": [
+            "#",
+            "Hash",
+            "Path"
+        ]
+    },
+    "read_lab_metadata": {
         "fixed_fields": {
             "study_type": "Whole Genome Sequencing",
-            "collector_name": "Not Provided"
+            "collector_name": "Not Provided [SNOMED:434941000124101]"
         },
         "organism_mapping": {
             "Severe acute respiratory syndrome coronavirus 2 [LOINC:LA31065-8]": {
@@ -44,6 +135,12 @@
             "Host Age Years",
             "Host Age Months",
             "Host Gender",
+            "Vaccinated",
+            "Specific medication for treatment or prophylaxis",
+            "Hospitalization",
+            "Admission to intensive care unit",
+            "Death",
+            "Immunosuppression",
             "Sequencing Date",
             "Nucleic acid extraction protocol",
             "Commercial All-in-one library kit",
@@ -66,14 +163,8 @@
             "Gene Name 2",
             "Diagnostic Pcr Ct Value-2",
             "Authors",
-            "Sequence file R1 fastq",
-            "Sequence file R2 fastq", 
-            "Vaccinated",
-            "Specific medication for treatment or prophylaxis",
-            "Hospitalization",
-            "Admission to intensive care unit",
-            "Death",
-            "Immunosuppression"
+            "Sequence file R1",
+            "Sequence file R2"
         ],
         "alt_heading_equivalences": {
             "Sample ID": "Sample ID given for sequencing",
@@ -118,15 +209,6 @@
                   "geo_loc_longitude"
                 ]
             },
-            "submitting_data": {
-                "file": "laboratory_address.json",
-                "map_field": "collecting_institution",
-                "adding_fields": [
-                    "submitting_institution",
-                    "submitting_institution_address",
-                    "submitting_institution_email"
-                ]
-            },
             "specimen_source_splitting": {
                 "file": "anatomical_material_collection_method.json",
                 "map_field": "specimen_source",
@@ -146,6 +228,7 @@
                 "Illumina": "sequencing_instrument_platform::Illumina",
                 "PacBio": "sequencing_instrument_platform::PacBio",
                 "Ion Torrent": "sequencing_instrument_platform::Ion Torrent",
+                "Ion Gene": "sequencing_instrument_platform::Ion Torrent",
                 "Oxford Nanopore": "sequencing_instrument_platform::Oxford Nanopore"
             }
         },
@@ -153,183 +236,50 @@
             "isolate_sample_id": "sequencing_sample_id"
         },
         "samples_json_fields": [
-            "fastq_r1_md5",
-            "fastq_r2_md5",
-            "sequence_file_R1_fastq",
-            "sequence_file_R2_fastq",
-            "r1_fastq_filepath",
-            "r2_fastq_filepath"
-        ]
-    },
-    "long_table_heading": [
-        "SAMPLE",
-        "CHROM",
-        "POS",
-        "REF",
-        "ALT",
-        "FILTER",
-        "DP",
-        "REF_DP",
-        "ALT_DP",
-        "AF",
-        "GENE",
-        "EFFECT",
-        "HGVS_C",
-        "HGVS_P",
-        "HGVS_P_1LETTER",
-        "CALLER",
-        "LINEAGE"
-    ],
-    "long_table_parse_aux": {
-        "Chromosome": "CHROM",
-        "Variant": {
-            "pos": "POS", 
-            "alt": "ALT", 
-            "ref": "REF"
-        },
-        "Filter": "FILTER",
-        "VariantInSample": {
-            "dp": "DP",
-            "ref_dp": "REF_DP",
-            "alt_dp": "ALT_DP",
-            "af": "AF"
-        },
-        "Effect": "EFFECT",
-        "VariantAnnotation": {
-            "hgvs_c": "HGVS_C",
-            "hgvs_p": "HGVS_P",
-            "hgvs_p_1_letter": "HGVS_P_1LETTER"
-        }
-    },
-    "gisaid_csv_headers": [
-        "submitter",
-        "covv_virus_name",
-        "covv_type",
-        "covv_passage",
-        "covv_collection_date",
-        "covv_location",
-        "covv_add_location",
-        "covv_host",
-        "covv_add_host_info",
-        "covv_sampling_strategy",
-        "covv_gender",
-        "covv_patient_age",
-        "covv_patient_status",
-        "covv_specimen",
-        "covv_outbreak",
-        "covv_last_vaccinated",
-        "covv_treatment",
-        "covv_seq_technology",
-        "covv_assembly_method",
-        "covv_coverage",
-        "covv_orig_lab",
-        "covv_orig_lab_addr",
-        "covv_provider_sample_id",
-        "covv_subm_lab",
-        "covv_subm_lab_addr",
-        "covv_subm_sample_id",
-        "covv_authors"
-    ],
-    "json_schemas": {
-        "relecov_schema": "relecov_schema.json",
-        "ena_schema": "ena_schema.json",
-        "gisaid_schema": "gisaid_schema.json"
-    },
-    "institution_mapping_file": {
-        "ISCIII": "ISCIII.json",
-        "HUGTiP": "HUGTiP.json"
-    },
-    "sftp_handle": {
-        "sftp_connection": {
-            "sftp_server": "sftprelecov.isciii.es",
-            "sftp_port": "22"
-        },
-        "metadata_processing": {
-            "sample_id_col": "Sample ID given for sequencing",
-            "header_flag": "CAMPO",
-            "excel_sheet": "METADATA_LAB",
-            "alternative_sheet": "5.Viral Characterisation and Se",
-            "alternative_flag": "CAMPO",
-            "alternative_sample_id_col": "Sample ID given for sequencing"
-        },
-        "abort_if_md5_mismatch": "False",
-        "platform_storage_folder": "/tmp/relecov",
-        "allowed_file_extensions": [
-            ".fastq.gz",
-            ".fastq",
-            ".fq",
-            ".fq.gz",
-            ".fasta",
-            ".fasta.gz",
-            ".fa",
-            ".fa.gz",
-            "bam"
-        ],
-        "allowed_download_options": [
-            "download_only",
-            "download_clean",
-            "delete_only"
-        ],
-        "skip_when_found": [
-            "#",
-            "Hash",
-            "Path"
-        ]
-    },
-    "GISAID_configuration": {
-        "submitter": "GISAID_ID"
-    },
-    "upload_database": {
-        "platform":{
-            "iskylims": {
-                "server_url": "http://relecov-iskylims.isciiides.es",
-                "api_url": "/wetlab/api/",
-                "store_samples": "create-sample",
-                "url_project_fields": "projects-fields",
-                "url_sample_fields": "sample-fields",
-                "param_sample_project": "project",
-                "project_name": "relecov",
-                "token": ""
-            },
-            "relecov": {
-            "server_url": "http://relecov-platform.isciiides.es",
-            "api_url": "/api/",
-            "store_samples": "createSampleData",
-            "bioinfodata": "createBioinfoData",
-            "variantdata": "createVariantData",
-            "sftp_info": "sftpInfo",
-            "token": ""
-            }
-        },
-        "iskylims_fixed_values": {
-            "patient_core": "",
-            "sample_project": "Relecov",
-            "only_recorded": "Yes",
-            "sample_location": "Not defined"
-        },
-        "relecov_sample_metadata": [
-            "authors",
-            "collecting_institution",
-            "collecting_lab_sample_id",
-            "ena_broker_name",
-            "ena_sample_accession",
-            "gisaid_accession_id",
-            "gisaid_virus_name",
-            "microbiology_lab_sample_id",
-            "r1_fastq_filepath",
-            "r2_fastq_filepath",
-            "schema_name",
-            "schema_version",
-            "sequencing_date",
             "sequence_file_R1_md5",
             "sequence_file_R2_md5",
-            "sequence_file_R1_fastq",
-            "sequence_file_R2_fastq",
-            "sequencing_sample_id",
-            "submitting_lab_sample_id"
+            "sequence_file_R1",
+            "sequence_file_R2",
+            "sequence_file_path_R1",
+            "sequence_file_path_R2",
+            "batch_id"
         ]
     },
-    "ENA_fields": {
+    "upload_to_gisaid": {
+        "gisaid_csv_headers": [
+            "submitter",
+            "covv_virus_name",
+            "covv_type",
+            "covv_passage",
+            "covv_collection_date",
+            "covv_location",
+            "covv_add_location",
+            "covv_host",
+            "covv_add_host_info",
+            "covv_sampling_strategy",
+            "covv_gender",
+            "covv_patient_age",
+            "covv_patient_status",
+            "covv_specimen",
+            "covv_outbreak",
+            "covv_last_vaccinated",
+            "covv_treatment",
+            "covv_seq_technology",
+            "covv_assembly_method",
+            "covv_coverage",
+            "covv_orig_lab",
+            "covv_orig_lab_addr",
+            "covv_provider_sample_id",
+            "covv_subm_lab",
+            "covv_subm_lab_addr",
+            "covv_subm_sample_id",
+            "covv_authors"
+        ],
+        "GISAID_configuration": {
+            "submitter": "GISAID_ID"
+        }
+    },
+    "upload_to_ena": {
         "ENA_configuration": {
             "study_alias": "RELECOV",
             "design_description": "Design Description",
@@ -421,13 +371,13 @@
                 "library_selection",
                 "library_strategy"
             ],
-            "r1_fastq_filepath": [
-                "r1_fastq_filepath",
-                "sequence_file_R1_fastq"
+            "sequence_file_path_R1": [
+                "sequence_file_path_R1",
+                "sequence_file_R1"
             ],
-            "r2_fastq_filepath": [
-                "r2_fastq_filepath",
-                "sequence_file_R2_fastq"
+            "sequence_file_path_R2": [
+                "sequence_file_path_R2",
+                "sequence_file_R2"
             ],
             "experiment_alias": [
                 "isolate_sample_id",
@@ -442,57 +392,65 @@
                 "isolate_sample_id"
             ],
             "file_name": [
-                "sequence_file_R1_fastq",
-                "sequence_file_R2_fastq"
+                "sequence_file_R1",
+                "sequence_file_R2"
             ],
             "file_checksum": [
-                "fastq_r1_md5",
-                "fastq_r2_md5"
+                "sequence_file_R1_md5",
+                "sequence_file_R2_md5"
             ]
         }
     },
-    "pipeline_manager": {
-        "analysis_group": "RLV",
-        "analysis_user": "icasas_C",
-        "doc_folder": "DOC",
-        "analysis_folder": "ANALYSIS",
-        "sample_stored_folder": "RAW",
-        "sample_link_folder": "00-reads",
-        "organism_config": {
-            "Severe acute respiratory syndrome coronavirus 2 [LOINC:LA31065-8]": {
-                "pipeline_template": "viralrecon",
-                "service_tag": "SARSCOV2",
-                "group_by_fields": [
-                    "sequencing_instrument_platform",
-                    "enrichment_panel",
-                    "enrichment_panel_version"
-                ]
+    "upload_database": {
+        "platform":{
+            "iskylims": {
+                "server_url": "http://relecov-iskylims.isciiides.es",
+                "api_url": "/wetlab/api/",
+                "store_samples": "create-sample",
+                "url_project_fields": "projects-fields",
+                "url_sample_fields": "sample-fields",
+                "param_sample_project": "project",
+                "project_name": "relecov",
+                "token": ""
             },
-            "Respiratory syncytial virus [SNOMED:6415009]": {
-                "pipeline_template": "IRMA",
-                "service_tag": "GENOMERSV",
-                "group_by_fields": [
-                    "sequencing_instrument_platform",
-                    "enrichment_panel",
-                    "enrichment_panel_version"
-                ]
-            },
-            "Influenza virus [SNOMED:725894000]": {
-                "pipeline_template": "IRMA",
-                "service_tag": "GENOMEFLU",
-                "group_by_fields": [
-                    "sequencing_instrument_platform"
-                ]
+            "relecov": {
+            "server_url": "http://relecov-platform.isciiides.es",
+            "api_url": "/api/",
+            "store_samples": "createSampleData",
+            "bioinfodata": "createBioinfoData",
+            "variantdata": "createVariantData",
+            "check_sample": "getSampleData",
+            "sftp_info": "sftpInfo",
+            "token": ""
             }
-        }
-    },
-    "mail_sender":{
-        "delivery_template_path_file": "./relecov_tools/templates/",
-        "email_host": "mx2.isciii.es",
-        "email_port": "587",
-        "email_host_user": "bioinformatica@isciii.es", 
-        "email_use_tls": "True",
-        "yaml_cred_path": "~/buisciii_config.yml",
-        "institutions_guide_path": "/data/bioinfoshare/UCCT_Relecov/statics/institutions_guide.json"
+        },
+        "iskylims_fixed_values": {
+            "patient_core": "",
+            "sample_project": "Relecov",
+            "only_recorded": "Yes",
+            "sample_location": "Not defined"
+        },
+        "relecov_sample_metadata": [
+            "authors",
+            "collecting_institution",
+            "collecting_lab_sample_id",
+            "ena_broker_name",
+            "ena_sample_accession",
+            "gisaid_accession_id",
+            "gisaid_virus_name",
+            "microbiology_lab_sample_id",
+            "sequence_file_path_R1",
+            "sequence_file_path_R2",
+            "schema_name",
+            "schema_version",
+            "sequencing_date",
+            "sequence_file_R1_md5",
+            "sequence_file_R2_md5",
+            "sequence_file_R1",
+            "sequence_file_R2",
+            "sequencing_sample_id",
+            "submitting_institution",
+            "submitting_lab_sample_id"
+        ]
     }
 }


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR Description
This PR addresses Issue #230 by restructuring the `configuration.json` file to group fields into logical categories based on the tools or modules that use them. The aim is to improve readability, maintainability, and modular access throughout the relecov-tools codebase.

### Summary of changes: _configuration.json_
Grouped previously top-level fields into new high-level keys:
- general: general-purpose and shared settings
- read_lab_metadata: used by the read-lab-metadata module
- read_bioinfo_metadata: used by the read-bioinfo-metadata module
- upload_to_ena: settings for ENA metadata upload
- upload_to_gisaid: settings for GISAID metadata export
- upload_database: for internal database upload (e.g. iskylims, relecov)
- pipeline_manager: execution and grouping settings for analysis pipelines
- sftp_handle: already grouped (no change)



## PR Checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).