### PR TITLE
Make build-schema multi-project and improve template version handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add background execution mode for wrapper [#880](https://github.com/BU-ISCIII/relecov-tools/pull/880)
 - Add weekly SFTP upload report [#881](https://github.com/BU-ISCIII/relecov-tools/pull/881)
 - Added support for configurable enum sources, template-only fields, and AMR metadata JSON generation. [#883](https://github.com/BU-ISCIII/relecov-tools/pull/883)
+- Make build-schema multi-project and improve template version handling [#888] (https://github.com/BU-ISCIII/relecov-tools/pull/888)
 
 #### Fixes
 

--- a/README.md
+++ b/README.md
@@ -599,7 +599,9 @@ Options:
   -d, --diff                      Prints a changelog/diff between the base and
                                   incoming versions of the schema.
   --version TEXT                  Specify the schema version.
-  -p, --project TEXT              Specficy the project to build the metadata
+  --initial-version               Start VERSION history explicitly with only
+                                  the current schema version.
+  -p, --project TEXT              Specify the project to build the metadata
                                   template.
   --non-interactive               Run the script without user interaction,
                                   using default values.

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -1292,14 +1292,14 @@ def pipeline_manager(
     "-s",
     "--schema_base",
     type=click.Path(),
-    help="Path to the base schema file. This file is used as a reference to compare it with the schema generated using this module. (Default: installed schema in 'relecov-tools/relecov_tools/schema/relecov_schema.json')",
+    help="Path to the base schema file. This file is used as a reference to compare it with the generated schema. By default, build-schema uses the installed schema for the selected project: '<project>_schema.json'.",
     required=False,
 )
 @click.option(
     "-e",
     "--excel_template",
     type=click.Path(),
-    help="Path to the excel template file. This file is used to get version history of the excel template (stored in assets/Relecov_metadata_*.xlsx)",
+    help="Path to the excel template file. This file is used to get version history of the selected project's excel template.",
     required=False,
 )
 @click.option(
@@ -1316,7 +1316,9 @@ def pipeline_manager(
 )
 @click.option("--version", help="Specify the schema version.")
 @click.option(
-    "-p", "--project", help="Specficy the project to build the metadata template."
+    "-p",
+    "--project",
+    help="Specify the project key used to build the schema and metadata template.",
 )
 @click.option(
     "--non-interactive",

--- a/relecov_tools/__main__.py
+++ b/relecov_tools/__main__.py
@@ -1316,6 +1316,11 @@ def pipeline_manager(
 )
 @click.option("--version", help="Specify the schema version.")
 @click.option(
+    "--initial-version",
+    is_flag=True,
+    help="Start VERSION history explicitly with only the current schema version.",
+)
+@click.option(
     "-p",
     "--project",
     help="Specify the project key used to build the schema and metadata template.",
@@ -1349,6 +1354,7 @@ def build_schema(
     diff,
     output_dir,
     version,
+    initial_version,
     project,
     non_interactive,
 ):

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -28,6 +28,19 @@ stderr = rich.console.Console(
 )
 
 
+def _slugify_project(value):
+    """Return a filesystem-friendly project identifier."""
+    project = str(value).strip().lower()
+    project = re.sub(r"\s+", "_", project)
+    project = re.sub(r"[^a-z0-9_-]+", "_", project)
+    return project.strip("_")
+
+
+def _display_project(value):
+    """Return a readable project label for generated metadata."""
+    return str(value).strip().replace("_", " ").replace("-", " ").title()
+
+
 class BuildSchema(BaseModule):
     def __init__(
         self,
@@ -47,6 +60,7 @@ class BuildSchema(BaseModule):
         """
         super().__init__(output_dir=output_dir, called_module=__name__)
         self.excel_file_path = input_file
+        self.excel_template = excel_template
         self.non_interactive = non_interactive
         # Validate params
         if not self.excel_file_path or not os.path.isfile(self.excel_file_path):
@@ -105,7 +119,12 @@ class BuildSchema(BaseModule):
         if project is None:
             project = relecov_tools.utils.prompt_text("Write the desired project:")
 
-        self.project = project
+        self.project = _slugify_project(project)
+        if not self.project:
+            raise ValueError("A valid project must be provided.")
+        self.project_label = _display_project(self.project)
+        self.schema_output_filename = f"{self.project}_schema.json"
+        self.template_output_prefix = f"{self.project_label}_metadata_template"
 
         available_projects = self.get_available_projects(self.build_schema_json_file)
 
@@ -118,8 +137,6 @@ class BuildSchema(BaseModule):
         self.configurables = (
             config_build_schema.get_configuration("configurables") or {}
         )
-        config_json = ConfigJson(extra_config=True)
-
         if self.project in available_projects:
             self.project_config = config_data.get(self.project, {})
         else:
@@ -148,38 +165,32 @@ class BuildSchema(BaseModule):
                     f"Defined base schema file not found: {schema_base}."
                 )
         else:
-            try:
-                relecov_schema = config_json.get_topic_data("generic", "relecov_schema")
-            except KeyError as key_error:
-                self.log.error(f"Configuration key error: {key_error}")
-                stderr.print(f"[orange]Configuration key error: {key_error}")
-                raise
-
-            try:
-                self.base_schema_path = os.path.join(
-                    os.path.dirname(os.path.realpath(__file__)),
-                    "schema",
-                    relecov_schema,
-                )
-            except FileNotFoundError as fnf_error:
-                self.log.error(f"Configuration file not found: {fnf_error}")
-                stderr.print(f"[red]Configuration file not found: {fnf_error}")
-                raise
+            project_schema = self.project_config.get(
+                "schema_file", self.schema_output_filename
+            )
+            self.base_schema_path = os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                "schema",
+                project_schema,
+            )
 
             if not relecov_tools.utils.file_exists(self.base_schema_path):
                 self.log.error(
-                    "[Error]Fatal error. Relecov schema were not found in current relecov-tools installation. Make sure relecov-tools command is functioning."
+                    f"[Error]Fatal error. {self.project_label} schema was not found in current relecov-tools installation: {self.base_schema_path}."
                 )
                 stderr.print(
-                    "[Error]Fatal error. Relecov schema were not found in current relecov-tools installation. Make sure relecov-tools command is functioning. Exiting..."
+                    f"[Error]Fatal error. {self.project_label} schema was not found in current relecov-tools installation: {self.base_schema_path}. Exiting..."
                 )
                 raise FileNotFoundError(
-                    "Fatal error. Relecov schema were not found in current relecov-tools installation. Make sure relecov-tools command is functioning."
+                    f"Fatal error. {self.project_label} schema was not found in current relecov-tools installation: {self.base_schema_path}."
                 )
 
-            self.log.info("RELECOV schema successfully found in the configuration.")
+            self.log.info(
+                "%s schema successfully found in the installation.",
+                self.project_label,
+            )
             stderr.print(
-                "[green]RELECOV schema successfully found in the configuration."
+                f"[green]{self.project_label} schema successfully found in the installation."
             )
 
             # TODO: What if no previous template exist?
@@ -212,13 +223,14 @@ class BuildSchema(BaseModule):
                     )
 
                 except (FileNotFoundError, IndexError):
-                    self.log.error(
-                        "[Error]Fatal error. Excel template was not found in current relecov-tools installation (assets)"
+                    self.excel_template = None
+                    self.log.warning(
+                        "%s excel template was not found in assets. A new version history will be started.",
+                        self.project_label,
                     )
                     stderr.print(
-                        "[Error]Fatal error. Excel template not found in current relecov-tools installation (assets). Exiting..."
+                        f"[yellow]{self.project_label} excel template was not found in assets. A new version history will be started."
                     )
-                    raise
 
     def _load_laboratory_addresses(self):
         """
@@ -867,16 +879,17 @@ class BuildSchema(BaseModule):
         }
         if root_schema:
             # Fill schema header
-            # FIXME: it gets 'relecov-tools' instead of RELECOV
-            project_name = relecov_tools.utils.get_package_name()
-            if isinstance(project_name, str):
-                project_name = project_name.strip()
-            if " " in project_name:
-                project_name = re.sub(r"\s+", "-", project_name)
-            new_schema["$id"] = relecov_tools.utils.get_schema_url()
-            new_schema["title"] = f"{project_name}-schema"
+            package_name = relecov_tools.utils.get_package_name()
+            branch_name = relecov_tools.utils.get_git_branch()
+            package_path = package_name.replace("-", "_")
+            new_schema["$id"] = (
+                "https://github.com/BU-ISCIII/"
+                f"{package_name}/blob/{branch_name}/{package_path}/schema/{self.schema_output_filename}"
+            )
+            new_schema["title"] = f"{self.project}-schema"
             new_schema["description"] = (
-                f"Json Schema that specifies the structure, content, and validation rules for {project_name}"
+                "Json Schema that specifies the structure, content, and validation "
+                f"rules for {self.project}"
             )
             new_schema["version"] = self.version
 
@@ -1057,7 +1070,7 @@ class BuildSchema(BaseModule):
             bool: True if the schema was successfully saved, False otherwise.
         """
         try:
-            path_to_save = f"{self.output_dir}/relecov_schema.json"
+            path_to_save = os.path.join(self.output_dir, self.schema_output_filename)
             with open(path_to_save, "w") as schema_file:
                 json.dump(json_data, schema_file, ensure_ascii=False, indent=4)
             self.log.info(f"New JSON schema saved to: {path_to_save}")
@@ -1366,7 +1379,7 @@ class BuildSchema(BaseModule):
                 version_history = pd.DataFrame(
                     [
                         {
-                            "FILE_VERSION": "Relecov_metadata_template_v1.0.0",
+                            "FILE_VERSION": f"{self.template_output_prefix}_v1.0.0",
                             "CODE": "1.0.0",
                             "NOTES CONTROL": "Initial version",
                             "DATE": datetime.now().strftime("%Y-%m-%d"),
@@ -1376,7 +1389,7 @@ class BuildSchema(BaseModule):
 
             next_version = self.version
             version_info = {
-                "FILE_VERSION": f"Relecov_metadata_template_v{next_version}",
+                "FILE_VERSION": f"{self.template_output_prefix}_v{next_version}",
                 "CODE": next_version,
                 "NOTES CONTROL": notes_control_input,
                 "DATE": datetime.now().strftime("%Y-%m-%d"),
@@ -1385,7 +1398,7 @@ class BuildSchema(BaseModule):
                 [version_history, pd.DataFrame([version_info])], ignore_index=True
             )
             out_file = os.path.join(
-                self.output_dir, f"Relecov_metadata_template_v{next_version}.xlsx"
+                self.output_dir, f"{self.template_output_prefix}_v{next_version}.xlsx"
             )
 
             # ------------------------------------------------------------------ #
@@ -1849,10 +1862,16 @@ class BuildSchema(BaseModule):
             ],
             "Path": [
                 shorten_path(self.output_dir),
-                shorten_path(f"{self.output_dir}/relecov_schema.json"),
+                shorten_path(
+                    os.path.join(self.output_dir, self.schema_output_filename)
+                ),
                 shorten_path(self.base_schema_path),
                 shorten_path(f"{self.output_dir}/build_schema_diff.txt"),
-                shorten_path(f"{self.output_dir}/Relecov_metadata_template_v*.xlsx"),
+                shorten_path(
+                    os.path.join(
+                        self.output_dir, f"{self.template_output_prefix}_v*.xlsx"
+                    )
+                ),
             ],
         }
 
@@ -1873,11 +1892,11 @@ class BuildSchema(BaseModule):
         stderr.print("[white]Start reading xlsx database")
         database_dic = self.read_database_definition()
 
-        # Verify current schema used by relecov-tools:
+        # Verify current schema used as base for this project:
         base_schema_json = relecov_tools.utils.read_json_file(self.base_schema_path)
         if not base_schema_json:
-            self.log.error("Couldn't find relecov base schema.)")
-            stderr.print("[red]Couldn't find relecov base schema. Exiting...)")
+            self.log.error(f"Couldn't find {self.project} base schema.)")
+            stderr.print(f"[red]Couldn't find {self.project} base schema. Exiting...)")
             sys.exit(1)
 
         # Create schema draft template (leave empty to be prompted to list of available schema versions)

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -190,11 +190,11 @@ class BuildSchema(BaseModule):
                     excel_template_path = os.path.join(
                         os.path.dirname(os.path.realpath(__file__)), "assets"
                     )
-                    # FIXME: filenames should inherit project name.
+                    template_prefix = f"{self.project}_metadata_template".lower()
                     excel_template = [
                         f
                         for f in os.listdir(excel_template_path)
-                        if f.startswith("Relecov_metadata_template")
+                        if f.lower().startswith(template_prefix)
                     ]
                     if len(excel_template) > 1:
                         self.log.error(

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -53,6 +53,7 @@ class BuildSchema(BaseModule):
         version=None,
         project=None,
         non_interactive=False,
+        initial_version=False,
     ):
         """
         Initialize the SchemaBuilder class. This class generates a JSON Schema file based on the provided draft version.
@@ -62,7 +63,12 @@ class BuildSchema(BaseModule):
         self.excel_file_path = input_file
         self.excel_template = excel_template
         self.non_interactive = non_interactive
+        self.initial_version = initial_version
         # Validate params
+        if self.initial_version and self.excel_template:
+            raise ValueError(
+                "--initial-version and --excel_template are incompatible options."
+            )
         if not self.excel_file_path or not os.path.isfile(self.excel_file_path):
             self.log.error("A valid Excel file path must be provided.")
             raise ValueError("A valid Excel file path must be provided.")
@@ -124,7 +130,7 @@ class BuildSchema(BaseModule):
             raise ValueError("A valid project must be provided.")
         self.project_label = _display_project(self.project)
         self.schema_output_filename = f"{self.project}_schema.json"
-        self.template_output_prefix = f"{self.project_label}_metadata_template"
+        self.template_output_prefix = f"{self.project}_metadata_template"
 
         available_projects = self.get_available_projects(self.build_schema_json_file)
 
@@ -193,44 +199,49 @@ class BuildSchema(BaseModule):
                 f"[green]{self.project_label} schema successfully found in the installation."
             )
 
-            # TODO: What if no previous template exist?
-            if excel_template:
-                self.excel_template = excel_template
-            else:
-                try:
-                    excel_template_path = os.path.join(
-                        os.path.dirname(os.path.realpath(__file__)), "assets"
-                    )
-                    template_prefix = f"{self.project}_metadata_template".lower()
-                    excel_template = [
-                        f
-                        for f in os.listdir(excel_template_path)
-                        if f.lower().startswith(template_prefix)
-                    ]
-                    if len(excel_template) > 1:
-                        self.log.error(
-                            "[Error]Fatal error. More than one excel template was found in current relecov-tools installation (assets)"
-                        )
-                        stderr.print(
-                            "[Error]Fatal error.More than one excel template was found in current relecov-tools installation (assets)..Exiting"
-                        )
-                        raise FileExistsError(
-                            "Fatal error. More than one excel template was found in current relecov-tools installation (assets)"
-                        )
+        self._resolve_version_history_template()
 
-                    self.excel_template = os.path.join(
-                        excel_template_path, excel_template[0]
-                    )
+    def _resolve_version_history_template(self):
+        if self.initial_version:
+            self.excel_template = None
+            return
 
-                except (FileNotFoundError, IndexError):
-                    self.excel_template = None
-                    self.log.warning(
-                        "%s excel template was not found in assets. A new version history will be started.",
-                        self.project_label,
-                    )
-                    stderr.print(
-                        f"[yellow]{self.project_label} excel template was not found in assets. A new version history will be started."
-                    )
+        if self.excel_template:
+            if not os.path.isfile(self.excel_template):
+                raise FileNotFoundError(
+                    f"Defined excel template file not found: {self.excel_template}."
+                )
+            return
+
+        excel_template_path = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), "assets"
+        )
+        template_prefix = f"{self.project}_metadata_template".lower()
+        excel_templates = [
+            f
+            for f in os.listdir(excel_template_path)
+            if f.lower().startswith(template_prefix) and f.lower().endswith(".xlsx")
+        ]
+        if len(excel_templates) > 1:
+            self.log.error(
+                "[Error]Fatal error. More than one excel template was found in current relecov-tools installation (assets)"
+            )
+            stderr.print(
+                "[Error]Fatal error. More than one excel template was found in current relecov-tools installation (assets). Exiting..."
+            )
+            raise FileExistsError(
+                "Fatal error. More than one excel template was found in current relecov-tools installation (assets)"
+            )
+        if not excel_templates:
+            msg = (
+                f"{self.project_label} excel template was not found in assets. "
+                "Use --initial-version to start a new VERSION history explicitly."
+            )
+            self.log.error(msg)
+            stderr.print(f"[red]{msg}")
+            raise FileNotFoundError(msg)
+
+        self.excel_template = os.path.join(excel_template_path, excel_templates[0])
 
     def _load_laboratory_addresses(self):
         """
@@ -1351,42 +1362,21 @@ class BuildSchema(BaseModule):
             None: If an error occurs during the process.
         """
         try:
+            default_note = (
+                "Initial version" if self.initial_version else "Auto-generated update"
+            )
             notes_control_input = (
-                "Auto-generated update"
+                default_note
                 if self.non_interactive
                 else input(
                     "\033[93mEnter a note about changes made to the schema: \033[0m"
                 )
+                or default_note
             )
 
             # ------------------------------------------------------------------ #
             # 1.  Versioning & paths
             # ------------------------------------------------------------------ #
-            version_history = pd.DataFrame(
-                columns=["FILE_VERSION", "CODE", "NOTES CONTROL", "DATE"]
-            )
-
-            try:
-                wb = openpyxl.load_workbook(self.excel_template)
-                ws_version = wb["VERSION"]
-                data = ws_version.values
-                columns = next(data)
-                version_history = pd.DataFrame(data, columns=columns)
-            except Exception as e:
-                self.log.warning(
-                    f"Error reading previous VERSION sheet: {e}. Setting 1.0.0 as default."
-                )
-                version_history = pd.DataFrame(
-                    [
-                        {
-                            "FILE_VERSION": f"{self.template_output_prefix}_v1.0.0",
-                            "CODE": "1.0.0",
-                            "NOTES CONTROL": "Initial version",
-                            "DATE": datetime.now().strftime("%Y-%m-%d"),
-                        }
-                    ]
-                )
-
             next_version = self.version
             version_info = {
                 "FILE_VERSION": f"{self.template_output_prefix}_v{next_version}",
@@ -1394,9 +1384,29 @@ class BuildSchema(BaseModule):
                 "NOTES CONTROL": notes_control_input,
                 "DATE": datetime.now().strftime("%Y-%m-%d"),
             }
-            version_history = pd.concat(
-                [version_history, pd.DataFrame([version_info])], ignore_index=True
-            )
+
+            if self.initial_version:
+                version_history = pd.DataFrame([version_info])
+            else:
+                try:
+                    wb = openpyxl.load_workbook(self.excel_template)
+                    ws_version = wb["VERSION"]
+                    data = ws_version.values
+                    columns = next(data)
+                    version_history = pd.DataFrame(data, columns=columns)
+                except Exception as e:
+                    msg = (
+                        f"Error reading previous VERSION sheet from "
+                        f"{self.excel_template}: {e}"
+                    )
+                    self.log.error(msg)
+                    stderr.print(f"[red]{msg}")
+                    raise ValueError(msg)
+
+                version_history = pd.concat(
+                    [version_history, pd.DataFrame([version_info])],
+                    ignore_index=True,
+                )
             out_file = os.path.join(
                 self.output_dir, f"{self.template_output_prefix}_v{next_version}.xlsx"
             )
@@ -1782,6 +1792,8 @@ class BuildSchema(BaseModule):
                 stderr.print(f"[red]Error adding dropdowns: {e}")
                 return None
 
+        except ValueError:
+            raise
         except Exception as e:
             self.log.error(f"Error in create_metadatalab_excel: {e}")
             stderr.print(f"[red]Error in create_metadatalab_excel: {e}")

--- a/relecov_tools/build_schema.py
+++ b/relecov_tools/build_schema.py
@@ -202,6 +202,11 @@ class BuildSchema(BaseModule):
         self._resolve_version_history_template()
 
     def _resolve_version_history_template(self):
+        """Resolve the previous Excel template used to read VERSION history.
+
+        Initial versions skip previous template lookup; regular versions use either
+        the explicit template path or the installed project template in assets.
+        """
         if self.initial_version:
             self.excel_template = None
             return

--- a/relecov_tools/conf/build_schema_config.json
+++ b/relecov_tools/conf/build_schema_config.json
@@ -88,6 +88,47 @@
                 "error_title": "Formato de fecha incorrecto",
                 "format_cells_as_text": true
             }
+        },
+        "redlabra": {
+            "schema_file": "redlabra_schema.json",
+            "host_age_years": {
+                "header_row_idx": 5,
+                "max_rows": 1000,
+                "validation_type": "whole",
+                "operator": "between",
+                "formula1": "3",
+                "formula2": "110",
+                "error_message": "El valor debe estar entre 3 y 110 años. Si es inferior a 3 años, debe rellenar la siguiente columna: [Host Age Months].",
+                "error_title": "Valor no permitido"
+            },
+            "host_age_months": {
+                "header_row_idx": 5,
+                "max_rows": 1000,
+                "validation_type": "whole",
+                "operator": "between",
+                "formula1": "0",
+                "formula2": "35",
+                "error_message": "El valor debe estar entre 0 y 35 meses.",
+                "error_title": "Valor no permitido"
+            },
+            "patient_birth_date": {
+                "header_row_idx": 5,
+                "max_rows": 1000,
+                "validation_type": "custom",
+                "formula1": "=OR({col_letter}5=\"\",IFERROR(AND(ISTEXT({col_letter}5),LEN({col_letter}5)=10,MID({col_letter}5,5,1)=\"-\",MID({col_letter}5,8,1)=\"-\",VALUE(MID({col_letter}5,6,2))>=1,VALUE(MID({col_letter}5,6,2))<=12,VALUE(RIGHT({col_letter}5,2))>=1,VALUE(RIGHT({col_letter}5,2))<=31,ISNUMBER(DATEVALUE({col_letter}5))),FALSE))",
+                "error_message": "Ingrese la fecha en formato correcto YYYY-MM-DD (ejemplo: 2024-02-12).",
+                "error_title": "Formato de fecha incorrecto",
+                "format_cells_as_text": true
+            },
+            "sample_collection_date": {
+                "header_row_idx": 5,
+                "max_rows": 1000,
+                "validation_type": "custom",
+                "formula1": "=OR({col_letter}5=\"\",IFERROR(AND(ISTEXT({col_letter}5),LEN({col_letter}5)=10,MID({col_letter}5,5,1)=\"-\",MID({col_letter}5,8,1)=\"-\",VALUE(MID({col_letter}5,6,2))>=1,VALUE(MID({col_letter}5,6,2))<=12,VALUE(RIGHT({col_letter}5,2))>=1,VALUE(RIGHT({col_letter}5,2))<=31,ISNUMBER(DATEVALUE({col_letter}5))),FALSE))",
+                "error_message": "Ingrese la fecha en formato correcto YYYY-MM-DD (ejemplo: 2024-02-12).",
+                "error_title": "Formato de fecha incorrecto",
+                "format_cells_as_text": true
+            }
         }
     },
     "configurables" : {
@@ -105,6 +146,19 @@
                 "Bioinformatics and QC metrics fields"
             ],
             "mepram": [
+                "Database Identifiers",
+                "Sample collection and processing",
+                "Public databases",
+                "Sequencing",
+                "Host information",
+                "Host exposure information",
+                "Files info",
+                "Bioinformatics and QC metrics fields",
+                "Contributor Acknowledgement",
+                "Strain characterization", 
+                "Other"
+            ],
+            "redlabra": [
                 "Database Identifiers",
                 "Sample collection and processing",
                 "Public databases",

--- a/relecov_tools/conf/initial_config-EQA2026.yaml
+++ b/relecov_tools/conf/initial_config-EQA2026.yaml
@@ -309,6 +309,7 @@ build_schema:
     draft_version: ''
     diff: false
     version: ''
+    initial_version: false
     project: ''
     non_interactive: false
     output_dir: ''

--- a/relecov_tools/conf/initial_config-MEPRAM.yaml
+++ b/relecov_tools/conf/initial_config-MEPRAM.yaml
@@ -315,6 +315,7 @@ build_schema:
     draft_version: ''
     diff: false
     version: ''
+    initial_version: false
     project: ''
     non_interactive: false
     output_dir: ''

--- a/relecov_tools/conf/initial_config-relecov.yaml
+++ b/relecov_tools/conf/initial_config-relecov.yaml
@@ -338,6 +338,7 @@ build_schema:
     draft_version: ''
     diff: false
     version: ''
+    initial_version: false
     project: ''
     non_interactive: false
     output_dir: ''


### PR DESCRIPTION
## Summary

This PR extends `build-schema` to support project-specific schema/template generation and improves how metadata template version history is handled.

## Changes

- Make `build-schema` project-aware.
- Use the selected project name to resolve default schemas and Excel templates.
- Add explicit `--initial-version` handling for first template releases.
- Preserve previous `VERSION` history when a template is provided or found in assets.
- Prevent incompatible use of `--initial-version` with `--excel_template`.
- Add Redlabra support for `build-schema`.

## Notes

Redlabra can now generate its own outputs, such as:

- `redlabra_schema.json`
- `redlabra_metadata_template_v*.xlsx`

## PR Checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`black and flake8`).
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).