### PR TITLE
Add background execution mode for wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.8.X] - 2026-XX-XX : <https://github.com/BU-ISCIII/relecov-tools/releases/tag/v1.8.X>
+## [1.8.1dev] - 2026-XX-XX : <https://github.com/BU-ISCIII/relecov-tools/releases/tag/v1.8.1dev>
 
 ### Credits
 
 - [Pablo Mata](https://github.com/shettland)
 - [Pau Pascual Mas](https://github.com/PauPascualMas)
 - [Alba Talavera](https://github.com/albatalavera)
+- [Alejandro Bernabeu](https://github.com/aberdur)
 
 #### Added enhancements
+
+- Add background execution mode for wrapper [#880](https://github.com/BU-ISCIII/relecov-tools/pull/880)
 
 #### Fixes
 

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ Usage: relecov-tools wrapper [OPTIONS]
 Options:
   -c, --config_file PATH    Path to config file in yaml format  [required]
   -o, --output_dir,         Directory where the generated output will be saved [required].
-  --background, --nohup     Launch wrapper in a detached background process and return immediately.
+  -bg, --background         Launch wrapper in a detached background process and return immediately.
   --background-log PATH     File where detached wrapper stdout/stderr will be written.
   --help                    Show this message and exit.
 ```

--- a/README.md
+++ b/README.md
@@ -465,8 +465,22 @@ Usage: relecov-tools wrapper [OPTIONS]
 Options:
   -c, --config_file PATH    Path to config file in yaml format  [required]
   -o, --output_dir,         Directory where the generated output will be saved [required].
+  --background, --nohup     Launch wrapper in a detached background process and return immediately.
+  --background-log PATH     File where detached wrapper stdout/stderr will be written.
   --help                    Show this message and exit.
 ```
+
+To keep a wrapper run alive after closing the VPN/SSH session:
+
+```
+relecov-tools wrapper --output_dir /path/to/output --background
+```
+
+By default, detached output is written to `wrapper_background_<timestamp>.log` in the
+configured wrapper log directory when available. If no wrapper log directory is
+configured, it falls back to the output directory. Use
+`--background-log /path/to/wrapper.log` to choose a custom file. The usual module logs
+and reports are still generated in their configured locations.
 
 #### logs-to-excel
 

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -2,6 +2,8 @@
 import logging
 import os
 import json
+import shlex
+import subprocess
 import sys
 from datetime import datetime
 import inspect
@@ -103,6 +105,71 @@ def merge_with_extra_config(ctx, add_extra_config=False):
     valid_keys = sig.parameters.keys()
     filtered = {k: v for k, v in merged.items() if k in valid_keys}
     return filtered
+
+
+def _strip_background_options(argv):
+    """Return argv without wrapper background-only options."""
+    stripped = []
+    skip_next = False
+    value_options = {"--background-log"}
+    flag_options = {"--background", "--nohup"}
+
+    for index, arg in enumerate(argv):
+        if skip_next:
+            skip_next = False
+            continue
+        if arg in flag_options:
+            continue
+        if arg in value_options:
+            if index + 1 < len(argv):
+                skip_next = True
+            continue
+        if any(arg.startswith(f"{option}=") for option in value_options):
+            continue
+        stripped.append(arg)
+    return stripped
+
+
+def _default_background_log_path(output_dir=None, log_dir=None):
+    if log_dir is None and relecov_tools.base_module.BaseModule._cli_log_file:
+        log_dir = os.path.dirname(relecov_tools.base_module.BaseModule._cli_log_file)
+    log_dir = log_dir or output_dir or os.path.join("/tmp", "relecov_tools")
+    timestamp = datetime.today().strftime("%Y%m%d%H%M%S")
+    return os.path.realpath(os.path.join(log_dir, f"wrapper_background_{timestamp}.log"))
+
+
+def _build_background_command(argv=None):
+    argv = list(argv or sys.argv)
+    stripped_argv = _strip_background_options(argv)
+    if stripped_argv and os.path.isfile(stripped_argv[0]):
+        return [sys.executable] + stripped_argv
+    return [sys.executable, "-m", "relecov_tools"] + stripped_argv[1:]
+
+
+def _launch_background_wrapper(output_dir=None, background_log=None):
+    command = _build_background_command()
+    log_filepath = os.path.realpath(
+        background_log or _default_background_log_path(output_dir)
+    )
+    os.makedirs(os.path.dirname(log_filepath), exist_ok=True)
+
+    env = os.environ.copy()
+    env["RELECOV_TOOLS_BACKGROUND_CHILD"] = "1"
+    with open(log_filepath, "ab", buffering=0) as log_handle:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            close_fds=True,
+            start_new_session=True,
+            env=env,
+        )
+    return process.pid, log_filepath, command
+
+
+def _format_command(command):
+    return " ".join(shlex.quote(part) for part in command)
 
 
 def run_relecov_tools():
@@ -1292,10 +1359,36 @@ def logs_to_excel(ctx, lab_code, output_dir, files):
     type=click.Path(file_okay=False, resolve_path=True),
     help="Directory where the generated output will be saved",
 )
+@click.option(
+    "--background",
+    "--nohup",
+    "background",
+    is_flag=True,
+    default=False,
+    help="Launch wrapper in a detached background process and return immediately.",
+)
+@click.option(
+    "--background-log",
+    type=click.Path(dir_okay=False, resolve_path=True),
+    default=None,
+    help="File where detached wrapper stdout/stderr will be written.",
+)
 @click.pass_context
-def wrapper(ctx, output_dir):
+def wrapper(ctx, output_dir, background, background_log):
     """Executes the modules in config file sequentially"""
+    if background:
+        pid, log_filepath, command = _launch_background_wrapper(
+            output_dir=output_dir, background_log=background_log
+        )
+        log.info("Detached wrapper process started with PID %s", pid)
+        stderr.print(f"[green]Wrapper launched in background with PID {pid}")
+        stderr.print(f"[blue]Output log: {log_filepath}")
+        stderr.print(f"[dim]Command: {_format_command(command)}")
+        return
+
     args_merged = merge_with_extra_config(ctx=ctx, add_extra_config=True)
+    args_merged.pop("background", None)
+    args_merged.pop("background_log", None)
     debug = ctx.obj.get("debug", False)
 
     try:

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -135,7 +135,9 @@ def _default_background_log_path(output_dir=None, log_dir=None):
         log_dir = os.path.dirname(relecov_tools.base_module.BaseModule._cli_log_file)
     log_dir = log_dir or output_dir or os.path.join("/tmp", "relecov_tools")
     timestamp = datetime.today().strftime("%Y%m%d%H%M%S")
-    return os.path.realpath(os.path.join(log_dir, f"wrapper_background_{timestamp}.log"))
+    return os.path.realpath(
+        os.path.join(log_dir, f"wrapper_background_{timestamp}.log")
+    )
 
 
 def _build_background_command(argv=None):

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -112,7 +112,7 @@ def _strip_background_options(argv):
     stripped = []
     skip_next = False
     value_options = {"--background-log"}
-    flag_options = {"--background", "--nohup"}
+    flag_options = {"-bg", "--background"}
 
     for index, arg in enumerate(argv):
         if skip_next:
@@ -1362,8 +1362,8 @@ def logs_to_excel(ctx, lab_code, output_dir, files):
     help="Directory where the generated output will be saved",
 )
 @click.option(
+    "-bg",
     "--background",
-    "--nohup",
     "background",
     is_flag=True,
     default=False,


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->
## PR Description
Adds a detached background execution mode for the `wrapper` command so long-running runs survive VPN or SSH session drops.

### Changes

- Adds `--background` with `--nohup` as an alias for `relecov-tools wrapper`.
- Adds `--background-log` to explicitly choose the detached stdout/stderr log file.
- Redirects detached process output to the configured wrapper log directory when available.
- Falls back to `--output_dir` or `/tmp/relecov_tools` when no wrapper log directory is configured.
- Documents the new usage in the README.

## PR Checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).