### PR TITLE
Moved sample_id_ontology used by validate to configuration.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Changed
 
+- Moved sample_id_ontology previously hard-coded in validate.py to configuration.json [#733](https://github.com/BU-ISCIII/relecov-tools/pull/733)
+
 #### Removed
 
 ### Requirements

--- a/relecov_tools/conf/configuration.json
+++ b/relecov_tools/conf/configuration.json
@@ -5,7 +5,8 @@
         },
         "validate_config": {
             "default_sample_id_registry": "/tmp/unique_sampleid_registry.json",
-            "starting_date": "2020-01-01"
+            "starting_date": "2020-01-01",
+            "sample_id_ontology": "GENEPIO:0000079"
         },
         "json_schemas": {
             "relecov_schema": "relecov_schema.json",

--- a/relecov_tools/validate.py
+++ b/relecov_tools/validate.py
@@ -130,7 +130,7 @@ class Validate(BaseModule):
         self.metadata = metadata
 
         # TODO: Include this field in configuration.json
-        sample_id_ontology = "GENEPIO:0000079"
+        sample_id_ontology = self.config.get_topic_data("generic", "sample_id_ontology")
         try:
             self.sample_id_field = Validate.get_field_from_schema(
                 sample_id_ontology, self.json_schema


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR Checklist

- [X] Closes #686 by moving the previously hard-coded ontology for sample_id to configuration.json
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).