### PR TITLE
Refactor read-bioinfo-metadata module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Included handling for already registered samples in the upload process [#774](https://github.com/BU-ISCIII/relecov-tools/pull/774)
 - Added new parameter `skip_upload_db` in `pipeline_manager` to allow skipping DB upload for testing purposes [#774](https://github.com/BU-ISCIII/relecov-tools/pull/774)
 - Support for using `unique_sample_id` as a key identifier in `read_bioinfo_metadata`, including fallback to combined ID format [#738](https://github.com/BU-ISCIII/relecov-tools/issues/738) [#775](https://github.com/BU-ISCIII/relecov-tools/pull/775)
+- Refactored `read_bioinfo_metadata` module for improved structure, readability, and maintainability [#777](https://github.com/BU-ISCIII/relecov-tools/pull/777)
 
 #### Fixes
 
@@ -34,8 +35,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Modified `upload_database` to accept `json_data` as either a path or a list of dicts [#774](https://github.com/BU-ISCIII/relecov-tools/pull/774)
 - `upload_database` now returns API upload results for downstream consumption [#774](https://github.com/BU-ISCIII/relecov-tools/pull/774)
 - Changed exit behavior in `pipeline_manager` to raise exceptions instead of using `exit(0)` [#774](https://github.com/BU-ISCIII/relecov-tools/pull/774)
-- Updated method signatures and added type annotations and docstrings for better code clarity [#774](https://github.com/BU-ISCIII/relecov-tools/pull/774)
+- Updated method signatures and added type annotations and docstring for better code clarity [#774](https://github.com/BU-ISCIII/relecov-tools/pull/774)
 - Enhanced `validate_samplenames` logic to support combined identifier format (`sequencing_sample_id_unique_sample_id`) when present [#738](https://github.com/BU-ISCIII/relecov-tools/issues/738) [#775](https://github.com/BU-ISCIII/relecov-tools/pull/775)
+- Renamed `add_bioinfo_files_path` to `map_and_extract_bioinfo_paths` in `read_bioinfo_metadata` for clarity and consistency [#777](https://github.com/BU-ISCIII/relecov-tools/pull/777)
 
 #### Removed
 

--- a/relecov_tools/assets/schema_utils/custom_validators.py
+++ b/relecov_tools/assets/schema_utils/custom_validators.py
@@ -2,6 +2,8 @@
 from jsonschema import FormatChecker, exceptions
 import datetime
 
+import relecov_tools.config_json
+
 
 def validate_with_exceptions(schema, data, errors):
     """Filter validation errors based on known exceptions.
@@ -29,7 +31,10 @@ def validate_with_exceptions(schema, data, errors):
         # allow not provided for numeric types
         if (
             error.validator == "type"
-            and error.instance == "Not Provided [SNOMED:434941000124101]"
+            and error.instance
+            == relecov_tools.config_json.ConfigJson().get_topic_data(
+                "generic", "not_provided_field"
+            )
             and prop_schema.get("type") in ["integer", "number"]
         ):
             continue
@@ -37,7 +42,10 @@ def validate_with_exceptions(schema, data, errors):
         # allow not provided for date format types
         if (
             error.validator == "format"
-            and error.instance == "Not Provided [SNOMED:434941000124101]"
+            and error.instance
+            == relecov_tools.config_json.ConfigJson().get_topic_data(
+                "generic", "not_provided_field"
+            )
             and prop_schema.get("type") == "string"
             and prop_schema.get("format") == "date"
         ):

--- a/relecov_tools/conf/configuration.json
+++ b/relecov_tools/conf/configuration.json
@@ -16,7 +16,8 @@
         "institution_mapping_file": {
             "ISCIII": "ISCIII.json",
             "HUGTiP": "HUGTiP.json"
-        }
+        },
+        "not_provided_field": "Not Provided [SNOMED:434941000124101]"
     },
     "pipeline_manager": {
         "analysis_group": "RLV",

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -1437,32 +1437,32 @@ class BioinfoMetadata(BaseModule):
         os.makedirs(out_path, exist_ok=True)
         batch_filepath = os.path.join(out_path, out_filename)
 
-        # Check samplesheet for matching samples
         self.validate_sample_names()
 
-        # Find and validate bioinfo files
         stderr.print("[blue]Scanning input directory...")
         self.log.info("Scanning input directory")
         files_found_dict = self.scan_directory()
+
         stderr.print("[blue]Validating required files...")
         self.log.info("Validating required files")
         self.validate_software_mandatory_files(files_found_dict)
+
         stderr.print("[blue]Adding bioinfo metadata to read lab metadata...")
         self.log.info("Adding bioinfo metadata to read lab metadata")
         self.j_data, extra_json_data = self.add_bioinfo_results_metadata(
             files_found_dict, file_tag, self.j_data, out_path
         )
+
         stderr.print("[blue]Adding fixed values")
         self.log.info("Adding fixed values")
         self.j_data = self.add_fixed_values(self.j_data, batch_filename)
-        # Adding files path
+
         stderr.print("[blue]Adding files path to read lab metadata")
         self.log.info("Adding files path to read lab metadata")
         self.j_data = self.map_and_extract_bioinfo_paths(files_found_dict, self.j_data)
 
-        # Dynamically import the function from the specified module
-        # to perform quality control evaluation
         stderr.print("[blue]Evaluating quality control...")
+        self.log.info("Evaluating quality control")
         module = importlib.import_module(
             f"relecov_tools.assets.pipeline_utils.{self.software_name}"
         )
@@ -1470,7 +1470,6 @@ class BioinfoMetadata(BaseModule):
             if hasattr(module, "quality_control_evaluation"):
                 qc_func = getattr(module, "quality_control_evaluation")
                 self.j_data = qc_func(self.j_data)
-
         except (AttributeError, NameError, TypeError, ValueError) as e:
             self.update_all_logs(
                 self.create_bioinfo_file.__name__,
@@ -1481,140 +1480,122 @@ class BioinfoMetadata(BaseModule):
                 f"[orange]Could not evaluate quality_control_evaluation for batch {self.j_data}: {e}"
             )
 
-        # Filter properties from batch_data that are not included in the schema
+        stderr.print("[blue]Validating bioinfo metadata...")
+        self.log.info("Validating bioinfo metadata")
+        if not self._validate_jdata_and_log_errors(out_path):
+            return False
+
+        stderr.print("[blue]Writing and splitting batches...")
+        self.log.info("Writing and splitting batches")
+        self._write_and_split_batches(
+            files_found_dict=files_found_dict,
+            batch_filepath=batch_filepath,
+            extra_json_data=extra_json_data,
+            out_path=out_path,
+        )
+
+        return True
+
+    def _validate_jdata_and_log_errors(self, out_path: str) -> bool:
         self.j_data = self.filter_properties(self.j_data)
+
         valid_rows, invalid_rows = relecov_tools.validate.Validate.validate_instances(
             self.j_data, self.json_schema, "sequencing_sample_id"
         )
-        valid_samples = [sample.get("sequencing_sample_id") for sample in valid_rows]
-        for sample in valid_samples:
-            self.logsum.feed_key(key=out_path, sample=sample)
+
+        for sample in valid_rows:
+            self.logsum.feed_key(key=out_path, sample=sample.get("sequencing_sample_id"))
+
         if invalid_rows:
-            unique_failed_samples = list(
-                {
-                    sample
-                    for samples in invalid_rows["samples"].values()
-                    for sample in samples
-                }
-            )
+            unique_failed_samples = list({
+                sample for samples in invalid_rows["samples"].values() for sample in samples
+            })
             for error_message, failed_samples in invalid_rows["samples"].items():
-                num_samples = len(failed_samples)
                 field_with_error = invalid_rows["fields"][error_message]
                 sample_list = "', '".join(failed_samples)
-                error_text = f"{error_message} in field '{field_with_error}' for {num_samples} sample/s: '{sample_list}'"
-                if len(unique_failed_samples) == len(self.j_data):
-                    self.logsum.add_error(key=out_path, entry=error_text)
-                else:
-                    self.logsum.add_warning(key=out_path, entry=error_text)
-                self.log.info(error_text)
-                stderr.print(f"[red]{error_text}")
-
+                error_text = (
+                    f"{error_message} in field '{field_with_error}' for {len(failed_samples)} sample/s: '{sample_list}'"
+                )
+                log_fn = self.logsum.add_error if len(unique_failed_samples) == len(self.j_data) else self.logsum.add_warning
+                log_fn(key=out_path, entry=error_text)
                 for fail_samp in failed_samples:
-                    self.logsum.add_error(
-                        key=out_path, sample=fail_samp, entry=error_text
-                    )
+                    self.logsum.add_error(key=out_path, sample=fail_samp, entry=error_text)
 
             if not self.soft_validation:
                 self.parent_create_error_summary(
                     called_module="read-bioinfo-metadata", logs=self.logsum.logs
                 )
-                error_msg = "Metadata was not completely validate, fix the errors or run with --soft_validation"
-                self.log.warning(error_msg)
-                stderr.print(f"[red]{error_msg}")
+                self.log.warning("Metadata was not completely validate, fix the errors or run with --soft_validation")
                 return False
-
         else:
-            stderr.print("[green]Bioinfo json successfully validated.")
+            self.j_data = valid_rows
             self.log.info("Bioinfo json successfully validated.")
 
-        self.j_data = valid_rows
+        return True
 
-        for sample in self.j_data:
-            self.logsum.feed_key(
-                key=out_path, sample=sample.get("sequencing_sample_id")
-            )
-
-        # Split files found based on each batch of samples
-        data_by_batch = self.split_data_by_batch(self.j_data)
-
-        if os.path.exists(batch_filepath):
-            stderr.print(
-                f"[blue]Bioinfo metadata {batch_filepath} file already exists. Merging new data if possible."
-            )
-            self.log.info(
-                f"Bioinfo metadata {batch_filepath} file already exists. Merging new data if possible."
-            )
-            self.j_data = self.merge_metadata(batch_filepath, self.j_data)
-        else:
-            relecov_tools.utils.write_json_to_file(self.j_data, batch_filepath)
-
+    def _write_and_split_batches(
+        self,
+        files_found_dict: dict,
+        batch_filepath: str,
+        extra_json_data: list[dict],
+        out_path: str,
+    ) -> None:
+        self.j_data = self._write_or_merge_json(batch_filepath, self.j_data)
         self.log.info(f"Created output json file: {batch_filepath}")
-        stderr.print(f"[green]Created batch json file: {batch_filepath}")
 
-        self.log.info("Splitting data by batch")
-        stderr.print("[blue]Splitting data by batch")
-
-        # Add bioinfo metadata to j_data
+        data_by_batch = self.split_data_by_batch(self.j_data)
         for batch_dir, batch_dict in data_by_batch.items():
             batch_data = batch_dict["j_data"]
             if not batch_data:
-                self.log.warning(
-                    f"Data from batch {batch_dir} was completely empty. Skipped."
-                )
+                self.log.warning(f"Data from batch {batch_dir} was completely empty. Skipped.")
                 self.update_all_logs(
                     self.create_bioinfo_file.__name__,
                     "warning",
                     f"Data from batch {batch_dir} was completely empty. Skipped.",
                 )
                 continue
-            first_sample = batch_data[0]
-            lab_code = first_sample.get(
-                "submitting_institution_id", batch_dir.split("/")[-2]
-            )
-            batch_date = first_sample.get("batch_id", batch_dir.split("/")[-1])
+
+            lab_code = batch_data[0].get("submitting_institution_id", batch_dir.split("/")[-2])
+            batch_date = batch_data[0].get("batch_id", batch_dir.split("/")[-1])
             file_tag = batch_date + "_" + self.hex
-            stderr.print(f"[blue]Processing data from {batch_dir}")
+
             self.log.info(f"Processing data from {batch_dir}")
+            self.split_tables_by_batch(files_found_dict, file_tag, batch_data, batch_dir)
 
-            self.split_tables_by_batch(
-                files_found_dict, file_tag, batch_data, batch_dir
-            )
-
-            tag = "bioinfo_lab_metadata_"
-            batch_filename = tag + lab_code + ".json"
-            batch_filename = self.tag_filename(batch_filename)
+            batch_filename = self.tag_filename("bioinfo_lab_metadata_" + lab_code + ".json")
             batch_filepath = os.path.join(batch_dir, batch_filename)
 
-            if os.path.exists(batch_filepath):
-                stderr.print(
-                    f"[blue]Bioinfo metadata {batch_filepath} file already exists. Merging new data if possible."
-                )
-                self.log.info(
-                    f"Bioinfo metadata {batch_filepath} file already exists. Merging new data if possible."
-                )
-                batch_data = self.merge_metadata(batch_filepath, batch_data)
-            else:
-                relecov_tools.utils.write_json_to_file(batch_data, batch_filepath)
-            for sample in batch_data:
-                self.logsum.feed_key(
-                    key=batch_dir, sample=sample.get("sequencing_sample_id")
-                )
+            batch_data = self._write_or_merge_json(batch_filepath, batch_data)
             self.log.info(f"Created output json file: {batch_filepath}")
-            stderr.print(f"[green]Created batch json file: {batch_filepath}")
+
+            for sample in batch_data:
+                self.logsum.feed_key(key=batch_dir, sample=sample.get("sequencing_sample_id"))
 
             for extra_json in extra_json_data:
-                filtered_batch_data, filename = self.split_extra_json_data(
-                    extra_json, batch_data
-                )
-
-                extra_filename = filename + "_" + lab_code + "_" + file_tag + ".json"
+                filtered_batch_data, filename = self.split_extra_json_data(extra_json, batch_data)
+                extra_filename = f"{filename}_{lab_code}_{file_tag}.json"
                 extra_filepath = os.path.join(batch_dir, extra_filename)
-
-                relecov_tools.utils.write_json_to_file(
-                    filtered_batch_data, extra_filepath
-                )
+                relecov_tools.utils.write_json_to_file(filtered_batch_data, extra_filepath)
 
         self.parent_create_error_summary(
             called_module="read-bioinfo-metadata", logs=self.logsum.logs
         )
-        return True
+
+    def _write_or_merge_json(self, filepath: str, data: list[dict]) -> list[dict]:
+        """
+        Writes data to a JSON file, or merges with existing data if the file already exists.
+
+        Args:
+            filepath (str): Path to the output JSON file.
+            data (list[dict]): List of dictionaries to write or merge.
+
+        Returns:
+            list[dict]: The resulting data after potential merge.
+        """
+        if os.path.exists(filepath):
+            stderr.print(f"[blue]Bioinfo metadata {filepath} file already exists. Merging new data if possible.")
+            self.log.info(f"Bioinfo metadata {filepath} file already exists. Merging new data if possible.")
+            return self.merge_metadata(filepath, data)
+
+        relecov_tools.utils.write_json_to_file(data, filepath)
+        return data

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -86,17 +86,20 @@ class BioinfoMetadata(BaseModule):
         super().__init__(output_dir=output_dir, called_module=__name__)
         self.log.info("Initiating read-bioinfo-metadata process")
 
-        self._init_json_schema(json_schema_file)
-        self._init_output_dir(output_dir)
-        self.logsum = self.parent_log_summary(output_dir=output_dir)
-        self.log_report = BioinfoReportLog()
-        self._init_readlabmeta_json(json_file)
-        self._init_j_data_and_batch()
+        # Init attributes
         self.update = update
         self.soft_validation = soft_validation
         self._init_input_folder(input_folder)
         self._init_software_name(software_name)
+        self._init_json_schema(json_schema_file)
+        self._init_output_dir(output_dir)
+        self._init_readlabmeta_json(json_file)
+        self._init_j_data_and_batch()
+
+        # Init logs
+        self.logsum = self.parent_log_summary(output_dir=output_dir)
         self._init_bioinfo_config()
+        self.log_report = BioinfoReportLog()
 
     def _init_json_schema(self, json_schema_file: str | None = None) -> None:
         """Initializes the JSON schema for bioinformatics metadata.

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -568,26 +568,27 @@ class BioinfoMetadata(BaseModule):
             field_errors (dict): Accumulator for mapping errors.
         """
         # Iterate over mapping fields and map values to the row
-        for field, value in mapping_fields.items():
+        for schema_field, table_field in mapping_fields.items():
             try:
                 # Get the raw value from map_data for the sample
-                raw_val = map_data[sample_name][value]
-                # Replace NA values if needed
-                raw_val = self.replace_na_value_if_needed(field, raw_val)
-                # get the expected type from the JSON schema
-                expected_type = (
-                    self.json_schema["properties"].get(field, {}).get("type", "string")
-                )
-                # convert the raw value to the expected type
-                row[field] = relecov_tools.utils.cast_value_to_schema_type(
-                    raw_val, expected_type
-                )
-                # assign the field to field value validated
-                field_valid[sample_name] = {field: value}
-
+                raw_val = map_data[sample_name][table_field]
             except KeyError as e:
-                field_errors[sample_name] = {field: str(e)}
-                row[field] = "Not Provided [SNOMED:434941000124101]"
+                field_errors[sample_name] = {schema_field: str(e)}
+                row[schema_field] = "Not Provided [SNOMED:434941000124101]"
+            # Replace NA values if needed
+            raw_val = self.replace_na_value_if_needed(schema_field, raw_val)
+            # get the expected type from the JSON schema
+            expected_type = (
+                self.json_schema["properties"]
+                .get(schema_field, {})
+                .get("type", "string")
+            )
+            # convert the raw value to the expected type
+            row[schema_field] = relecov_tools.utils.cast_value_to_schema_type(
+                raw_val, expected_type
+            )
+            # assign the field to field value validated
+            field_valid[sample_name] = {schema_field: table_field}
 
     def _map_non_multiple_sample(
         self,

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -428,7 +428,7 @@ class BioinfoMetadata(BaseModule):
         j_data: list[dict],
         map_data: dict,
         mapping_fields: dict,
-        table_name: str,
+        table_name: list[str],
     ) -> list[dict]:
         """
         Maps bioinformatics metadata from map_data to j_data based on the mapping_fields.
@@ -437,7 +437,7 @@ class BioinfoMetadata(BaseModule):
             j_data (list[dict]): Metadata from the lab (one item per sample).
             map_data (dict): Processed bioinformatic metadata, indexed by sample name.
             mapping_fields (dict): Mapping from JSON fields to software fields as defined in the config.
-            table_name (str): Name or path of the mapping table.
+            table_name (list[str]): Name or path of the mapping table.
 
         Returns:
             list[dict]: The updated j_data list with mapped bioinformatic fields.

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -814,7 +814,9 @@ class BioinfoMetadata(BaseModule):
             return None, data
         return data, None
 
-    def extract_sample_metadata_from_table(self, file_list: list, conf_tab_name: str) -> dict:
+    def extract_sample_metadata_from_table(
+        self, file_list: list, conf_tab_name: str
+    ) -> dict:
         """Reads a tabular file in different formats and returns a dictionary containing
         the corresponding data for each sample.
 
@@ -1421,7 +1423,7 @@ class BioinfoMetadata(BaseModule):
         return filtered_batch_data, filename
 
     def _validate_jdata_and_log_errors(self, out_path: str) -> bool:
-        """ Validate the j_data against the JSON schema and log errors if any.
+        """Validate the j_data against the JSON schema and log errors if any.
 
         Args:
         out_path (str)
@@ -1484,7 +1486,7 @@ class BioinfoMetadata(BaseModule):
         batch_filepath: str,
         extra_json_data: list[dict],
     ) -> None:
-        """ Splits json data by batch and writes it to the output file.
+        """Splits json data by batch and writes it to the output file.
 
         Args:
         files_found_dict

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -1472,7 +1472,9 @@ class BioinfoMetadata(BaseModule):
                 self.log.warning(
                     "Metadata was not completely validate, fix the errors or run with --soft_validation"
                 )
-                stderr.print("Metadata was not completely validate, fix the errors or run with --soft_validation")
+                stderr.print(
+                    "Metadata was not completely validate, fix the errors or run with --soft_validation"
+                )
                 return False
         else:
             self.j_data = valid_rows

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -85,10 +85,15 @@ class BioinfoMetadata(BaseModule):
 
         super().__init__(output_dir=output_dir, called_module=__name__)
         self.log.info("Initiating read-bioinfo-metadata process")
-
-        # Init attributes
+        # Init params
         self.update = update
         self.soft_validation = soft_validation
+
+        # Init logs
+        self.log_report = BioinfoReportLog()
+        self.logsum = self.parent_log_summary(output_dir=output_dir)
+
+        # Init attributes
         self._init_input_folder(input_folder)
         self._init_software_name(software_name)
         self._init_json_schema(json_schema_file)
@@ -96,10 +101,8 @@ class BioinfoMetadata(BaseModule):
         self._init_readlabmeta_json(json_file)
         self._init_j_data_and_batch()
 
-        # Init logs
-        self.logsum = self.parent_log_summary(output_dir=output_dir)
+        # Init config
         self._init_bioinfo_config()
-        self.log_report = BioinfoReportLog()
 
     def _init_json_schema(self, json_schema_file: str | None = None) -> None:
         """Initializes the JSON schema for bioinformatics metadata.

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -98,7 +98,16 @@ class BioinfoMetadata(BaseModule):
         self._init_software_name(software_name)
         self._init_bioinfo_config()
 
-    def _init_json_schema(self, json_schema_file):
+    def _init_json_schema(self, json_schema_file: str | None = None) -> None:
+        """Initializes the JSON schema for bioinformatics metadata.
+
+        Args:
+            json_schema_file (str) optional
+                Path to the JSON schema file. If not provided, it will use the default schema defined in the config.
+
+        Returns:
+            None
+        """
         if json_schema_file is None:
             config_json = ConfigJson()
             schema_name = config_json.get_topic_data("generic", "relecov_schema")
@@ -107,7 +116,16 @@ class BioinfoMetadata(BaseModule):
             )
         self.json_schema = relecov_tools.utils.read_json_file(json_schema_file)
 
-    def _init_output_dir(self, output_dir):
+    def _init_output_dir(self, output_dir: str | None = None) -> None:
+        """Initializes the output directory for storing results.
+
+        Args:
+            output_dir (str | None)
+                Path to the output directory. If not provided, it will prompt the user to select one.
+
+        Returns:
+            None
+        """
         if output_dir is None:
             self.output_dir = relecov_tools.utils.prompt_path(
                 msg="Select the output folder"
@@ -115,7 +133,19 @@ class BioinfoMetadata(BaseModule):
         else:
             self.output_dir = os.path.realpath(output_dir)
 
-    def _init_readlabmeta_json(self, json_file):
+    def _init_readlabmeta_json(self, json_file: str | None = None) -> None:
+        """Initializes the readlab metadata JSON file.
+
+        Args:
+            json_file (str | None): Path to the readlab metadata JSON file.
+            If not provided, it will prompt the user to select one.
+
+        Raises:
+            ValueError
+                If the provided JSON file does not exist or is not a valid file.
+        Returns:
+            None
+        """
         if json_file is None:
             json_file = relecov_tools.utils.prompt_path(
                 msg="Select the json file that was created by the pipeline-manager or read-lab-metadata module."
@@ -130,13 +160,27 @@ class BioinfoMetadata(BaseModule):
             raise ValueError(f"Json file {json_file} does not exist, cannot continue.")
         self.readlabmeta_json_file = json_file
 
-    def _init_j_data_and_batch(self):
+    def _init_j_data_and_batch(self) -> None:
+        """Initializes the j_data and batch ID from the readlab metadata JSON file.
+        Args:
+            None
+        Returns:
+            None
+        """
         stderr.print("[blue]Reading lab metadata json")
         self.j_data = self.collect_info_from_lab_json()
         batch_id = self.get_batch_id_from_data(self.j_data)
         self.set_batch_id(batch_id)
 
-    def _init_input_folder(self, input_folder):
+    def _init_input_folder(self, input_folder: str | None = None) -> None:
+        """Initializes the input folder for bioinformatics analysis files.
+
+        Args:
+        input_folder (str | None)
+            Path to the input folder. If not provided, it will prompt the user to select one.
+        Returns:
+            None
+        """
         if input_folder is None:
             self.input_folder = relecov_tools.utils.prompt_path(
                 msg="Select the input folder"
@@ -144,7 +188,21 @@ class BioinfoMetadata(BaseModule):
         else:
             self.input_folder = input_folder
 
-    def _init_software_name(self, software_name):
+    def _init_software_name(self, software_name: str | None = None) -> None:
+        """Initializes the software name used in the bioinformatic analysis.
+
+        Args:
+        software_name (str | None)
+            Name of the software, pipeline or tool used in the bioinformatic analysis.
+            If not provided, it will prompt the user to select one.
+
+        Raises:
+        ValueError
+            If no software name is provided, it raises a ValueError and logs an error message.
+
+        Returns:
+            None
+        """
         if software_name is None:
             software_name = relecov_tools.utils.prompt_path(
                 msg="Select the software, pipeline or tool use in the bioinformatic analysis: "
@@ -160,7 +218,15 @@ class BioinfoMetadata(BaseModule):
             self.log_report.print_log_report(self.__init__.__name__, ["error"])
             raise ValueError("No software name provided, cannot continue.")
 
-    def _init_bioinfo_config(self):
+    def _init_bioinfo_config(self) -> None:
+        """Initializes the bioinformatics configuration based on the provided software name.
+
+        Raises:
+        ValueError
+            If the software name is not found in the available software configurations or if no configuration is found for the given software name.
+        ValueError
+            If no configuration is available for the given software name, it raises a ValueError and logs an error message.
+        """
         self.bioinfo_json_file = os.path.join(
             os.path.dirname(__file__), "conf", "bioinfo_config.json"
         )
@@ -226,9 +292,7 @@ class BioinfoMetadata(BaseModule):
 
         # Get the total number of files and scanned files in all folders in self.input_folder
         total_files, scanned_files_per_folder = self._walk_input_folder()
-        files_found = self._find_matching_files(
-            method_name, scanned_files_per_folder
-        )
+        files_found = self._find_matching_files(method_name, scanned_files_per_folder)
         # search for files matching the patterns defined in the software configuration
         if files_found:
             # If files are found, update the log report and return the files_found dictionary
@@ -253,7 +317,7 @@ class BioinfoMetadata(BaseModule):
 
     def _walk_input_folder(self) -> tuple[int, list[tuple[str, list[str]]]]:
         """Walk through the input folder and collect all files.
-        Returns: 
+        Returns:
         """
         total_files = 0
         scanned_files_per_folder = []
@@ -268,13 +332,13 @@ class BioinfoMetadata(BaseModule):
         self, method_name: str, scanned_files_per_folder: list[tuple[str, list[str]]]
     ) -> dict[str, list[str]]:
         """For each topic in the software configuration, search for matching files.
-            
-            Args:
-            scanned_files_per_folder (list[tuple[str, list[str]]]): A list of tuples containing the root path and a list of files in that path.
-            method_name (str): The name of the method being logged.
-            
-            Returns:
-            files_found (dict): A dictionary containing file paths found based on the definitions provided in the bioinformatic JSON file within the software scope (self.software_config).
+
+        Args:
+        scanned_files_per_folder (list[tuple[str, list[str]]]): A list of tuples containing the root path and a list of files in that path.
+        method_name (str): The name of the method being logged.
+
+        Returns:
+        files_found (dict): A dictionary containing file paths found based on the definitions provided in the bioinformatic JSON file within the software scope (self.software_config).
         """
         files_found = {}
 

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -1282,7 +1282,6 @@ class BioinfoMetadata(BaseModule):
                         log_type,
                         f"Could not create batch table for {file}: {e}",
                     )
-        self.log_report.print_log_report(method_name, ["valid", "warning", "error"])
         return
 
     def merge_metadata(self, batch_filepath: str, batch_data: list[dict]) -> list[dict]:
@@ -1473,10 +1472,12 @@ class BioinfoMetadata(BaseModule):
                 self.log.warning(
                     "Metadata was not completely validate, fix the errors or run with --soft_validation"
                 )
+                stderr.print("Metadata was not completely validate, fix the errors or run with --soft_validation")
                 return False
         else:
             self.j_data = valid_rows
             self.log.info("Bioinfo json successfully validated.")
+            stderr.print("[green] Bioinfo json successfully validated.")
 
         return True
 
@@ -1498,7 +1499,8 @@ class BioinfoMetadata(BaseModule):
             batch_data.
         """
         self.j_data = self._write_or_merge_json(batch_filepath, self.j_data)
-        self.log.info(f"Created output json file: {batch_filepath}")
+        self.log.info(f"Created complete batch json file: {batch_filepath}")
+        stderr.print(f"Created complete batch json file: {batch_filepath}")
 
         data_by_batch = self.split_data_by_batch(self.j_data)
         for batch_dir, batch_dict in data_by_batch.items():
@@ -1531,7 +1533,8 @@ class BioinfoMetadata(BaseModule):
             batch_filepath = os.path.join(batch_dir, batch_filename)
 
             batch_data = self._write_or_merge_json(batch_filepath, batch_data)
-            self.log.info(f"Created output json file: {batch_filepath}")
+            self.log.info(f"Created output laboratory json file: {batch_filepath}")
+            stderr.print(f"Created output laboratory json file: {batch_filepath}")
 
             for sample in batch_data:
                 self.logsum.feed_key(

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -452,9 +452,8 @@ class BioinfoMetadata(BaseModule):
         sample_ids = {
             sample_name for row in j_data if (sample_name := self._get_sample_name(row))
         }
-        matched_samples = sample_ids & set(map_data.keys())
         # check if samples from j_data match the samples in map_data
-        no_samples = not matched_samples
+        matched_samples = sample_ids & set(map_data.keys())
 
         # iterate over j_data
         for row in j_data:
@@ -484,7 +483,7 @@ class BioinfoMetadata(BaseModule):
                 not self.software_config[self.current_config_key].get(
                     "multiple_samples"
                 )
-                and no_samples
+                and not matched_samples
             ):
                 self._map_non_multiple_sample(
                     row, map_data, mapping_fields, field_valid, field_errors

--- a/relecov_tools/read_bioinfo_metadata.py
+++ b/relecov_tools/read_bioinfo_metadata.py
@@ -492,7 +492,9 @@ class BioinfoMetadata(BaseModule):
             else:
                 errors.append(sample_name)
                 for field in mapping_fields:
-                    row[field] = "Not Provided [SNOMED:434941000124101]"
+                    row[field] = self.config_json.get_topic_data(
+                        "generic", "not_provided_field"
+                    )
 
         # work around when map_data comes from several per-sample tables/files instead of single table
         # get the dirname where the tables/files are or basename of the table_name

--- a/relecov_tools/read_lab_metadata.py
+++ b/relecov_tools/read_lab_metadata.py
@@ -73,15 +73,17 @@ class LabMetadata(BaseModule):
         else:
             self.output_dir = output_dir
 
-        config_json = ConfigJson(extra_config=True)
+        self.config_json = ConfigJson(extra_config=True)
 
         # TODO: remove hardcoded schema selection
-        relecov_schema = config_json.get_topic_data("generic", "relecov_schema")
+        relecov_schema = self.config_json.get_topic_data("generic", "relecov_schema")
         relecov_sch_path = os.path.join(
             os.path.dirname(os.path.realpath(__file__)), "schema", relecov_schema
         )
-        self.configuration = config_json
-        self.institution_config = config_json.get_configuration("institutions_config")
+        self.configuration = self.config_json
+        self.institution_config = self.config_json.get_configuration(
+            "institutions_config"
+        )
 
         out_path = os.path.realpath(self.output_dir)
         self.lab_code = out_path.split("/")[-2]
@@ -113,15 +115,15 @@ class LabMetadata(BaseModule):
                 )
                 continue
         self.date = dtime.now().strftime("%Y%m%d%H%M%S")
-        self.json_req_files = config_json.get_topic_data(
+        self.json_req_files = self.config_json.get_topic_data(
             "read_lab_metadata", "lab_metadata_req_json"
         )
         self.schema_name = self.relecov_sch_json["title"]
         self.schema_version = self.relecov_sch_json["version"]
-        self.metadata_processing = config_json.get_topic_data(
+        self.metadata_processing = self.config_json.get_topic_data(
             "sftp_handle", "metadata_processing"
         )
-        self.samples_json_fields = config_json.get_topic_data(
+        self.samples_json_fields = self.config_json.get_topic_data(
             "read_lab_metadata", "samples_json_fields"
         )
         self.unique_sample_id = "sequencing_sample_id"
@@ -143,7 +145,7 @@ class LabMetadata(BaseModule):
             try:
                 return relecov_tools.utils.calculate_md5(file)
             except IOError:
-                return "Not Provided [SNOMED:434941000124101]"
+                return self.config_json.get_topic_data("generic", "not_provided_field")
 
         # The files are and md5file are supposed to be located together
         dir_path = self.files_folder
@@ -401,7 +403,9 @@ class LabMetadata(BaseModule):
                         continue
                     # TODO: Include Not Provided as a configuration field
                     fields_to_add = {
-                        x: "Not Provided [SNOMED:434941000124101]"
+                        x: self.config_json.get_topic_data(
+                            "generic", "not_provided_field"
+                        )
                         for x in json_fields["adding_fields"]
                     }
                     m_data[idx].update(fields_to_add)
@@ -444,7 +448,9 @@ class LabMetadata(BaseModule):
             if file_format_val:
                 row["file_format"] = file_format_val
             else:
-                row["file_format"] = "Not Provided [SNOMED:434941000124101]"
+                row["file_format"] = self.config_json.get_topic_data(
+                    "generic", "not_provided_field"
+                )
 
         return metadata
 

--- a/relecov_tools/utils.py
+++ b/relecov_tools/utils.py
@@ -28,6 +28,8 @@ import semantic_version
 import subprocess
 import importlib.metadata
 
+import relecov_tools.config_json
+
 log = logging.getLogger(__name__)
 
 
@@ -96,7 +98,11 @@ def read_excel_file(f_name, sheet_name, header_flag, leave_empty=True):
             for idx in range(0, len(heading)):
                 if l_row[idx] is None:
                     data_row[heading[idx]] = (
-                        None if leave_empty else "Not Provided [SNOMED:434941000124101]"
+                        None
+                        if leave_empty
+                        else relecov_tools.config_json.ConfigJson().get_topic_data(
+                            "generic", "not_provided_field"
+                        )
                     )
                 else:
                     data_row[heading[idx]] = l_row[idx]
@@ -126,7 +132,9 @@ def read_excel_file(f_name, sheet_name, header_flag, leave_empty=True):
                         data_row[heading[idx]] = (
                             None
                             if leave_empty
-                            else "Not Provided [SNOMED:434941000124101]"
+                            else relecov_tools.config_json.ConfigJson().get_topic_data(
+                                "generic", "not_provided_field"
+                            )
                         )
                     else:
                         data_row[heading[idx]] = val


### PR DESCRIPTION
This pull request performs a comprehensive refactor of the `read_bioinfo_metadata` module to improve clarity, structure, and maintainability, while preserving functionality.

### read_bioinfo_metadata module
- Refactored `__init__` method using internal auxiliary methods for improved modularity
- Reorganized initialization blocks and added inline comments for clarity
- Refactored `scan_directory` for improved readability and logic flow
- Simplified conditionals and renamed variables for consistency and clarity
- Added type annotations and detailed docstrings to new auxiliary methods
- Refactored `mapping_over_sample` for more transparent data handling
- Renamed and refactored `add_bioinfo_files_path` to `map_and_extract_bioinfo_paths`
- Refactored `add_bioinfo_results_metadata` and `create_bioinfo_files` to reduce complexity and improve naming
- Performed minor spelling corrections and added missing comments/docstrings throughout

### Related Issues
N/A

<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR Checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).