### PR TITLE
Hotfix: Left modules_outpath empty to fix sftp_modules workflow

### DIFF
--- a/relecov_tools/conf/initial_config-relecov.yaml
+++ b/relecov_tools/conf/initial_config-relecov.yaml
@@ -13,11 +13,7 @@ generic:
   project_name: "Relecov"
   logs_config:
     default_outpath: /tmp/
-    modules_outpath:
-      wrapper: /tmp/wrapper
-      download: /tmp/download
-      pipeline_manager: /tmp/pipeline_manager
-      read_bioinfo_metadata: /tmp/read_bioinfo_metadata
+    modules_outpath: {}
   json_schemas:
     relecov_schema: relecov_schema.json
     ena_schema: ena_schema.json


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR Checklist

- [X] /tmp does not exist in github actions machines so it caused the tests of sftp_modules.yaml to fail. This hotfix solves the issue.
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).