### PR TITLE
Fix `data` completeness in `rest_api.standardize_response`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 #### Fixes
 
 - Remove sample_fingerprint from upload-database module [#790](https://github.com/BU-ISCIII/relecov-tools/pull/790)
+- Fix data completeness in rest_api.standardize_response [#791](https://github.com/BU-ISCIII/relecov-tools/pull/791)
 
 #### Changed
 

--- a/relecov_tools/rest_api.py
+++ b/relecov_tools/rest_api.py
@@ -267,7 +267,17 @@ class RestApi:
                 result["data"] = payload["data"]
             else:
                 _, alt_data = _first_key(payload, list(data_keys))
-                result["data"] = alt_data if alt_data is not None else {}
+                if alt_data is not None:
+                    result["data"] = alt_data
+                else:
+                    # fallback: use all non-canonical keys
+                    canon_keys = set(message_keys) | set(error_keys) | set(data_keys)
+                    canon_keys |= {"message", "ERROR", "data"}
+                    extra = {k: v for k, v in payload.items() if k not in canon_keys}
+                    if extra:
+                        result["data"] = extra
+                    else:
+                        result["data"] = {}
 
             # If HTTP status is not success and API did not include ERROR, synthesize it
             if not is_success and "ERROR" not in result:


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR Description
This PR improves the `RestApi.standardize_response()` method to ensure that when an API response does not include any of the expected `data` keys (`data`, `payload`, `result`), the remaining non-canonical keys are preserved under `result["data"]`.  

Previously, such responses resulted in an empty `data` object, even if the payload contained useful fields. Now, all keys except `message` and `error` (and their aliases) are captured as part of `data`, avoiding silent data loss.  

## PR Checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).