### PR TITLE
Fix list handling in `rest_api.py`; Fix download invalid_folder processing; Fix pipeline-manager R1 check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Remove sample_fingerprint from upload-database module [#790](https://github.com/BU-ISCIII/relecov-tools/pull/790)
 - Fix data completeness in rest_api.standardize_response [#791](https://github.com/BU-ISCIII/relecov-tools/pull/791)
-- Fix list handling in rest_api.py [#792](https://github.com/BU-ISCIII/relecov-tools/pull/792)
+- Fix list handling in rest_api.py; Fix download invalid_folder processing; Fix pipeline-manager R1 check [#792](https://github.com/BU-ISCIII/relecov-tools/pull/792)
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Remove sample_fingerprint from upload-database module [#790](https://github.com/BU-ISCIII/relecov-tools/pull/790)
 - Fix data completeness in rest_api.standardize_response [#791](https://github.com/BU-ISCIII/relecov-tools/pull/791)
+- Fix list handling in rest_api.py [#792](https://github.com/BU-ISCIII/relecov-tools/pull/792)
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Remove sample_fingerprint from upload-database module [#790](https://github.com/BU-ISCIII/relecov-tools/pull/790)
 - Fix data completeness in rest_api.standardize_response [#791](https://github.com/BU-ISCIII/relecov-tools/pull/791)
-- Fix list handling in rest_api.py; Fix download invalid_folder processing; Fix pipeline-manager R1 check [#792](https://github.com/BU-ISCIII/relecov-tools/pull/792)
+- Fix list handling in rest_api.py [#792](https://github.com/BU-ISCIII/relecov-tools/pull/792)
+- Fix download invalid_folder processing [#792](https://github.com/BU-ISCIII/relecov-tools/pull/792)
+- Fix pipeline-manager R1 check [#792](https://github.com/BU-ISCIII/relecov-tools/pull/792)
 
 #### Changed
 

--- a/relecov_tools/download.py
+++ b/relecov_tools/download.py
@@ -508,6 +508,7 @@ class Download(BaseModule):
                     log_text = "Sequence File R1 not defined in Metadata for sample %s"
                     stderr.print(f"[red]{str(log_text % s_name)}")
                     self.include_error(entry=str(log_text % s_name), sample=s_name)
+                    continue
                 try:
                     if not row[index_layout]:
                         error_text = "Missing 'Library Layout' value for sample %s."
@@ -1363,6 +1364,9 @@ class Download(BaseModule):
             self.log.info("Finished download for folder: %s", folder)
             stderr.print(f"Finished download for folder {folder}")
             remote_md5sum = self.find_remote_md5sum(folder)
+            remote_md5_basename = (
+                os.path.basename(remote_md5sum) if remote_md5sum else None
+            )
             corrupted = []
             if remote_md5sum and fetched_files:
                 # Get the md5checksum to validate integrity of files after download
@@ -1507,7 +1511,10 @@ class Download(BaseModule):
                     )
             self.log.info(f"Finished processing {folder}")
             stderr.print(f"[green]Finished processing {folder}")
-            self.finished_folders[folder] = list(files_md5_dict.keys())
+            downloaded_items = list(files_md5_dict.keys())
+            if remote_md5_basename:
+                downloaded_items.append(remote_md5_basename)
+            self.finished_folders[folder] = downloaded_items
             self.finished_folders[folder].append(meta_file)
         return
 

--- a/relecov_tools/rest_api.py
+++ b/relecov_tools/rest_api.py
@@ -283,6 +283,20 @@ class RestApi:
             if not is_success and "ERROR" not in result:
                 result["ERROR"] = result["message"] or f"HTTP {status_code}"
 
+        elif isinstance(payload, list):
+            # JSON list payload (e.g., sample-info returning rows). Keep as data.
+            if is_success:
+                result["message"] = (
+                    "OK"
+                    if not isinstance(payload, dict)
+                    else result.get("message", "OK")
+                )
+                result["data"] = payload
+            else:
+                # On error with list (unlikely), still surface as data and set message
+                result["message"] = "Unexpected error"
+                result["data"] = payload
+
         else:
             # Non-JSON response
             text = ""


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR Description
This PR fixes data handling as a list. Previously, when data was received, it remained empty.
Closses #763 #793 and #794.

## PR Checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).