### PR TITLE
Revert extra-config change: restore `logs_config = config.get_configuration("logs_config")`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixes
 
+- Revert extra-config change: restore logs_config = config.get_configuration("logs_config") [#734](https://github.com/BU-ISCIII/relecov-tools/pull/734)
+
 #### Changed
 
 - Moved sample_id_ontology previously hard-coded in validate.py to configuration.json [#733](https://github.com/BU-ISCIII/relecov-tools/pull/733)

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -212,7 +212,7 @@ def relecov_tools_cli(ctx, verbose, log_path, debug, hex_code):
         config = relecov_tools.config_json.ConfigJson(extra_config=True)
     else:
         config = relecov_tools.config_json.ConfigJson()
-    logs_config = config.get_topic_data("generic", "logs_config")
+    logs_config = config.get_configuration("logs_config")
     default_outpath = logs_config.get("default_outpath", "/tmp/relecov_tools")
     if log_path is None:
         log_path = logs_config.get("modules_outpath", {}).get(called_module)

--- a/relecov_tools/base_module.py
+++ b/relecov_tools/base_module.py
@@ -43,7 +43,7 @@ class BaseModule:
         self.batch_id = "temp_id"
         self.basemod_date = datetime.today().strftime("%Y%m%d%H%M%S")
         config = ConfigJson(extra_config=True)
-        logs_config = config.get_topic_data("generic", "logs_config")
+        logs_config = config.get_configuration("logs_config")
         if self.called_module in logs_config.get("modules_outpath", {}):
             output_dir = logs_config["modules_outpath"][self.called_module]
         else:

--- a/relecov_tools/log_summary.py
+++ b/relecov_tools/log_summary.py
@@ -40,7 +40,7 @@ class LogSum:
         else:
             log.info("No output_dir provided, selecting it from config...")
             config_json = ConfigJson(extra_config=True)
-            logs_config = config_json.get_topic_data("generic", "logs_config")
+            logs_config = config_json.get_configuration("logs_config")
             output_dir = logs_config.get("default_outpath", "/tmp")
 
         log.info(f"Log summary outpath set to {output_dir}")


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR Description
This PR rolls back an incorrect change introduced in a previous commit:

```
#### Incorrect
logs_config = config.get_topic_data("generic", "logs_config")
```

```
#### Restored
logs_config = config.get_configuration("logs_config")
```

## PR Checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).