### PR TITLE
Fixed `create_summary_tables.py` to properly create variant files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 #### Fixes
 
 - Fixed wrong message and keyerror when uploading to iskylims [#803](https://github.com/BU-ISCIII/relecov-tools/pull/803)
+- Fixed create_summary_tables.py to properly create csv variant files [#809](https://github.com/BU-ISCIII/relecov-tools/pull/809).
 
 #### Changed
 

--- a/relecov_tools/assets/pipeline_utils/create_summary_tables.py
+++ b/relecov_tools/assets/pipeline_utils/create_summary_tables.py
@@ -144,6 +144,9 @@ def process_json_files(
                                 "MICROBIOLOGY_LAB_SAMPLE_ID": sample.get(
                                     "microbiology_lab_sample_id", "-"
                                 ),
+                                "CONSENSUS_SEQUENCE_FILENAME": sample.get(
+                                    "consensus_sequence_filename", "-"
+                                ),
                                 "GISAID_ACCESSION_ID": sample.get(
                                     "gisaid_accession_id", "-"
                                 ),
@@ -182,7 +185,7 @@ def process_json_files(
                         sample_variant_data[sample_id] = sample
                         # Determination of the season for each sample
                         for entry in all_data:
-                            if str(entry["SEQUENCING_SAMPLE_ID"]) == sample_id:
+                            if str(entry["CONSENSUS_SEQUENCE_FILENAME"]) == sample_id:
                                 season = entry["SEASON"]
                                 variant_entries = sample.get("variants", [])
                                 for variant in variant_entries:


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR Checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## PR Checklist

As per the title, this PR fixes a bug in `create_summary_tables.py` so that csv variant files are created properly.