### PR TITLE
Fixed surveillance script for proper variant data handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Pau Pascual Mas](https://github.com/PauPascualMas)
 - [Alba Talavera](https://github.com/albatalavera)
 - [Alejandro Bernabeu](https://github.com/aberdur)
+- [Victor Lopez](https://github.com/victor5lm)
 
 #### Added enhancements
 
@@ -27,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix duplicated row in metadata form and clean some MEPRAM initial config [#879] (https://github.com/BU-ISCIII/relecov-tools/pull/879)
 - Fix date validation in Excel metadata templates and add some schema validation checks [#886] (https://github.com/BU-ISCIII/relecov-tools/pull/886)
 - Improve METADATA_LAB template formatting and duplicate sample detection [#887] (https://github.com/BU-ISCIII/relecov-tools/pull/887)
+- Fixed the surveillance script for proper variant data handling [#891] (https://github.com/BU-ISCIII/relecov-tools/pull/891). 
 
 #### Changed
 

--- a/relecov_tools/assets/pipeline_utils/create_summary_tables.py
+++ b/relecov_tools/assets/pipeline_utils/create_summary_tables.py
@@ -371,7 +371,6 @@ def process_json_files(
             else:
                 df_variants = df_variants_new
 
-            # clave biológica mínima de unicidad
             df_variants = df_variants.drop_duplicates(
                 subset=["SAMPLE", "CHROM", "POS", "REF", "ALT"]
             )

--- a/relecov_tools/assets/pipeline_utils/create_summary_tables.py
+++ b/relecov_tools/assets/pipeline_utils/create_summary_tables.py
@@ -49,6 +49,7 @@ def process_json_files(
     long_table_file=None,
     output_dir="surveillance_files",
     specified_week=None,
+    specified_season=None,
     copy_fasta=False,
 ):
     os.makedirs(output_dir, exist_ok=True)
@@ -108,6 +109,9 @@ def process_json_files(
                         week = get_epi_week(sample["sample_collection_date"])
                         season = get_epi_season(sample["sample_collection_date"])
                         if specified_week and week != specified_week:
+                            continue
+                        
+                        if specified_season and season != specified_season:
                             continue
 
                         analysis_date = sample.get("bioinformatics_analysis_date", "-")
@@ -355,7 +359,23 @@ def process_json_files(
             season_dir = os.path.join(sars_output_dir, f"season_{season}")
             os.makedirs(season_dir, exist_ok=True)
             variant_csv_path = os.path.join(season_dir, "variant_data.csv")
-            df_variants = pd.DataFrame(variant_rows)
+            df_variants_new = pd.DataFrame(variant_rows)
+
+            if os.path.exists(variant_csv_path):
+                df_variants_existing = pd.read_csv(variant_csv_path, dtype=str)
+
+                df_variants = pd.concat(
+                    [df_variants_existing, df_variants_new],
+                    ignore_index=True
+                )
+            else:
+                df_variants = df_variants_new
+
+            # clave biológica mínima de unicidad
+            df_variants = df_variants.drop_duplicates(
+                subset=["SAMPLE", "CHROM", "POS", "REF", "ALT"]
+            )
+
             df_variants.to_csv(variant_csv_path, index=False)
             print(
                 f"Written variant data for SARS season {season} to {variant_csv_path}"
@@ -442,6 +462,11 @@ if __name__ == "__main__":
         help="Filter for specific epidemiological week (format: YYYY-WW)",
     )
     parser.add_argument(
+        "-s",
+        "--season",
+        help="Filter for specific epidemiological season (format: YYYY_YYYY)",
+    )   
+    parser.add_argument(
         "-c",
         "--copy-fasta",
         action="store_true",
@@ -467,5 +492,6 @@ if __name__ == "__main__":
         args.long_table_file,
         args.output,
         args.week,
+        args.season,
         args.copy_fasta,
     )

--- a/relecov_tools/assets/pipeline_utils/create_summary_tables.py
+++ b/relecov_tools/assets/pipeline_utils/create_summary_tables.py
@@ -110,7 +110,7 @@ def process_json_files(
                         season = get_epi_season(sample["sample_collection_date"])
                         if specified_week and week != specified_week:
                             continue
-                        
+
                         if specified_season and season != specified_season:
                             continue
 
@@ -365,8 +365,7 @@ def process_json_files(
                 df_variants_existing = pd.read_csv(variant_csv_path, dtype=str)
 
                 df_variants = pd.concat(
-                    [df_variants_existing, df_variants_new],
-                    ignore_index=True
+                    [df_variants_existing, df_variants_new], ignore_index=True
                 )
             else:
                 df_variants = df_variants_new
@@ -464,7 +463,7 @@ if __name__ == "__main__":
         "-s",
         "--season",
         help="Filter for specific epidemiological season (format: YYYY_YYYY)",
-    )   
+    )
     parser.add_argument(
         "-c",
         "--copy-fasta",


### PR DESCRIPTION
<!--
# relecov-isciii tools pull request

Based on nf-core/viralrecon pull request template

Fill in the appropriate checklist below and delete whatever is not relevant.

PRs should be made against the develop of hotfix branch, unless you're preparing a software release.
-->

## PR Checklist

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`black and flake8`).
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## PR Description

Until now, the `variant_data.csv` file seemed to contain only those variants for the samples indicated in the JSON files given to the surveillance script as part of specific txt files. This meant this CSV file was being overwritten. This PR fixes this, and offers the possibility to filter results by epidemiological season as well.