### PR TITLE
Improve METADATA_LAB template formatting and duplicate sample detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed new version filename taxprofiler[#877](https://github.com/BU-ISCIII/relecov-tools/pull/877)
 - Fix duplicated row in metadata form and clean some MEPRAM initial config [#879] (https://github.com/BU-ISCIII/relecov-tools/pull/879)
 - Fix date validation in Excel metadata templates and add some schema validation checks [#886] (https://github.com/BU-ISCIII/relecov-tools/pull/886)
+- Improve METADATA_LAB template formatting and duplicate sample detection [#887] (https://github.com/BU-ISCIII/relecov-tools/pull/887)
 
 #### Changed
 

--- a/relecov_tools/assets/schema_utils/metadatalab_template.py
+++ b/relecov_tools/assets/schema_utils/metadatalab_template.py
@@ -312,6 +312,46 @@ def format_metadata_data_entry_area(
             cell.alignment = data_alignment
 
 
+DUPLICATE_ID_COLUMN_LABELS = (
+    "Public Health sample id (SIVIES)",
+    "Isolate ID given by the COLLECTING institution",
+    "Sample ID given by the COLLECTING institution",
+    "Isolate ID given by the SUBMITTING institution",
+    "Sample ID given by the SUBMITTING institution",
+    "Sample/Isolate ID given for GIPI submission",
+    "Sample/Isolate ID given for sequencing",
+    "ENA Sample Id",
+    "ENA Sample ID",
+)
+
+
+def add_duplicate_value_formatting(
+    ws_metadata,
+    target_column_labels=DUPLICATE_ID_COLUMN_LABELS,
+    header_row=1,
+    start_row=5,
+    end_row=1000,
+):
+    """Highlight repeated non-empty values within each selected data column."""
+    red_fill = PatternFill(start_color="F54627", end_color="F54627", fill_type="solid")
+
+    for cell in ws_metadata[header_row]:
+        # Header labels are only used to locate the columns; duplicates are checked below start_row.
+        if cell.value not in target_column_labels:
+            continue
+
+        col_letter = cell.column_letter
+        cell_range = f"${col_letter}${start_row}:${col_letter}${end_row}"
+        formula = (
+            f'AND(${col_letter}{start_row}<>"",'
+            f"COUNTIF({cell_range},${col_letter}{start_row})>1)"
+        )
+        rule = FormulaRule(formula=[formula], fill=red_fill)
+        ws_metadata.conditional_formatting.add(
+            f"{col_letter}{start_row}:{col_letter}{end_row}", rule
+        )
+
+
 def add_conditional_format_age_check(
     ws_metadata,
     df_filtered,

--- a/relecov_tools/assets/schema_utils/metadatalab_template.py
+++ b/relecov_tools/assets/schema_utils/metadatalab_template.py
@@ -8,7 +8,7 @@ import relecov_tools.utils
 from openpyxl.worksheet.datavalidation import DataValidation
 from openpyxl.utils import column_index_from_string
 from openpyxl.formatting.rule import FormulaRule
-from openpyxl.styles import PatternFill
+from openpyxl.styles import Alignment, Font, PatternFill
 
 log = logging.getLogger(__name__)
 stderr = rich.console.Console(
@@ -288,6 +288,28 @@ def create_condition(ws_metadata, conditions, df_filtered):
                     for cell in row:
                         cell.number_format = "yyyy-mm-dd"
     return ws_metadata
+
+
+def format_metadata_data_entry_area(
+    ws_metadata,
+    start_row=5,
+    end_row=1000,
+    start_col=2,
+    end_col=None,
+):
+    """Give empty input cells an explicit data style so Excel does not extend the header style."""
+    end_col = end_col or ws_metadata.max_column
+    no_fill = PatternFill(fill_type=None)
+    data_font = Font(bold=False, color="000000")
+    data_alignment = Alignment(wrap_text=False, vertical="top")
+
+    for row in ws_metadata.iter_rows(
+        min_row=start_row, max_row=end_row, min_col=start_col, max_col=end_col
+    ):
+        for cell in row:
+            cell.fill = no_fill
+            cell.font = data_font
+            cell.alignment = data_alignment
 
 
 def add_conditional_format_age_check(

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -1672,6 +1672,7 @@ class BuildSchema(BaseModule):
                     ws_metadata, end_col=len(df_filtered) + 1
                 )
                 mt.create_condition(ws_metadata, self.project_config, df_filtered)
+                mt.add_duplicate_value_formatting(ws_metadata)
                 mt.add_conditional_format_age_check(ws_metadata, df_filtered)
 
                 # Hidden sheet for dropdowns

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -1668,6 +1668,9 @@ class BuildSchema(BaseModule):
                 ws_metadata = wb["METADATA_LAB"]
                 ws_metadata.freeze_panes = self.configurables.get("freeze_panel", "D1")
                 ws_metadata.delete_rows(5)
+                mt.format_metadata_data_entry_area(
+                    ws_metadata, end_col=len(df_filtered) + 1
+                )
                 mt.create_condition(ws_metadata, self.project_config, df_filtered)
                 mt.add_conditional_format_age_check(ws_metadata, df_filtered)
 


### PR DESCRIPTION
This PR fixes a formatting bug in the generated METADATA_LAB template and adds visual support to detect duplicated sample names.

**Changes:**
- Added conditional formatting to highlight duplicated sample names in the metadata template.
- Fixed the METADATA_LAB header formatting so that it does not extend into data rows.

## PR Checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).