### PR TITLE
Fix `"target_folders": ""` handling in `download` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Credits
 
+- [Alejandro Bernabeu](https://github.com/aberdur)
+
 #### Added enhancements
 
 #### Fixes
+
+- Fix "target_folders": "" handling in download module [#760](https://github.com/BU-ISCIII/relecov-tools/pull/760)
 
 #### Changed
 

--- a/relecov_tools/download.py
+++ b/relecov_tools/download.py
@@ -103,7 +103,16 @@ class Download(BaseModule):
         if sftp_user is None:
             sftp_user = relecov_tools.utils.prompt_text(msg="Enter the user id")
         if isinstance(self.target_folders, str):
-            self.target_folders = self.target_folders.strip("[").strip("]").split(",")
+            self.target_folders = [
+                f.strip()
+                for f in self.target_folders.strip("[").strip("]").split(",")
+                if f.strip()
+            ]
+        elif isinstance(self.target_folders, list):
+            self.target_folders = [f.strip() for f in self.target_folders if f.strip()]
+        if not self.target_folders:
+            self.target_folders = None
+
         self.logsum = self.parent_log_summary(output_dir=self.platform_storage_folder)
         if sftp_passwd is None:
             sftp_passwd = relecov_tools.utils.prompt_password(msg="Enter your password")


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR Description

This PR fixes an edge-case in the download module where an empty target_folders value in extra_config.json caused the run to crash instead of defaulting to “process every COD folder.”

**What happened before**

```
"download": {
  "target_folders": []    // or ""
}
```
The loader attempted to iterate over an empty list / string and raised a TypeError or ValueError, aborting the download.

## PR Checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).