### PR TITLE
Added support for configurable enum sources, template-only fields, and AMR metadata JSON generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add background execution mode for wrapper [#880](https://github.com/BU-ISCIII/relecov-tools/pull/880)
 - Add weekly SFTP upload report [#881](https://github.com/BU-ISCIII/relecov-tools/pull/881)
+- Added support for configurable enum sources, template-only fields, and AMR metadata JSON generation. [#883](https://github.com/BU-ISCIII/relecov-tools/pull/883)
 
 #### Fixes
 

--- a/relecov_tools/assets/schema_utils/amr_metadata.py
+++ b/relecov_tools/assets/schema_utils/amr_metadata.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+import json
+import os
+
+import pandas as pd
+
+SOURCE_SHEET = "amr_gene_list"
+OUTPUT_FILENAME = "amr_genes.json"
+
+
+def load_amr_gene_list(excel_file_path: str) -> pd.DataFrame:
+    """
+    Read the optional amr_gene_list sheet from the input Excel file.
+
+    Args:
+        excel_file_path (str): Path to the schema definition Excel file.
+
+    Returns:
+        pd.DataFrame: AMR gene list data, or an empty DataFrame if the sheet is absent.
+    """
+    try:
+        df = pd.read_excel(
+            excel_file_path,
+            sheet_name=SOURCE_SHEET,
+            na_values=["nan", "N/A", "NA", ""],
+        )
+    except ValueError:
+        return pd.DataFrame()
+
+    if not df.empty:
+        df.columns = [str(column).strip() for column in df.columns]
+        if "Name" in df.columns:
+            df = df[df["Name"].notna()]
+
+    return df
+
+
+def clean_amr_value(value) -> str:
+    """
+    Clean an AMR metadata value for JSON serialization.
+
+    Args:
+        value: Raw value from the amr_gene_list sheet.
+
+    Returns:
+        str: Stripped string value, or an empty string for NA values.
+    """
+    return "" if pd.isna(value) else str(value).strip()
+
+
+def build_amr_genes_json(df: pd.DataFrame, version: str) -> dict:
+    """
+    Build the amr_genes.json content from an amr_gene_list dataframe.
+
+    The output keeps genes and alleles keyed by their formatted Name value. Alleles
+    also include the corresponding gene when gen_for_alleles matches a gene
+    Name_CARD value in the same source sheet.
+
+    Args:
+        df (pd.DataFrame): Data from the amr_gene_list sheet.
+        version (str): Schema version to include in the output JSON.
+
+    Returns:
+        dict: JSON-serializable AMR metadata, or an empty dict if there is no data.
+    """
+    if df.empty:
+        return {}
+
+    if "Category" in df.columns:
+        gene_rows = df[df["Category"].astype(str).str.strip().str.lower() == "gene"]
+    else:
+        gene_rows = pd.DataFrame()
+
+    gene_name_by_card = {
+        clean_amr_value(row.get("Name_CARD")): clean_amr_value(row.get("Name"))
+        for _, row in gene_rows.iterrows()
+        if clean_amr_value(row.get("Name_CARD")) and clean_amr_value(row.get("Name"))
+    }
+
+    terms = {}
+    for _, row in df.iterrows():
+        name = clean_amr_value(row.get("Name"))
+        if not name:
+            continue
+
+        category = clean_amr_value(row.get("Category")).lower()
+        name_card = clean_amr_value(row.get("Name_CARD"))
+        gene_for_alleles = clean_amr_value(row.get("gen_for_alleles"))
+
+        term = {
+            "name_card": name_card,
+            "aro_accession": clean_amr_value(row.get("ARO Accession")),
+            "name": name,
+            "category": category,
+            "classification": clean_amr_value(row.get("Classification")),
+            "description": clean_amr_value(row.get("Description")),
+        }
+
+        if category == "allele":
+            term["allele_name"] = name
+            term["gene_name_card"] = gene_for_alleles
+            term["gene_name"] = gene_name_by_card.get(
+                gene_for_alleles, gene_for_alleles
+            )
+        elif category == "gene":
+            term["gene_name_card"] = name_card
+            term["gene_name"] = name
+
+        terms[name] = term
+
+    return {
+        "version": version,
+        "source_sheet": SOURCE_SHEET,
+        "terms": terms,
+    }
+
+
+def save_amr_genes_json(
+    excel_file_path: str, output_dir: str, version: str
+) -> str | None:
+    """
+    Build and save amr_genes.json from the optional amr_gene_list sheet.
+
+    Args:
+        excel_file_path (str): Path to the schema definition Excel file.
+        output_dir (str): Directory where amr_genes.json should be written.
+        version (str): Schema version to include in the output JSON.
+
+    Returns:
+        str | None: Output path when the file is written, otherwise None.
+    """
+    df = load_amr_gene_list(excel_file_path)
+    amr_genes = build_amr_genes_json(df, version)
+    if not amr_genes:
+        return None
+
+    output_path = os.path.join(output_dir, OUTPUT_FILENAME)
+    with open(output_path, "w", encoding="utf-8") as fh:
+        fh.write(json.dumps(amr_genes, indent=4, ensure_ascii=False))
+
+    return output_path

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -325,6 +325,78 @@ class BuildSchema(BaseModule):
         column, category = source
         return self._amr_column_values(column, category=category)
 
+    @staticmethod
+    def _clean_amr_value(value) -> str:
+        return "" if pd.isna(value) else str(value).strip()
+
+    def _build_amr_genes_json(self) -> dict:
+        df = self._load_amr_gene_list()
+        if df.empty:
+            return {}
+
+        if "Category" in df.columns:
+            gene_rows = df[
+                df["Category"].astype(str).str.strip().str.lower() == "gene"
+            ]
+        else:
+            gene_rows = pd.DataFrame()
+        gene_name_by_card = {
+            self._clean_amr_value(row.get("Name_CARD")): self._clean_amr_value(
+                row.get("Name")
+            )
+            for _, row in gene_rows.iterrows()
+            if self._clean_amr_value(row.get("Name_CARD"))
+            and self._clean_amr_value(row.get("Name"))
+        }
+
+        terms = {}
+        for _, row in df.iterrows():
+            name = self._clean_amr_value(row.get("Name"))
+            if not name:
+                continue
+
+            category = self._clean_amr_value(row.get("Category")).lower()
+            name_card = self._clean_amr_value(row.get("Name_CARD"))
+            gene_for_alleles = self._clean_amr_value(row.get("gen_for_alleles"))
+
+            term = {
+                "name_card": name_card,
+                "aro_accession": self._clean_amr_value(row.get("ARO Accession")),
+                "name": name,
+                "category": category,
+                "classification": self._clean_amr_value(row.get("Classification")),
+                "description": self._clean_amr_value(row.get("Description")),
+            }
+
+            if category == "allele":
+                term["allele_name"] = name
+                term["gene_name_card"] = gene_for_alleles
+                term["gene_name"] = gene_name_by_card.get(
+                    gene_for_alleles, gene_for_alleles
+                )
+            elif category == "gene":
+                term["gene_name_card"] = name_card
+                term["gene_name"] = name
+
+            terms[name] = term
+
+        return {
+            "version": self.version,
+            "source_sheet": "amr_gene_list",
+            "terms": terms,
+        }
+
+    def _save_amr_genes_json(self):
+        amr_genes = self._build_amr_genes_json()
+        if not amr_genes:
+            return
+
+        output_path = os.path.join(self.output_dir, "amr_genes.json")
+        with open(output_path, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps(amr_genes, indent=4, ensure_ascii=False))
+        self.log.info("AMR genes JSON saved to %s", output_path)
+        stderr.print(f"[green]AMR genes JSON saved to: {output_path}")
+
     def validate_database_definition(self, json_data):
         """Validate the mandatory features and ensure:
         - No duplicate enum values in the JSON schema.
@@ -1658,6 +1730,7 @@ class BuildSchema(BaseModule):
 
         # Saves new JSON schema
         self.save_new_schema(new_schema_json)
+        self._save_amr_genes_json()
 
         # Create metadata lab template
         if self.non_interactive or relecov_tools.utils.prompt_yn_question(

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -287,17 +287,14 @@ class BuildSchema(BaseModule):
         self._amr_gene_list_df = df
         return self._amr_gene_list_df
 
-    def _amr_column_values(
-        self, column: str, category: str | None = None
-    ) -> list[str]:
+    def _amr_column_values(self, column: str, category: str | None = None) -> list[str]:
         df = self._load_amr_gene_list()
         if df.empty or column not in df.columns:
             return []
 
         if category and "Category" in df.columns:
             df = df[
-                df["Category"].astype(str).str.strip().str.lower()
-                == category.lower()
+                df["Category"].astype(str).str.strip().str.lower() == category.lower()
             ]
 
         values = [
@@ -335,9 +332,7 @@ class BuildSchema(BaseModule):
             return {}
 
         if "Category" in df.columns:
-            gene_rows = df[
-                df["Category"].astype(str).str.strip().str.lower() == "gene"
-            ]
+            gene_rows = df[df["Category"].astype(str).str.strip().str.lower() == "gene"]
         else:
             gene_rows = pd.DataFrame()
         gene_name_by_card = {
@@ -1310,7 +1305,9 @@ class BuildSchema(BaseModule):
                     )
                 )
                 if "enum" in df.columns:
-                    df["enum"] = df["enum"].where(pd.notnull(df["enum"]), resolved_enums)
+                    df["enum"] = df["enum"].where(
+                        pd.notnull(df["enum"]), resolved_enums
+                    )
                 else:
                     df["enum"] = resolved_enums
                 common_dropdown = self._lab_dropdowns["collecting_institution"]

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -57,6 +57,8 @@ class BuildSchema(BaseModule):
 
         # No metadata is being processed so batch_id will be execution date
         self.set_batch_id(self.basemod_date)
+        # Cache for the optional AMR enum source sheet.
+        self._amr_gene_list_df = None
 
         # Validate output folder creation
         if not output_dir:
@@ -263,6 +265,65 @@ class BuildSchema(BaseModule):
         if not isinstance(submitting_lab_form, str):
             return False
         return submitting_lab_form.strip().upper() == "ONLY"
+
+    def _load_amr_gene_list(self) -> pd.DataFrame:
+        if self._amr_gene_list_df is not None:
+            return self._amr_gene_list_df
+
+        try:
+            df = pd.read_excel(
+                self.excel_file_path,
+                sheet_name="amr_gene_list",
+                na_values=["nan", "N/A", "NA", ""],
+            )
+        except ValueError:
+            df = pd.DataFrame()
+
+        if not df.empty:
+            df.columns = [str(column).strip() for column in df.columns]
+            if "Name" in df.columns:
+                df = df[df["Name"].notna()]
+
+        self._amr_gene_list_df = df
+        return self._amr_gene_list_df
+
+    def _amr_column_values(
+        self, column: str, category: str | None = None
+    ) -> list[str]:
+        df = self._load_amr_gene_list()
+        if df.empty or column not in df.columns:
+            return []
+
+        if category and "Category" in df.columns:
+            df = df[
+                df["Category"].astype(str).str.strip().str.lower()
+                == category.lower()
+            ]
+
+        values = [
+            str(value).strip()
+            for value in df[column].dropna().tolist()
+            if str(value).strip()
+        ]
+        return list(dict.fromkeys(values))
+
+    def _amr_enum_values_for_property(
+        self, property_id: str, parent_property_id: str | None = None
+    ) -> list[str]:
+        if parent_property_id != "amr_acquired_genes":
+            return []
+
+        enum_sources = {
+            "allele_name": ("Name", "allele"),
+            "gene_name": ("Name", "gene"),
+            "classification": ("Classification", None),
+            "description": ("Description", None),
+        }
+        source = enum_sources.get(property_id)
+        if not source:
+            return []
+        column, category = source
+        return self._amr_column_values(column, category=category)
 
     def validate_database_definition(self, json_data):
         """Validate the mandatory features and ensure:
@@ -598,7 +659,9 @@ class BuildSchema(BaseModule):
 
         return jsonschema_value
 
-    def handle_properties(self, json_data: dict[str, dict]) -> tuple[dict, dict, dict]:
+    def handle_properties(
+        self, json_data: dict[str, dict], parent_property_id: str | None = None
+    ) -> tuple[dict, dict, dict]:
         """
         Handle the generation of simple and nested properties from the database definition.
 
@@ -620,6 +683,11 @@ class BuildSchema(BaseModule):
         for property_id, db_features_dic in json_data.items():
             is_required = db_features_dic.get("required (Y/N)", "") == "Y"
             has_enum = db_features_dic.get("enum", False)
+            amr_enum_values = self._amr_enum_values_for_property(
+                property_id, parent_property_id=parent_property_id
+            )
+            if amr_enum_values:
+                has_enum = "; ".join(amr_enum_values)
             if property_id in [
                 "collecting_institution",
                 "submitting_institution",
@@ -637,7 +705,10 @@ class BuildSchema(BaseModule):
                 schema_draft = {"type": "object", "properties": {}, "required": []}
                 subschema = self.read_database_definition(property_id)
                 complex_json_feature = self.build_new_schema(
-                    subschema, schema_draft, root_schema=False
+                    subschema,
+                    schema_draft,
+                    root_schema=False,
+                    parent_property_id=property_id,
                 )
                 if complex_json_feature:
                     if complex_json_feature.get("$defs"):
@@ -661,6 +732,8 @@ class BuildSchema(BaseModule):
                         continue
                     # Extra check to avoid non-mapping properties.
                     if db_feature_key in mapping_features:
+                        if db_feature_key == "enum" and isinstance(has_enum, str):
+                            db_feature_value = has_enum
                         std_json_feature = self.jsonschema_object(
                             property_id,
                             mapping_features[db_feature_key],
@@ -729,7 +802,11 @@ class BuildSchema(BaseModule):
         return {"allOf": all_of_base} if all_of_base else {}
 
     def build_new_schema(
-        self, json_data: dict[str, dict], schema_draft: dict, root_schema: bool = True
+        self,
+        json_data: dict[str, dict],
+        schema_draft: dict,
+        root_schema: bool = True,
+        parent_property_id: str | None = None,
     ) -> dict[str, any]:
         """
         Build a new JSON Schema based on the provided JSON data and draft template, in three stages:
@@ -770,7 +847,9 @@ class BuildSchema(BaseModule):
         # Fill schema properties
         # Properties
         try:
-            properties, required, defs = self.handle_properties(json_data)
+            properties, required, defs = self.handle_properties(
+                json_data, parent_property_id=parent_property_id
+            )
         except Exception as e:
             self.log.error(f"Error building properties: {str(e)}")
             stderr.print(f"[red]Error building properties: {str(e)}")
@@ -907,11 +986,32 @@ class BuildSchema(BaseModule):
         if isinstance(enum_value, list):
             return enum_value
         if isinstance(enum_value, str):
+            loaded_values = self._load_enum_values_from_sheet(enum_value)
+            if loaded_values:
+                return loaded_values
             loaded_values = self._load_enum_values_from_file(enum_value)
             if loaded_values:
                 return loaded_values
             return [value.strip() for value in enum_value.split("; ") if value.strip()]
         return pd.NA
+
+    def _load_enum_values_from_sheet(self, enum_value: str) -> list[str]:
+        enum_reference = enum_value.strip()
+        if enum_reference == "amr_gene_list":
+            return self._amr_column_values("Name")
+
+        if not enum_reference.startswith("@sheet:"):
+            return []
+
+        reference_parts = [
+            part.strip() for part in enum_reference.removeprefix("@sheet:").split(":")
+        ]
+        sheet_name = reference_parts[0] if reference_parts else ""
+        column_name = reference_parts[1] if len(reference_parts) > 1 else "Name"
+        if sheet_name != "amr_gene_list":
+            return []
+
+        return self._amr_column_values(column_name)
 
     def _load_enum_values_from_file(self, enum_value: str) -> list[str]:
         enum_file = enum_value.strip()

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -305,7 +305,7 @@ class BuildSchema(BaseModule):
             for value in df[column].dropna().tolist()
             if str(value).strip()
         ]
-        return list(dict.fromkeys(values))
+        return self._sort_enum_values(list(dict.fromkeys(values)))
 
     def _amr_enum_values_for_property(
         self, property_id: str, parent_property_id: str | None = None
@@ -748,7 +748,9 @@ class BuildSchema(BaseModule):
                 required_properties.append(property_id)
             # If there is an enum in the property, parse it and add it to definitions
             if isinstance(has_enum, str):
-                enum = [value.strip() for value in has_enum.split("; ")]
+                enum = self._sort_enum_values(
+                    [value.strip() for value in has_enum.split("; ") if value.strip()]
+                )
                 definitions["$defs"]["enums"][property_id] = {}
                 definitions["$defs"]["enums"][property_id]["enum"] = enum
 
@@ -982,17 +984,40 @@ class BuildSchema(BaseModule):
 
     # FIXME: overview-tab - FIX first column values
     # FIXME: overview-tab - Still need to add the column that maps to tab metadatalab
+    def _sort_enum_values(self, enum_values: list[str]) -> list[str]:
+        last_values = {
+            "not sequenced": 0,
+            "no enrichment": 1,
+            "not applicable": 2,
+            "not collected": 3,
+            "not provided": 4,
+            "missing": 5,
+            "restricted access": 6,
+            "other": 7,
+        }
+
+        def sort_key(value: str):
+            normalized_value = value.strip().casefold()
+            for last_value, last_order in last_values.items():
+                if last_value in normalized_value:
+                    return (1, last_order)
+            return (0, normalized_value)
+
+        return sorted(enum_values, key=sort_key)
+
     def _parse_enum_values(self, enum_value):
         if isinstance(enum_value, list):
-            return enum_value
+            return self._sort_enum_values(enum_value)
         if isinstance(enum_value, str):
             loaded_values = self._load_enum_values_from_sheet(enum_value)
             if loaded_values:
-                return loaded_values
+                return self._sort_enum_values(loaded_values)
             loaded_values = self._load_enum_values_from_file(enum_value)
             if loaded_values:
-                return loaded_values
-            return [value.strip() for value in enum_value.split("; ") if value.strip()]
+                return self._sort_enum_values(loaded_values)
+            return self._sort_enum_values(
+                [value.strip() for value in enum_value.split("; ") if value.strip()]
+            )
         return pd.NA
 
     def _load_enum_values_from_sheet(self, enum_value: str) -> list[str]:

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -59,6 +59,8 @@ class BuildSchema(BaseModule):
         self.set_batch_id(self.basemod_date)
         # Cache for the optional AMR enum source sheet.
         self._amr_gene_list_df = None
+        # Cache for generic enum source sheets referenced from the input Excel.
+        self._enum_sheet_cache = {}
 
         # Validate output folder creation
         if not output_dir:
@@ -287,15 +289,10 @@ class BuildSchema(BaseModule):
         self._amr_gene_list_df = df
         return self._amr_gene_list_df
 
-    def _amr_column_values(self, column: str, category: str | None = None) -> list[str]:
+    def _amr_column_values(self, column: str) -> list[str]:
         df = self._load_amr_gene_list()
         if df.empty or column not in df.columns:
             return []
-
-        if category and "Category" in df.columns:
-            df = df[
-                df["Category"].astype(str).str.strip().str.lower() == category.lower()
-            ]
 
         values = [
             str(value).strip()
@@ -303,24 +300,6 @@ class BuildSchema(BaseModule):
             if str(value).strip()
         ]
         return self._sort_enum_values(list(dict.fromkeys(values)))
-
-    def _amr_enum_values_for_property(
-        self, property_id: str, parent_property_id: str | None = None
-    ) -> list[str]:
-        if parent_property_id != "amr_acquired_genes":
-            return []
-
-        enum_sources = {
-            "allele_name": ("Name", "allele"),
-            "gene_name": ("Name", "gene"),
-            "classification": ("Classification", None),
-            "description": ("Description", None),
-        }
-        source = enum_sources.get(property_id)
-        if not source:
-            return []
-        column, category = source
-        return self._amr_column_values(column, category=category)
 
     @staticmethod
     def _clean_amr_value(value) -> str:
@@ -726,9 +705,7 @@ class BuildSchema(BaseModule):
 
         return jsonschema_value
 
-    def handle_properties(
-        self, json_data: dict[str, dict], parent_property_id: str | None = None
-    ) -> tuple[dict, dict, dict]:
+    def handle_properties(self, json_data: dict[str, dict]) -> tuple[dict, dict, dict]:
         """
         Handle the generation of simple and nested properties from the database definition.
 
@@ -750,11 +727,6 @@ class BuildSchema(BaseModule):
         for property_id, db_features_dic in json_data.items():
             is_required = db_features_dic.get("required (Y/N)", "") == "Y"
             has_enum = db_features_dic.get("enum", False)
-            amr_enum_values = self._amr_enum_values_for_property(
-                property_id, parent_property_id=parent_property_id
-            )
-            if amr_enum_values:
-                has_enum = "; ".join(amr_enum_values)
             if property_id in [
                 "collecting_institution",
                 "submitting_institution",
@@ -775,7 +747,6 @@ class BuildSchema(BaseModule):
                     subschema,
                     schema_draft,
                     root_schema=False,
-                    parent_property_id=property_id,
                 )
                 if complex_json_feature:
                     if complex_json_feature.get("$defs"):
@@ -815,9 +786,7 @@ class BuildSchema(BaseModule):
                 required_properties.append(property_id)
             # If there is an enum in the property, parse it and add it to definitions
             if isinstance(has_enum, str):
-                enum = self._sort_enum_values(
-                    [value.strip() for value in has_enum.split("; ") if value.strip()]
-                )
+                enum = self._parse_enum_values(has_enum)
                 definitions["$defs"]["enums"][property_id] = {}
                 definitions["$defs"]["enums"][property_id]["enum"] = enum
 
@@ -875,7 +844,6 @@ class BuildSchema(BaseModule):
         json_data: dict[str, dict],
         schema_draft: dict,
         root_schema: bool = True,
-        parent_property_id: str | None = None,
     ) -> dict[str, any]:
         """
         Build a new JSON Schema based on the provided JSON data and draft template, in three stages:
@@ -916,9 +884,7 @@ class BuildSchema(BaseModule):
         # Fill schema properties
         # Properties
         try:
-            properties, required, defs = self.handle_properties(
-                json_data, parent_property_id=parent_property_id
-            )
+            properties, required, defs = self.handle_properties(json_data)
         except Exception as e:
             self.log.error(f"Error building properties: {str(e)}")
             stderr.print(f"[red]Error building properties: {str(e)}")
@@ -1077,15 +1043,51 @@ class BuildSchema(BaseModule):
             return self._sort_enum_values(enum_value)
         if isinstance(enum_value, str):
             loaded_values = self._load_enum_values_from_sheet(enum_value)
-            if loaded_values:
+            if loaded_values or enum_value.strip().startswith("@sheet:"):
                 return self._sort_enum_values(loaded_values)
             loaded_values = self._load_enum_values_from_file(enum_value)
-            if loaded_values:
+            if loaded_values or enum_value.strip().startswith(("@file:", "@")):
                 return self._sort_enum_values(loaded_values)
             return self._sort_enum_values(
                 [value.strip() for value in enum_value.split("; ") if value.strip()]
             )
         return pd.NA
+
+    def _load_enum_source_sheet(self, sheet_name: str) -> pd.DataFrame:
+        if sheet_name == "amr_gene_list":
+            return self._load_amr_gene_list()
+
+        if sheet_name not in self._enum_sheet_cache:
+            try:
+                df = pd.read_excel(
+                    self.excel_file_path,
+                    sheet_name=sheet_name,
+                    na_values=["nan", "N/A", "NA", ""],
+                )
+            except ValueError:
+                self._enum_sheet_cache[sheet_name] = pd.DataFrame()
+            else:
+                df.columns = [str(column).strip() for column in df.columns]
+                self._enum_sheet_cache[sheet_name] = df
+
+        return self._enum_sheet_cache[sheet_name]
+
+    def _filter_enum_source_sheet(
+        self, df: pd.DataFrame, filter_references: list[str]
+    ) -> pd.DataFrame:
+        for filter_reference in filter_references:
+            if "=" not in filter_reference:
+                return pd.DataFrame()
+            column_name, expected_value = [
+                item.strip() for item in filter_reference.split("=", maxsplit=1)
+            ]
+            if not column_name or column_name not in df.columns:
+                return pd.DataFrame()
+            df = df[
+                df[column_name].astype(str).str.strip().str.casefold()
+                == expected_value.casefold()
+            ]
+        return df
 
     def _load_enum_values_from_sheet(self, enum_value: str) -> list[str]:
         enum_reference = enum_value.strip()
@@ -1098,12 +1100,24 @@ class BuildSchema(BaseModule):
         reference_parts = [
             part.strip() for part in enum_reference.removeprefix("@sheet:").split(":")
         ]
-        sheet_name = reference_parts[0] if reference_parts else ""
-        column_name = reference_parts[1] if len(reference_parts) > 1 else "Name"
-        if sheet_name != "amr_gene_list":
+        if len(reference_parts) < 2:
             return []
 
-        return self._amr_column_values(column_name)
+        sheet_name, column_name = reference_parts[:2]
+        if not sheet_name or not column_name:
+            return []
+
+        df = self._load_enum_source_sheet(sheet_name)
+        df = self._filter_enum_source_sheet(df, reference_parts[2:])
+        if df.empty or column_name not in df.columns:
+            return []
+
+        values = [
+            str(value).strip()
+            for value in df[column_name].dropna().tolist()
+            if str(value).strip()
+        ]
+        return list(dict.fromkeys(values))
 
     def _load_enum_values_from_file(self, enum_value: str) -> list[str]:
         enum_file = enum_value.strip()

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -262,14 +262,27 @@ class BuildSchema(BaseModule):
         return dropdowns, uniques
 
     def _is_template_only_property(self, property_definition: dict) -> bool:
-        """Return True when a database definition row is only for the lab template."""
+        """
+        Check whether a database definition row should only be included in the template.
+
+        Args:
+            property_definition (dict): Definition of one property from the input Excel.
+
+        Returns:
+            bool: True if submitting_lab_form is set to ONLY, False otherwise.
+        """
         submitting_lab_form = property_definition.get("submitting_lab_form")
         if not isinstance(submitting_lab_form, str):
             return False
         return submitting_lab_form.strip().upper() == "ONLY"
 
     def _save_amr_genes_json(self):
-        """Ask the AMR schema utility to write amr_genes.json when data is available."""
+        """
+        Generate the AMR genes metadata JSON file when amr_gene_list is available.
+
+        The AMR-specific parsing and writing logic lives in schema_utils. This
+        method only integrates that output into the build-schema workflow.
+        """
         output_path = (
             relecov_tools.assets.schema_utils.amr_metadata.save_amr_genes_json(
                 self.excel_file_path,
@@ -930,10 +943,16 @@ class BuildSchema(BaseModule):
             stderr.print(f"[red]An unexpected error occurred: {str(e)}")
         return False
 
-    # FIXME: overview-tab - FIX first column values
-    # FIXME: overview-tab - Still need to add the column that maps to tab metadatalab
     def _sort_enum_values(self, enum_values: list[str]) -> list[str]:
-        """Sort enum values alphabetically, keeping configured missing-value terms last."""
+        """
+        Sort enum values alphabetically while keeping configured special terms last.
+
+        Args:
+            enum_values (list[str]): Enum values to sort.
+
+        Returns:
+            list[str]: Sorted enum values.
+        """
         last_values = {
             "not sequenced": 0,
             "no enrichment": 1,
@@ -962,6 +981,12 @@ class BuildSchema(BaseModule):
         - @sheet:sheet_name:column_name
         - @sheet:sheet_name:column_name:filter_column=filter_value
         - @file:file_name.txt or @file_name.txt
+
+        Args:
+            enum_value: Raw enum value from the input Excel or an already parsed list.
+
+        Returns:
+            list[str] | pandas.NA: Parsed and sorted enum values, or pd.NA if empty.
         """
         if isinstance(enum_value, list):
             return self._sort_enum_values(enum_value)
@@ -978,7 +1003,15 @@ class BuildSchema(BaseModule):
         return pd.NA
 
     def _load_enum_source_sheet(self, sheet_name: str) -> pd.DataFrame:
-        """Read and cache an enum source sheet from the input Excel file."""
+        """
+        Read and cache an enum source sheet from the input Excel file.
+
+        Args:
+            sheet_name (str): Name of the Excel sheet to load.
+
+        Returns:
+            pd.DataFrame: Sheet contents, or an empty DataFrame if the sheet is absent.
+        """
         if sheet_name not in self._enum_sheet_cache:
             try:
                 df = pd.read_excel(
@@ -997,7 +1030,20 @@ class BuildSchema(BaseModule):
     def _filter_enum_source_sheet(
         self, df: pd.DataFrame, filter_references: list[str]
     ) -> pd.DataFrame:
-        """Apply case-insensitive filters written as column=value to an enum sheet."""
+        """
+        Apply case-insensitive column=value filters to an enum source sheet.
+
+        For example, the reference
+        @sheet:amr_gene_list:Name:Category=allele
+        loads the Name column from the amr_gene_list sheet, keeping rows where Category is allele.
+
+        Args:
+            df (pd.DataFrame): Enum source sheet contents.
+            filter_references (list[str]): Filters from @sheet references.
+
+        Returns:
+            pd.DataFrame: Filtered data, or an empty DataFrame if a filter is invalid.
+        """
         for filter_reference in filter_references:
             if "=" not in filter_reference:
                 return pd.DataFrame()
@@ -1013,7 +1059,15 @@ class BuildSchema(BaseModule):
         return df
 
     def _load_enum_values_from_sheet(self, enum_value: str) -> list[str]:
-        """Load enum values from an Excel sheet reference in the enum column."""
+        """
+        Load enum values from an Excel sheet reference in the enum column.
+
+        Args:
+            enum_value (str): Reference using @sheet:sheet_name:column_name syntax.
+
+        Returns:
+            list[str]: Unique enum values from the referenced sheet column.
+        """
         enum_reference = enum_value.strip()
         if not enum_reference.startswith("@sheet:"):
             return []
@@ -1041,7 +1095,15 @@ class BuildSchema(BaseModule):
         return list(dict.fromkeys(values))
 
     def _load_enum_values_from_file(self, enum_value: str) -> list[str]:
-        """Load enum values from a txt file in relecov_tools/conf."""
+        """
+        Load enum values from a txt file in relecov_tools/conf.
+
+        Args:
+            enum_value (str): File reference using @file:file_name.txt or @file_name.txt.
+
+        Returns:
+            list[str]: Enum values read from the file, ignoring blank/comment lines.
+        """
         enum_file = enum_value.strip()
         if enum_file.startswith("@file:"):
             enum_file = enum_file.removeprefix("@file:").strip()
@@ -1063,7 +1125,19 @@ class BuildSchema(BaseModule):
             ]
 
     def _template_only_properties_to_df(self, database_definition: dict | None):
-        """Build template rows for properties marked as ONLY in submitting_lab_form."""
+        """
+        Build metadata template rows for properties marked as ONLY.
+
+        Properties with submitting_lab_form set to ONLY are excluded from the JSON
+        schema, so they need to be converted directly from the input Excel definition
+        into template rows.
+
+        Args:
+            database_definition (dict | None): Full database definition from the input Excel.
+
+        Returns:
+            pd.DataFrame: Template rows for ONLY properties.
+        """
         if not database_definition:
             return pd.DataFrame()
 

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -449,6 +449,9 @@ class BuildSchema(BaseModule):
             sheet_name=sheet_id,
             na_values=["nan", "N/A", "NA", ""],
         )
+        property_column = df.columns[0]
+        df = df[df[property_column].notna()]
+        df = df[df[property_column].astype(str).str.strip() != ""]
         # Convert database to json format
         json_data = {}
         for row in df.itertuples(index=False):

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -258,6 +258,12 @@ class BuildSchema(BaseModule):
         uniques = {k: sorted(v) for k, v in uniques.items()}
         return dropdowns, uniques
 
+    def _is_template_only_property(self, property_definition: dict) -> bool:
+        submitting_lab_form = property_definition.get("submitting_lab_form")
+        if not isinstance(submitting_lab_form, str):
+            return False
+        return submitting_lab_form.strip().upper() == "ONLY"
+
     def validate_database_definition(self, json_data):
         """Validate the mandatory features and ensure:
         - No duplicate enum values in the JSON schema.
@@ -741,6 +747,11 @@ class BuildSchema(BaseModule):
         """
         # Pre-properties
         new_schema = schema_draft
+        json_data = {
+            property_id: property_definition
+            for property_id, property_definition in json_data.items()
+            if not self._is_template_only_property(property_definition)
+        }
         if root_schema:
             # Fill schema header
             # FIXME: it gets 'relecov-tools' instead of RELECOV
@@ -892,7 +903,76 @@ class BuildSchema(BaseModule):
 
     # FIXME: overview-tab - FIX first column values
     # FIXME: overview-tab - Still need to add the column that maps to tab metadatalab
-    def create_metadatalab_excel(self, json_schema):
+    def _parse_enum_values(self, enum_value):
+        if isinstance(enum_value, list):
+            return enum_value
+        if isinstance(enum_value, str):
+            loaded_values = self._load_enum_values_from_file(enum_value)
+            if loaded_values:
+                return loaded_values
+            return [value.strip() for value in enum_value.split("; ") if value.strip()]
+        return pd.NA
+
+    def _load_enum_values_from_file(self, enum_value: str) -> list[str]:
+        enum_file = enum_value.strip()
+        if enum_file.startswith("@file:"):
+            enum_file = enum_file.removeprefix("@file:").strip()
+        elif enum_file.startswith("@"):
+            enum_file = enum_file.removeprefix("@").strip()
+
+        if not enum_file.endswith(".txt"):
+            return []
+
+        enum_path = os.path.join(os.path.dirname(__file__), "conf", enum_file)
+        if not os.path.exists(enum_path):
+            return []
+
+        with open(enum_path, encoding="utf-8") as fh:
+            return [
+                line.strip()
+                for line in fh
+                if line.strip() and not line.lstrip().startswith("#")
+            ]
+
+    def _template_only_properties_to_df(self, database_definition: dict | None):
+        if not database_definition:
+            return pd.DataFrame()
+
+        mapping_features = self.configurables.get("database_mapping_features", {})
+        template_rows = []
+        for property_id in database_definition:
+            db_features = database_definition[property_id]
+            if not self._is_template_only_property(db_features):
+                continue
+
+            row = {
+                "property_id": property_id,
+                "field_id": property_id,
+                "parent_property_id": None,
+                "parent_label": "",
+                "parent_classification": "",
+                "is_required": db_features.get("required (Y/N)", "") == "Y",
+            }
+            for db_feature_key, db_feature_value in db_features.items():
+                schema_key = mapping_features.get(db_feature_key)
+                if not schema_key:
+                    continue
+                if schema_key == "enum":
+                    row["enum"] = self._parse_enum_values(db_feature_value)
+                    continue
+                std_json_feature = self.jsonschema_object(
+                    property_id,
+                    schema_key,
+                    db_feature_value,
+                    expected_type=db_features.get("type"),
+                )
+                row.update(std_json_feature)
+
+            template_rows.append(row)
+
+        return pd.DataFrame(template_rows)
+
+    def create_metadatalab_excel(self, json_schema, database_definition=None):
         """
         Generates an Excel template file for Metadata LAB with four sheets:
         Overview, Metadata LAB, Data Validation, and Version History.
@@ -979,6 +1059,11 @@ class BuildSchema(BaseModule):
                 df = relecov_tools.assets.schema_utils.metadatalab_template.schema_properties_to_df(
                     schema_properties_flatten
                 )
+                template_only_df = self._template_only_properties_to_df(
+                    database_definition
+                )
+                if not template_only_df.empty:
+                    df = pd.concat([df, template_only_df], ignore_index=True)
 
                 classification_overrides = self.configurables.get(
                     "classification_filters", {}
@@ -1020,13 +1105,17 @@ class BuildSchema(BaseModule):
                         clean_ontologies(values) if isinstance(values, list) else values
                     )
 
-                df["enum"] = df["$ref"].apply(
+                resolved_enums = df["$ref"].apply(
                     lambda row: (
                         resolve_enum_ref(row, enum_defs=enum_defs)
                         if not pd.isna(row)
                         else row
                     )
                 )
+                if "enum" in df.columns:
+                    df["enum"] = df["enum"].where(pd.notnull(df["enum"]), resolved_enums)
+                else:
+                    df["enum"] = resolved_enums
                 common_dropdown = self._lab_dropdowns["collecting_institution"]
 
                 lab_fields = [
@@ -1050,8 +1139,8 @@ class BuildSchema(BaseModule):
             # 3.  Headers / filtering
             # ------------------------------------------------------------------ #
             if "header" in df.columns:
-                df["header"] = df["header"].astype(str).str.strip()
-                df_filtered = df[df["header"].str.upper() == "Y"]
+                df["header"] = df["header"].astype(str).str.strip().str.upper()
+                df_filtered = df[df["header"].isin(["Y", "ONLY"])]
             else:
                 self.log.warning(
                     "No se encontró la columna 'header', usando df sin filtrar."
@@ -1449,7 +1538,7 @@ class BuildSchema(BaseModule):
         if self.non_interactive or relecov_tools.utils.prompt_yn_question(
             "Do you want to create a metadata lab file?:"
         ):
-            self.create_metadatalab_excel(new_schema_json)
+            self.create_metadatalab_excel(new_schema_json, database_dic)
 
         # Return new schema
         return new_schema_json

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -10,6 +10,7 @@ import difflib
 import inspect
 
 import relecov_tools.utils
+import relecov_tools.assets.schema_utils.amr_metadata
 import relecov_tools.assets.schema_utils.jsonschema_draft
 import relecov_tools.assets.schema_utils.metadatalab_template
 from relecov_tools.config_json import ConfigJson
@@ -57,8 +58,6 @@ class BuildSchema(BaseModule):
 
         # No metadata is being processed so batch_id will be execution date
         self.set_batch_id(self.basemod_date)
-        # Cache for the optional AMR enum source sheet.
-        self._amr_gene_list_df = None
         # Cache for generic enum source sheets referenced from the input Excel.
         self._enum_sheet_cache = {}
 
@@ -263,111 +262,24 @@ class BuildSchema(BaseModule):
         return dropdowns, uniques
 
     def _is_template_only_property(self, property_definition: dict) -> bool:
+        """Return True when a database definition row is only for the lab template."""
         submitting_lab_form = property_definition.get("submitting_lab_form")
         if not isinstance(submitting_lab_form, str):
             return False
         return submitting_lab_form.strip().upper() == "ONLY"
 
-    def _load_amr_gene_list(self) -> pd.DataFrame:
-        if self._amr_gene_list_df is not None:
-            return self._amr_gene_list_df
-
-        try:
-            df = pd.read_excel(
-                self.excel_file_path,
-                sheet_name="amr_gene_list",
-                na_values=["nan", "N/A", "NA", ""],
-            )
-        except ValueError:
-            df = pd.DataFrame()
-
-        if not df.empty:
-            df.columns = [str(column).strip() for column in df.columns]
-            if "Name" in df.columns:
-                df = df[df["Name"].notna()]
-
-        self._amr_gene_list_df = df
-        return self._amr_gene_list_df
-
-    def _amr_column_values(self, column: str) -> list[str]:
-        df = self._load_amr_gene_list()
-        if df.empty or column not in df.columns:
-            return []
-
-        values = [
-            str(value).strip()
-            for value in df[column].dropna().tolist()
-            if str(value).strip()
-        ]
-        return self._sort_enum_values(list(dict.fromkeys(values)))
-
-    @staticmethod
-    def _clean_amr_value(value) -> str:
-        return "" if pd.isna(value) else str(value).strip()
-
-    def _build_amr_genes_json(self) -> dict:
-        df = self._load_amr_gene_list()
-        if df.empty:
-            return {}
-
-        if "Category" in df.columns:
-            gene_rows = df[df["Category"].astype(str).str.strip().str.lower() == "gene"]
-        else:
-            gene_rows = pd.DataFrame()
-        gene_name_by_card = {
-            self._clean_amr_value(row.get("Name_CARD")): self._clean_amr_value(
-                row.get("Name")
-            )
-            for _, row in gene_rows.iterrows()
-            if self._clean_amr_value(row.get("Name_CARD"))
-            and self._clean_amr_value(row.get("Name"))
-        }
-
-        terms = {}
-        for _, row in df.iterrows():
-            name = self._clean_amr_value(row.get("Name"))
-            if not name:
-                continue
-
-            category = self._clean_amr_value(row.get("Category")).lower()
-            name_card = self._clean_amr_value(row.get("Name_CARD"))
-            gene_for_alleles = self._clean_amr_value(row.get("gen_for_alleles"))
-
-            term = {
-                "name_card": name_card,
-                "aro_accession": self._clean_amr_value(row.get("ARO Accession")),
-                "name": name,
-                "category": category,
-                "classification": self._clean_amr_value(row.get("Classification")),
-                "description": self._clean_amr_value(row.get("Description")),
-            }
-
-            if category == "allele":
-                term["allele_name"] = name
-                term["gene_name_card"] = gene_for_alleles
-                term["gene_name"] = gene_name_by_card.get(
-                    gene_for_alleles, gene_for_alleles
-                )
-            elif category == "gene":
-                term["gene_name_card"] = name_card
-                term["gene_name"] = name
-
-            terms[name] = term
-
-        return {
-            "version": self.version,
-            "source_sheet": "amr_gene_list",
-            "terms": terms,
-        }
-
     def _save_amr_genes_json(self):
-        amr_genes = self._build_amr_genes_json()
-        if not amr_genes:
+        """Ask the AMR schema utility to write amr_genes.json when data is available."""
+        output_path = (
+            relecov_tools.assets.schema_utils.amr_metadata.save_amr_genes_json(
+                self.excel_file_path,
+                self.output_dir,
+                self.version,
+            )
+        )
+        if not output_path:
             return
 
-        output_path = os.path.join(self.output_dir, "amr_genes.json")
-        with open(output_path, "w", encoding="utf-8") as fh:
-            fh.write(json.dumps(amr_genes, indent=4, ensure_ascii=False))
         self.log.info("AMR genes JSON saved to %s", output_path)
         stderr.print(f"[green]AMR genes JSON saved to: {output_path}")
 
@@ -1018,6 +930,7 @@ class BuildSchema(BaseModule):
     # FIXME: overview-tab - FIX first column values
     # FIXME: overview-tab - Still need to add the column that maps to tab metadatalab
     def _sort_enum_values(self, enum_values: list[str]) -> list[str]:
+        """Sort enum values alphabetically, keeping configured missing-value terms last."""
         last_values = {
             "not sequenced": 0,
             "no enrichment": 1,
@@ -1039,6 +952,14 @@ class BuildSchema(BaseModule):
         return sorted(enum_values, key=sort_key)
 
     def _parse_enum_values(self, enum_value):
+        """
+        Resolve enum definitions from lists, Excel sheet references, txt files, or cells.
+
+        Supported references:
+        - @sheet:sheet_name:column_name
+        - @sheet:sheet_name:column_name:filter_column=filter_value
+        - @file:file_name.txt or @file_name.txt
+        """
         if isinstance(enum_value, list):
             return self._sort_enum_values(enum_value)
         if isinstance(enum_value, str):
@@ -1054,9 +975,7 @@ class BuildSchema(BaseModule):
         return pd.NA
 
     def _load_enum_source_sheet(self, sheet_name: str) -> pd.DataFrame:
-        if sheet_name == "amr_gene_list":
-            return self._load_amr_gene_list()
-
+        """Read and cache an enum source sheet from the input Excel file."""
         if sheet_name not in self._enum_sheet_cache:
             try:
                 df = pd.read_excel(
@@ -1075,6 +994,7 @@ class BuildSchema(BaseModule):
     def _filter_enum_source_sheet(
         self, df: pd.DataFrame, filter_references: list[str]
     ) -> pd.DataFrame:
+        """Apply case-insensitive filters written as column=value to an enum sheet."""
         for filter_reference in filter_references:
             if "=" not in filter_reference:
                 return pd.DataFrame()
@@ -1090,10 +1010,8 @@ class BuildSchema(BaseModule):
         return df
 
     def _load_enum_values_from_sheet(self, enum_value: str) -> list[str]:
+        """Load enum values from an Excel sheet reference in the enum column."""
         enum_reference = enum_value.strip()
-        if enum_reference == "amr_gene_list":
-            return self._amr_column_values("Name")
-
         if not enum_reference.startswith("@sheet:"):
             return []
 
@@ -1120,6 +1038,7 @@ class BuildSchema(BaseModule):
         return list(dict.fromkeys(values))
 
     def _load_enum_values_from_file(self, enum_value: str) -> list[str]:
+        """Load enum values from a txt file in relecov_tools/conf."""
         enum_file = enum_value.strip()
         if enum_file.startswith("@file:"):
             enum_file = enum_file.removeprefix("@file:").strip()
@@ -1141,6 +1060,7 @@ class BuildSchema(BaseModule):
             ]
 
     def _template_only_properties_to_df(self, database_definition: dict | None):
+        """Build template rows for properties marked as ONLY in submitting_lab_form."""
         if not database_definition:
             return pd.DataFrame()
 


### PR DESCRIPTION
### Summary
This PR updates schema generation to support configurable enum sources from the input Excel, template-only lab form fields, alphabetically sorted enum values, and automatic generation of `amr_genes.json` for downstream AMR metadata processing.

### Changes
- Added support for `ONLY` in `submitting_lab_form` to include fields in the metadata template while excluding them from the generated JSON schema.
- Added support for loading long enum lists from `.txt` files in `conf` or from Excel sheets using `@sheet:sheet_name:column_name`.
- Added support for filtered Excel enum sources using `@sheet:sheet_name:column_name:filter_column=filter_value`.
- Updated `amr_acquired_genes` to derive its enum values from `amr_gene_list` using the configurable Excel enum source syntax.
- Added automatic generation of `amr_genes.json` in the schema output directory using `amr_gene_list`.
- Sorted enum values alphabetically, keeping special values such as `Not applicable`, `Not collected`, `Not provided`, `Missing`, `Restricted access`, and `Other` at the end.


## PR Checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).