### PR TITLE
Enhance build-schema dropdowns and update read-lab-metadata for new Excel format

### DIFF
--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -127,6 +127,18 @@ class LabMetadata(BaseModule):
         self.unique_sample_id = "sequencing_sample_id"
 
     def _split_institution(self, raw: str) -> tuple[str, str]:
+        """
+        Split a free-text institution string into:
+
+            1. **name** – the visible name without any bracketed tags.
+            2. **code** – the last bracketed element, assumed to be the CCN
+            (e.g. `[1328000027]`). If no second bracket exists, returns "".
+
+        Example
+        -------
+        _split_institution("Hospital X [Madrid] [1328000027]")
+        ("Hospital X", "1328000027")
+        """
         name = re.split(r"\s*\[", raw, maxsplit=1)[0].strip()
         brackets = re.findall(r"\[([^\]]+)\]", raw)
         code = brackets[-1].strip() if len(brackets) >= 2 else ""


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR Description

This PR introduces coordinated updates to the build-schema and read-lab-metadata modules to support richer dropdowns in the Excel template while preserving clean values in the JSON schema and downstream processing.

### build-schema improvements
**Dropdown format:** Lists for collecting / submitting institution fields now display entries as

```
{institution_name} [{geo_loc_city}] [{ccn}]
Example: Hospital Universitari Vall d'Hebron [Barcelona] [CAT-HUVH]
```

**Schema integrity:**
When the JSON schema is generated, only institution_name is retained in the enum, preventing city/CCN decorations from becoming part of the canonical value set.

### read-lab-metadata updates
**Smart parsing of new dropdown values**
Detects and splits the combined dropdown string, extracting {institution_name} for internal mapping.
**Configuration mapping**
Looks up collecting_institution_code_1 against configuration.json exactly as before, but with this new property.

## PR Checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`black and flake8`).
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).