### PR TITLE
Minor fix left in PR #741. `data` is directly included in api response

### DIFF
--- a/relecov_tools/rest_api.py
+++ b/relecov_tools/rest_api.py
@@ -187,6 +187,7 @@ class RestApi:
                 or data.get("message")
                 or "Unexpected error"
             )
+            data = data.get("data", data)
         else:
             if response.status_code not in success_codes:
                 message = "Unexpected error"


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR Checklist

- [X] This PR includes a small hotfix to directly include 'data' from response.json() if the key can be located, as it is the expected behaviour 
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).